### PR TITLE
feat(cli): change default port to 8010 and add namespace option

### DIFF
--- a/kaos-cli/README.md
+++ b/kaos-cli/README.md
@@ -20,14 +20,16 @@ Start a CORS-enabled proxy to the Kubernetes API server:
 kaos ui
 ```
 
-This starts a local proxy on port 8080 that:
+This starts a local proxy on port 8010 that:
 - Proxies requests to the Kubernetes API using your kubeconfig credentials
 - Adds CORS headers to enable browser-based access
 - Exposes the `mcp-session-id` header for MCP protocol support
 
 Options:
 - `--k8s-url`: Override the Kubernetes API URL (default: from kubeconfig)
-- `--expose-port`: Port to expose the proxy on (default: 8080)
+- `--expose-port`: Port to expose the proxy on (default: 8010)
+- `--namespace`, `-n`: Initial namespace to display in the UI (default: "default")
+- `--no-browser`: Don't automatically open the browser
 
 Example:
 ```bash
@@ -36,6 +38,9 @@ kaos ui
 
 # Custom port
 kaos ui --expose-port 9000
+
+# Start with a specific namespace
+kaos ui --namespace kaos-system
 
 # Custom K8s URL
 kaos ui --k8s-url https://my-cluster:6443

--- a/kaos-cli/kaos_cli/main.py
+++ b/kaos-cli/kaos_cli/main.py
@@ -28,9 +28,15 @@ def ui(
         help="Kubernetes API server URL. If not provided, uses kubeconfig.",
     ),
     expose_port: int = typer.Option(
-        8080,
+        8010,
         "--expose-port",
         help="Port to expose the CORS proxy on.",
+    ),
+    namespace: str = typer.Option(
+        "default",
+        "--namespace",
+        "-n",
+        help="Initial namespace to display in the UI.",
     ),
     no_browser: bool = typer.Option(
         False,
@@ -39,7 +45,7 @@ def ui(
     ),
 ) -> None:
     """Start a CORS-enabled proxy and open the KAOS UI."""
-    ui_command(k8s_url=k8s_url, expose_port=expose_port, no_browser=no_browser)
+    ui_command(k8s_url=k8s_url, expose_port=expose_port, namespace=namespace, no_browser=no_browser)
 
 
 @app.command(name="install")

--- a/kaos-cli/kaos_cli/ui.py
+++ b/kaos-cli/kaos_cli/ui.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 import webbrowser
+from urllib.parse import urlencode
 
 import typer
 import uvicorn
@@ -13,14 +14,28 @@ import uvicorn
 KAOS_UI_URL = "https://axsaucedo.github.io/kaos-ui/"
 
 
-def ui_command(k8s_url: str | None, expose_port: int, no_browser: bool) -> None:
+def ui_command(k8s_url: str | None, expose_port: int, namespace: str, no_browser: bool) -> None:
     """Start a CORS-enabled proxy to the Kubernetes API server."""
     from kaos_cli.proxy import create_proxy_app
 
     app = create_proxy_app(k8s_url=k8s_url)
 
     typer.echo(f"Starting KAOS UI proxy on http://localhost:{expose_port}")
-    typer.echo(f"KAOS UI: {KAOS_UI_URL}")
+    
+    # Build UI URL with query parameters
+    query_params = {}
+    # Only add kubernetesUrl if not using default port
+    if expose_port != 8010:
+        query_params["kubernetesUrl"] = f"http://localhost:{expose_port}"
+    # Only add namespace if not using default
+    if namespace and namespace != "default":
+        query_params["namespace"] = namespace
+    
+    ui_url = KAOS_UI_URL
+    if query_params:
+        ui_url = f"{KAOS_UI_URL}?{urlencode(query_params)}"
+    
+    typer.echo(f"KAOS UI: {ui_url}")
     typer.echo("Press Ctrl+C to stop")
 
     def handle_signal(signum: int, frame: object) -> None:
@@ -34,7 +49,7 @@ def ui_command(k8s_url: str | None, expose_port: int, no_browser: bool) -> None:
     if not no_browser:
         def open_browser() -> None:
             time.sleep(1.5)
-            webbrowser.open(KAOS_UI_URL)
+            webbrowser.open(ui_url)
 
         browser_thread = threading.Thread(target=open_browser, daemon=True)
         browser_thread.start()


### PR DESCRIPTION
- Change default proxy port from 8080 to 8010
- Add --namespace/-n option for initial UI namespace
- Pass kubernetesUrl and namespace query params to UI URL
- Only add query params when non-default values are used