### PR TITLE
perf(ci): use native ARM runners for multi-platform builds

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -20,12 +20,30 @@ env:
   AGENT_IMAGE: axsauze/kaos-agent
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  # Build operator image on native runners for each platform
+  build-operator:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    outputs:
+      # Export digests for manifest merge
+      digest-amd64: ${{ steps.build.outputs.digest }}
+      digest-arm64: ${{ steps.build.outputs.digest }}
     steps:
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -38,8 +56,128 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata for operator
-        id: meta-operator
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.OPERATOR_IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./operator
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.OPERATOR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=operator-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=operator-${{ env.PLATFORM_PAIR }},mode=max
+          github-token: ${{ github.token }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/operator
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/operator/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/operator/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Build agent image on native runners for each platform
+  build-agent:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.AGENT_IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./python
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.AGENT_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=agent-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=agent-${{ env.PLATFORM_PAIR }},mode=max
+          github-token: ${{ github.token }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/agent
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/agent/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/agent/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge operator manifests from all platforms
+  merge-operator:
+    runs-on: ubuntu-latest
+    needs: build-operator
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/operator
+          pattern: operator-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.OPERATOR_IMAGE }}
@@ -48,8 +186,42 @@ jobs:
             type=sha,prefix=
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Extract metadata for agent
-        id: meta-agent
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests/operator
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.OPERATOR_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.OPERATOR_IMAGE }}:${{ steps.meta.outputs.version }}
+
+  # Merge agent manifests from all platforms
+  merge-agent:
+    runs-on: ubuntu-latest
+    needs: build-agent
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/agent
+          pattern: agent-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.AGENT_IMAGE }}
@@ -58,30 +230,12 @@ jobs:
             type=sha,prefix=
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Build and push operator image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./operator
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta-operator.outputs.tags }}
-          labels: ${{ steps.meta-operator.outputs.labels }}
-          # Use scoped cache to avoid conflicts between images
-          # mode=max exports all layers for maximum cache reuse
-          cache-from: type=gha,scope=operator
-          cache-to: type=gha,scope=operator,mode=max
-          # Provide GitHub token to avoid rate limiting on cache lookups
-          github-token: ${{ github.token }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests/agent
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.AGENT_IMAGE }}@sha256:%s ' *)
 
-      - name: Build and push agent image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./python
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta-agent.outputs.tags }}
-          labels: ${{ steps.meta-agent.outputs.labels }}
-          # Use scoped cache to avoid conflicts between images
-          cache-from: type=gha,scope=agent
-          cache-to: type=gha,scope=agent,mode=max
-          github-token: ${{ github.token }}
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.AGENT_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
- Use matrix strategy with native runners (ubuntu-latest for amd64, ubuntu-24.04-arm for arm64)
- Build by digest and merge manifests for faster parallel builds
- Separate jobs for operator and agent images
- Should reduce build time from ~17min to ~3-4min