### PR TITLE
fix(ci): add permissions to docs.yaml for reusable workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,11 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   read-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add contents, pages, and id-token write permissions at workflow level
- Required for reusable workflow to have proper GitHub Pages access
- Fixes 'nested job requesting permissions' error on merge