### PR TITLE
fix(docs): improve gh-pages checkout and add state persistence

### DIFF
--- a/.github/workflows/reusable-docs.yaml
+++ b/.github/workflows/reusable-docs.yaml
@@ -77,21 +77,36 @@ jobs:
         run: npm run build
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-        continue-on-error: true
+        id: checkout-gh-pages
+        run: |
+          # Try to fetch gh-pages branch
+          if git fetch origin gh-pages:gh-pages 2>/dev/null; then
+            echo "gh-pages branch exists, checking out..."
+            git worktree add gh-pages gh-pages
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "gh-pages branch does not exist yet"
+            mkdir -p gh-pages
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Prepare deployment directory
         run: |
           # Create deployment directory
           mkdir -p deploy
           
-          # Copy existing gh-pages content if it exists
-          if [ -d "gh-pages" ]; then
+          # Copy existing gh-pages content if it exists and has content
+          if [ -d "gh-pages" ] && [ "$(ls -A gh-pages 2>/dev/null)" ]; then
+            echo "Copying existing gh-pages content..."
             cp -r gh-pages/* deploy/ 2>/dev/null || true
+            # Remove git-related files
+            rm -rf deploy/.git deploy/.nojekyll 2>/dev/null || true
+          else
+            echo "No existing gh-pages content found, starting fresh"
           fi
+          
+          # Add .nojekyll to prevent Jekyll processing
+          touch deploy/.nojekyll
           
           # Deploy to the specified path
           DEPLOY_PATH="${{ inputs.deploy-path }}"
@@ -113,6 +128,9 @@ jobs:
           
           echo "Deployment structure:"
           ls -la deploy/
+          echo ""
+          echo "Subdirectories:"
+          find deploy -maxdepth 1 -type d
 
       - name: Package Helm chart
         if: inputs.package-helm && inputs.helm-version != ''
@@ -124,6 +142,16 @@ jobs:
             --app-version "$VERSION" \
             -d deploy/charts
           helm repo index deploy/charts --url https://axsaucedo.github.io/kaos/charts
+
+      - name: Push to gh-pages branch
+        run: |
+          cd deploy
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Deploy docs: ${{ inputs.deploy-path }} @ ${{ github.sha }}"
+          git push -f "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" HEAD:gh-pages
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
- Replace actions/checkout with git fetch/worktree for gh-pages
- Add step to push deploy content to gh-pages branch for state persistence
- Add .nojekyll file to prevent Jekyll processing
- Improves debugging with detailed deployment structure output

This fixes the issue where gh-pages branch checkout would fail silently and each deployment would start fresh, overwriting previous versions.