### PR TITLE
fix(release): enable Helm chart publishing to gh-pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,7 +127,8 @@ jobs:
       base-path: /kaos/v${{ needs.validate.outputs.version }}/
       deploy-path: v${{ needs.validate.outputs.version }}
       update-latest: true
-      package-helm: false
+      package-helm: true
+      helm-version: ${{ needs.validate.outputs.version }}
 
   # Create GitHub Release
   create-release:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,0 +1,39 @@
+name: Test Release
+
+on:
+  push:
+    tags: ['v0.0.*']  # Only test tags
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse tag
+        id: parse
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Test release version: $VERSION"
+
+  # Publish docs and Helm chart - this is what we're testing
+  publish-docs:
+    needs: validate
+    uses: ./.github/workflows/reusable-docs.yaml
+    with:
+      version: ${{ needs.validate.outputs.version }}
+      base-path: /kaos/v${{ needs.validate.outputs.version }}/
+      deploy-path: v${{ needs.validate.outputs.version }}
+      update-latest: false  # Don't update latest for test releases
+      package-helm: true
+      helm-version: ${{ needs.validate.outputs.version }}


### PR DESCRIPTION
## Summary
Fixes Helm chart not being published to gh-pages during releases.

## Changes
- Set `package-helm: true` in release.yaml publish-docs job
- Add `helm-version` parameter to use release version
- Add test-release.yaml for validating release workflow with v0.0.x tags

## Root Cause
In release.yaml line 130, `package-helm: false` meant Helm charts were only uploaded as GitHub Release artifacts but not published to gh-pages. This caused v0.1.3 chart to be missing from the Helm repository.

## Testing
After merging, push a v0.0.1 test tag to validate the workflow.