### PR TITLE
feat(docs): add mermaid diagram support to VitePress

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,3 +81,4 @@ Detailed instructions are in `.github/instructions/`:
 - `e2e.instructions.md`: E2E test setup, structure, gotchas and fast testing
 - `python.instructions.md`: Data Plane Python runtime framework details
 - `operator.instructions.md`: Control Plane Golang operator development
+- `docs.instructions.md`: VitePress docs, mermaid diagrams, multi-version builds

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,163 @@
+# Documentation Instructions
+
+## Quick Reference
+```bash
+cd docs
+npm install                    # Install dependencies
+npm run dev                    # Start dev server (localhost:5173)
+npm run build                  # Build static site
+npm run preview                # Preview build locally
+```
+
+Or use the Makefile:
+```bash
+make install dev build preview clean
+```
+
+## Project Structure
+```
+docs/
+├── .vitepress/
+│   ├── config.ts              # VitePress config (mermaid, nav, sidebar)
+│   ├── theme/
+│   │   ├── index.ts           # Theme customization
+│   │   └── custom.css         # Custom styles
+│   ├── dist/                  # Build output (gitignored)
+│   └── cache/                 # Build cache (gitignored)
+├── public/                    # Static assets (copied as-is)
+│   ├── logo.svg
+│   ├── redirect-index.html    # Root redirect to /latest/
+│   └── demo.gif
+├── package.json
+├── Makefile                   # Convenience commands
+└── [content directories]/     # Markdown content
+```
+
+## Multi-Version Documentation
+
+### How It Works
+1. `docs.yaml` workflow deploys `/dev/` on main branch pushes
+2. `release.yaml` workflow deploys `/vX.Y.Z/` and updates `/latest/` on version tags
+3. Version dropdown is dynamically built from git tags via `VERSIONS_JSON` env var
+
+### Key Environment Variables
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `DOCS_VERSION` | `dev`, `1.0.0` | Version shown in navbar |
+| `DOCS_BASE` | `/kaos/dev/` | Base path for assets/links |
+| `VERSIONS_JSON` | `["1.0.0","0.9.0"]` | Available versions for dropdown |
+
+### Testing Version Builds Locally
+```bash
+DOCS_VERSION=1.0.0 DOCS_BASE=/kaos/v1.0.0/ npm run build
+```
+
+## Mermaid Diagrams
+
+Mermaid diagrams are supported via `vitepress-plugin-mermaid`. Use standard mermaid code blocks:
+
+~~~markdown
+```mermaid
+graph LR
+    A[Client] --> B[Agent]
+    B --> C[Model API]
+```
+~~~
+
+### Mermaid Tips
+- Test diagrams at https://mermaid.live before adding to docs
+- Avoid complex diagrams that don't render well on mobile
+- Mermaid config is in `config.ts` under `mermaid` key
+
+## Making Documentation Changes
+
+### Adding New Pages
+1. Create `.md` file in appropriate directory
+2. Add to sidebar in `.vitepress/config.ts`
+3. Test locally with `npm run dev`
+
+### Modifying Config
+- **Navbar/Sidebar**: Edit `config.ts` `nav` and `sidebar` sections
+- **Styling**: Edit `theme/custom.css`
+- **Mermaid**: Config in `config.ts` `mermaid` section
+
+### Common Issues
+
+#### Version Dropdown Not Working
+- Dropdown links are absolute URLs to `axsaucedo.github.io/kaos/`
+- When testing locally, version switching won't work (expected)
+- Verify correct versions in GitHub Actions build logs
+
+#### Dead Link Warnings
+- `ignoreDeadLinks: true` is set to allow cross-version links
+- External links to other versions may 404 locally
+
+#### Mermaid Not Rendering
+- Ensure `vitepress-plugin-mermaid` is in package.json
+- Check diagram syntax at https://mermaid.live
+- Run `npm install` to update dependencies
+
+## Retrospective Version Rebuilds
+
+When docs infrastructure changes (e.g., adding mermaid support), existing version docs need rebuilding.
+
+### Rebuild a Single Version
+```bash
+# Option 1: Re-run release workflow from GitHub UI
+# Go to Actions > Release > select tag > Re-run all jobs
+
+# Option 2: Force-push the tag to trigger workflow
+git checkout v1.0.0
+git checkout -b rebuild-v1.0.0
+# Cherry-pick infrastructure changes from main
+git cherry-pick <commit-hash>
+git tag -f v1.0.0
+git push origin v1.0.0 --force
+```
+
+### Rebuild All Versions
+For bulk rebuilds, use the GitHub Actions workflow manually or run:
+```bash
+# List versions
+make list-tags
+
+# For each version, re-trigger the release workflow via GitHub UI
+```
+
+### Important: What Gets Rebuilt
+- Only files in `docs/` are rebuilt
+- Version-specific content should NOT be changed
+- Only infrastructure changes (mermaid, theme, etc.) should be cherry-picked
+
+## CI/CD Integration
+
+### Workflows
+| Workflow | Trigger | Deploys To |
+|----------|---------|------------|
+| `docs.yaml` | Push to main (docs/) | `/dev/` |
+| `release.yaml` | Version tag push | `/vX.Y.Z/` + `/latest/` |
+
+### Deployment Structure
+```
+gh-pages branch:
+├── index.html          # Redirect to /latest/
+├── dev/                # Latest main branch
+├── latest/             # Symlink to newest version
+├── v1.0.0/             # Version-specific builds
+├── v0.9.0/
+└── charts/             # Helm chart repository
+```
+
+## Testing Checklist
+
+Before pushing docs changes:
+- [ ] `npm run build` succeeds without errors
+- [ ] `npm run preview` shows content correctly
+- [ ] Mermaid diagrams render (if applicable)
+- [ ] Navigation links work
+- [ ] Mobile layout looks acceptable
+
+For infrastructure changes:
+- [ ] Test with different `DOCS_VERSION` and `DOCS_BASE` values
+- [ ] Verify version dropdown shows correct items
+- [ ] Check that `redirect-index.html` still works

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import { withMermaid } from 'vitepress-plugin-mermaid'
 
 // Get version info from environment variables
 // DOCS_VERSION: 'dev', '1.0.0', etc.
@@ -35,7 +36,7 @@ function getVersionsNav() {
   }
 }
 
-export default defineConfig({
+export default withMermaid(defineConfig({
   title: 'KAOS',
   description: 'K8s Agent Orchestration System',
   
@@ -158,5 +159,13 @@ export default defineConfig({
       pattern: 'https://github.com/axsaucedo/kaos/edit/main/docs/:path',
       text: 'Edit this page on GitHub'
     }
+  },
+  
+  // Mermaid configuration
+  mermaid: {
+    // Refer to https://mermaid.js.org/config/setup/modules/mermaidAPI.html#mermaidapi-configuration-defaults
+  },
+  mermaidPlugin: {
+    class: 'mermaid'
   }
-})
+}))

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,86 @@
+.PHONY: help install dev build preview clean rebuild-tags rebuild-tag list-tags
+
+# Default target
+help:
+	@echo "KAOS Documentation Commands"
+	@echo ""
+	@echo "Local Development:"
+	@echo "  make install        - Install npm dependencies"
+	@echo "  make dev            - Start development server"
+	@echo "  make build          - Build static site"
+	@echo "  make preview        - Preview built site locally"
+	@echo "  make clean          - Remove build artifacts"
+	@echo ""
+	@echo "Version Management:"
+	@echo "  make list-tags      - List available version tags"
+	@echo "  make rebuild-tag TAG=v1.0.0  - Trigger docs rebuild for specific tag"
+	@echo "  make rebuild-tags   - Rebuild docs for all version tags (interactive)"
+	@echo ""
+
+# Install dependencies
+install:
+	npm install
+
+# Start development server
+dev:
+	npm run dev
+
+# Build static site
+build:
+	npm run build
+
+# Preview built site
+preview:
+	npm run preview
+
+# Clean build artifacts
+clean:
+	rm -rf .vitepress/dist .vitepress/cache node_modules/.vite
+
+# List available version tags
+list-tags:
+	@echo "Available version tags (excluding v0.0.x test tags):"
+	@git tag --list "v*" --sort=-v:refname | grep -v '^v0\.0\.' | head -20
+
+# Rebuild docs for a specific tag by triggering workflow dispatch
+# Usage: make rebuild-tag TAG=v1.0.0
+rebuild-tag:
+ifndef TAG
+	$(error TAG is required. Usage: make rebuild-tag TAG=v1.0.0)
+endif
+	@echo "Triggering docs rebuild for tag: $(TAG)"
+	@VERSION=$$(echo $(TAG) | sed 's/^v//'); \
+	gh workflow run release.yaml --ref $(TAG) 2>/dev/null || \
+	echo "Note: release.yaml workflow can only run on tag refs. Use rebuild-tags for bulk rebuilds."
+	@echo ""
+	@echo "Alternative: Create and push a lightweight commit to rebuild:"
+	@echo "  1. Checkout the tag: git checkout $(TAG)"
+	@echo "  2. Create a branch: git checkout -b docs-rebuild-$(TAG)"
+	@echo "  3. Make a trivial change to docs/"
+	@echo "  4. Commit and tag: git tag -f $(TAG) && git push --tags -f"
+	@echo ""
+	@echo "Or use the GitHub Actions UI to manually trigger the workflow."
+
+# Interactive rebuild of all version tags
+# This displays instructions for rebuilding all versions retrospectively
+rebuild-tags:
+	@echo "=== Retrospective Docs Rebuild ==="
+	@echo ""
+	@echo "To rebuild docs for all version tags with current config (e.g., mermaid support):"
+	@echo ""
+	@echo "Option 1: Re-run release workflow for each tag (via GitHub UI)"
+	@echo "  1. Go to GitHub Actions > Release workflow"
+	@echo "  2. Re-run for each version tag"
+	@echo ""
+	@echo "Option 2: Cherry-pick docs changes to version branches"
+	@echo "  For each version tag that needs rebuilding:"
+	@echo "  1. Create a temp branch from the tag"
+	@echo "  2. Cherry-pick the docs config commits"
+	@echo "  3. Force-push the tag"
+	@echo "  4. This triggers the release workflow"
+	@echo ""
+	@echo "Option 3: Use the rebuild script (recommended for bulk updates)"
+	@echo "  ./scripts/rebuild-version-docs.sh"
+	@echo ""
+	@echo "Available versions to rebuild:"
+	@git tag --list "v*" --sort=-v:refname | grep -v '^v0\.0\.' | head -10

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,8 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "vitepress": "^1.5.0"
+    "mermaid": "^11.12.2",
+    "vitepress": "^1.5.0",
+    "vitepress-plugin-mermaid": "^2.0.17"
   }
 }


### PR DESCRIPTION
## Summary
Add mermaid diagram support to VitePress documentation.

## Changes
- Add `vitepress-plugin-mermaid` and `mermaid` dependencies
- Configure mermaid in `.vitepress/config.ts` with `withMermaid` wrapper
- Create `docs/Makefile` with dev, build, and version rebuild commands
- Create `.github/instructions/docs.instructions.md` for docs development
- Update `copilot-instructions.md` to reference docs instructions

## Testing
- `npm run build` succeeds
- Existing mermaid diagrams in concepts.md, overview.md, etc. will now render

## Next Steps
After merging, existing version tags need to be rebuilt to get mermaid support:
1. Go to GitHub Actions
2. Re-run the release workflow for each version tag