### PR TITLE
fix(release): make workflow idempotent for re-runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,19 +108,39 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Check if version already published
+        id: check-pypi
+        run: |
+          VERSION=${{ needs.validate.outputs.version }}
+          if curl -s "https://pypi.org/pypi/kaos-cli/${VERSION}/json" | grep -q '"version"'; then
+            echo "Version $VERSION already exists on PyPI, skipping publish"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version $VERSION not found on PyPI, will publish"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup Python
+        if: steps.check-pypi.outputs.skip != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Install build tools
+        if: steps.check-pypi.outputs.skip != 'true'
         run: python -m pip install --upgrade pip build
+
       - name: Update version and build kaos-cli
+        if: steps.check-pypi.outputs.skip != 'true'
         working-directory: kaos-cli
         run: |
           VERSION=${{ needs.validate.outputs.version }}
           sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
           python -m build
+
       - name: Publish to PyPI
+        if: steps.check-pypi.outputs.skip != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: kaos-cli/dist/
@@ -193,7 +213,21 @@ jobs:
           echo "Next dev version: $NEXT_DEV"
           echo "Python dev version: $PYTHON_DEV"
 
+      - name: Check if already bumped
+        id: check-bump
+        run: |
+          CURRENT_VERSION=$(cat VERSION)
+          NEXT_DEV=${{ steps.next.outputs.next_dev }}
+          if [ "$CURRENT_VERSION" = "$NEXT_DEV" ]; then
+            echo "VERSION already set to $NEXT_DEV, skipping bump"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION is $CURRENT_VERSION, will bump to $NEXT_DEV"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Update version files
+        if: steps.check-bump.outputs.skip != 'true'
         run: |
           NEXT_DEV=${{ steps.next.outputs.next_dev }}
           PYTHON_DEV=${{ steps.next.outputs.python_dev }}
@@ -222,6 +256,7 @@ jobs:
           grep -E "kaos-(operator|agent|mcp-server):" operator/chart/values.yaml
 
       - name: Create Pull Request
+        if: steps.check-bump.outputs.skip != 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
@@ -245,7 +280,7 @@ jobs:
             version-bump
 
       - name: Enable auto-merge for bump PR
-        if: steps.cpr.outputs.pull-request-number
+        if: steps.check-bump.outputs.skip != 'true' && steps.cpr.outputs.pull-request-number
         run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-docs.yaml
+++ b/.github/workflows/reusable-docs.yaml
@@ -174,6 +174,9 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: deploy
+          name: github-pages-${{ inputs.deploy-path }}
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages-${{ inputs.deploy-path }}


### PR DESCRIPTION
## Summary
Fixes GitHub Pages deployment failures when release workflow is re-run.

## Issues Fixed
1. **Multiple artifacts error**: `deploy-pages@v4` fails with "Multiple artifacts named 'github-pages' were unexpectedly found" when workflow is re-run
2. **PyPI publish failure**: Re-running fails if version already published
3. **Version bump duplicates**: Creates duplicate PRs if version already bumped on main

## Changes
- Use unique artifact names (`github-pages-{deploy-path}`) to prevent artifact conflicts
- Add PyPI version check to skip publish if version exists
- Add VERSION file check to skip bump if already set to next dev version

## Testing
- Can be tested by re-running the release workflow for v0.2.1 after merging
- Workflow will now succeed on re-runs instead of failing

Fixes v0.2.1 docs deployment issue