### PR TITLE
fix(ci): Add mcp-python-string to image build workflows

### DIFF
--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -6,8 +6,10 @@ on:
     paths:
       - 'operator/**'
       - 'data-plane/kaos-framework/**'
+      - 'data-plane/mcp-servers/**'
       - 'VERSION'
       - '.github/workflows/dev-build.yaml'
+      - '.github/workflows/reusable-build-images.yaml'
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -247,13 +247,14 @@ jobs:
           sed -i "s|axsauze/kaos-operator:v[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-operator:v$NEXT_DEV|g" operator/chart/values.yaml
           sed -i "s|axsauze/kaos-agent:v[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-agent:v$NEXT_DEV|g" operator/chart/values.yaml
           sed -i "s|axsauze/kaos-mcp-server:v[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-mcp-server:v$NEXT_DEV|g" operator/chart/values.yaml
+          sed -i "s|axsauze/kaos-mcp-python-string:v[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-mcp-python-string:v$NEXT_DEV|g" operator/chart/values.yaml
 
           echo "Updated files:"
           cat VERSION
           grep "^version" data-plane/kaos-framework/pyproject.toml
           grep "^version" kaos-cli/pyproject.toml
           grep "^version:\|^appVersion:" operator/chart/Chart.yaml
-          grep -E "kaos-(operator|agent|mcp-server):" operator/chart/values.yaml
+          grep -E "kaos-(operator|agent|mcp-server|mcp-python-string):" operator/chart/values.yaml
 
       - name: Create Pull Request
         if: steps.check-bump.outputs.skip != 'true'

--- a/.github/workflows/reusable-build-images.yaml
+++ b/.github/workflows/reusable-build-images.yaml
@@ -27,6 +27,7 @@ env:
   REGISTRY: docker.io
   OPERATOR_IMAGE: axsauze/kaos-operator
   AGENT_IMAGE: axsauze/kaos-agent
+  MCP_PYTHON_STRING_IMAGE: axsauze/kaos-mcp-python-string
 
 jobs:
   # Build operator image on native runners for each platform
@@ -244,3 +245,111 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.AGENT_IMAGE }}:${{ inputs.version }}
+
+  # Build MCP python-string image on native runners for each platform
+  build-mcp-python-string:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.MCP_PYTHON_STRING_IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./data-plane/mcp-servers/python-string
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.MCP_PYTHON_STRING_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=mcp-python-string-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=mcp-python-string-${{ env.PLATFORM_PAIR }},mode=max
+          github-token: ${{ github.token }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/mcp-python-string
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/mcp-python-string/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-prefix }}mcp-python-string-digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/mcp-python-string/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge MCP python-string manifests from all platforms
+  merge-mcp-python-string:
+    runs-on: ubuntu-latest
+    needs: build-mcp-python-string
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/mcp-python-string
+          pattern: ${{ inputs.artifact-prefix }}mcp-python-string-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.MCP_PYTHON_STRING_IMAGE }}
+          tags: |
+            type=raw,value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ inputs.push-latest }}
+            type=sha,prefix=
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests/mcp-python-string
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.MCP_PYTHON_STRING_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.MCP_PYTHON_STRING_IMAGE }}:${{ inputs.version }}

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -32,7 +32,7 @@ kubernetesClusterDomain: cluster.local
 defaultImages:
   agentRuntime: axsauze/kaos-agent:v0.2.2-dev
   mcpServer: axsauze/kaos-mcp-server:v0.2.2-dev
-  mcpPythonString: axsauze/kaos-mcp-python-string:v0.1.4-dev
+  mcpPythonString: axsauze/kaos-mcp-python-string:v0.2.2-dev
   mcpKubernetes: quay.io/containers/kubernetes_mcp_server:latest
   mcpSlack: zencoderai/slack-mcp:latest
   litellm: ghcr.io/berriai/litellm:main-stable


### PR DESCRIPTION
## Problem
The `axsauze/kaos-mcp-python-string` image was not being built during releases:
1. Had its own workflow only triggered on path changes to python-string directory
2. Not included in `reusable-build-images.yaml` used by releases
3. Version in values.yaml (`v0.1.4-dev`) was outdated vs current (`0.2.2-dev`)
4. `release.yaml` version bump didn't update mcpPythonString tag

## Solution
- Add mcp-python-string build jobs to `reusable-build-images.yaml`
- Update `release.yaml` version bump to include mcpPythonString tag
- Add `mcp-servers` path to `dev-build.yaml` triggers
- Sync values.yaml mcpPythonString to current version (0.2.2-dev)

## Testing
The image will now be built:
1. On dev builds (push to main)
2. On releases (version tags)
3. With version bumps including the mcpPythonString tag

Fixes: Image not found error for kaos-mcp-python-string runtime