### PR TITLE
fix(release): remove v prefix from image tags to match VERSION file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,18 +243,21 @@ jobs:
           sed -i "s/^version: .*/version: $NEXT_DEV/" operator/chart/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: \"$NEXT_DEV\"/" operator/chart/Chart.yaml
 
-          # Update Helm values.yaml image tags (use v prefix for image tags)
-          sed -i "s|axsauze/kaos-operator:v[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-operator:v$NEXT_DEV|g" operator/chart/values.yaml
-          sed -i "s|axsauze/kaos-agent:v[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-agent:v$NEXT_DEV|g" operator/chart/values.yaml
-          sed -i "s|axsauze/kaos-mcp-server:v[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-mcp-server:v$NEXT_DEV|g" operator/chart/values.yaml
-          sed -i "s|axsauze/kaos-mcp-python-string:v[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-mcp-python-string:v$NEXT_DEV|g" operator/chart/values.yaml
+          # Update Helm values.yaml image tags (must match VERSION file format without v prefix)
+          # Operator uses separate repository/tag fields
+          sed -i "s|^\(\s*tag:\s*\)[0-9]*\.[0-9]*\.[0-9]*[^\"]*|\1$NEXT_DEV|" operator/chart/values.yaml
+          # Data plane images use full image:tag format
+          sed -i "s|axsauze/kaos-agent:[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-agent:$NEXT_DEV|g" operator/chart/values.yaml
+          sed -i "s|axsauze/kaos-mcp-server:[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-mcp-server:$NEXT_DEV|g" operator/chart/values.yaml
+          sed -i "s|axsauze/kaos-mcp-python-string:[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-mcp-python-string:$NEXT_DEV|g" operator/chart/values.yaml
+          sed -i "s|axsauze/kaos-mcp-pctx:[0-9]*\.[0-9]*\.[0-9]*[^\"]*|axsauze/kaos-mcp-pctx:$NEXT_DEV|g" operator/chart/values.yaml
 
           echo "Updated files:"
           cat VERSION
           grep "^version" data-plane/kaos-framework/pyproject.toml
           grep "^version" kaos-cli/pyproject.toml
           grep "^version:\|^appVersion:" operator/chart/Chart.yaml
-          grep -E "kaos-(operator|agent|mcp-server|mcp-python-string):" operator/chart/values.yaml
+          grep -E "tag:|kaos-(agent|mcp-server|mcp-python-string|mcp-pctx):" operator/chart/values.yaml
 
       - name: Create Pull Request
         if: steps.check-bump.outputs.skip != 'true'
@@ -270,7 +273,7 @@ jobs:
             - `VERSION` → `${{ steps.next.outputs.next_dev }}`
             - Python packages → `${{ steps.next.outputs.python_dev }}`
             - Helm chart → `${{ steps.next.outputs.next_dev }}`
-            - Helm values.yaml image tags → `v${{ steps.next.outputs.next_dev }}`
+            - Helm values.yaml image tags → `${{ steps.next.outputs.next_dev }}`
 
             ## What's Next
             This PR should be merged to prepare for the next development cycle.

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -10,7 +10,7 @@ controllerManager:
       readOnlyRootFilesystem: true
     image:
       repository: axsauze/kaos-operator
-      tag: v0.1.4-dev
+      tag: 0.2.2-dev
     imagePullPolicy: IfNotPresent
     resources:
       limits:
@@ -30,10 +30,10 @@ kubernetesClusterDomain: cluster.local
 
 # Default images for agent runtime and MCP servers
 defaultImages:
-  agentRuntime: axsauze/kaos-agent:v0.2.2-dev
-  mcpServer: axsauze/kaos-mcp-server:v0.2.2-dev
-  mcpPythonString: axsauze/kaos-mcp-python-string:v0.2.2-dev
-  mcpPctx: axsauze/kaos-mcp-pctx:v0.2.2-dev
+  agentRuntime: axsauze/kaos-agent:0.2.2-dev
+  mcpServer: axsauze/kaos-mcp-server:0.2.2-dev
+  mcpPythonString: axsauze/kaos-mcp-python-string:0.2.2-dev
+  mcpPctx: axsauze/kaos-mcp-pctx:0.2.2-dev
   mcpKubernetes: quay.io/containers/kubernetes_mcp_server:latest
   mcpSlack: zencoderai/slack-mcp:latest
   litellm: ghcr.io/berriai/litellm:main-stable


### PR DESCRIPTION
## Problem

After a release, the bump-version step in release.yaml was adding a `v` prefix to image tags in values.yaml (e.g., `v0.2.2-dev`), but images are built using the VERSION file which has no `v` prefix (e.g., `0.2.2-dev`).

This caused `ImagePullBackOff` errors when deploying with the Helm chart because the images don't exist with the `v` prefix.

## Root Cause

Commit 1db848d (`fix(ci): update release workflow to bump values.yaml image tags`) introduced the `v` prefix to values.yaml tags without matching how images are built/pushed in `reusable-build-images.yaml`.

The release workflow:
1. Strips `v` from tag (e.g., `v1.0.0` → `1.0.0`)
2. Pushes images with tag `1.0.0` (no `v`)
3. Bumps values.yaml to `v1.0.1-dev` (adds `v` back - **BUG**)

Meanwhile:
- VERSION file has `1.0.1-dev` (no `v`)
- Makefile builds images using VERSION (no `v`)
- Mismatch causes ImagePull errors

## Changes

- Remove `v` prefix from sed commands in release.yaml bump-version step
- Add `kaos-mcp-pctx` image to the bump list (was missing)
- Fix current values.yaml to use correct tags without `v` prefix

## Testing

The fix ensures consistency between:
- VERSION file: `X.Y.Z-dev`
- Helm values.yaml image tags: `X.Y.Z-dev`
- Built images: `axsauze/kaos-*:X.Y.Z-dev`