### PR TITLE
fix(docs): prevent duplicate artifact error on workflow re-runs

### DIFF
--- a/.github/workflows/reusable-docs.yaml
+++ b/.github/workflows/reusable-docs.yaml
@@ -174,9 +174,9 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: deploy
-          name: github-pages-${{ inputs.deploy-path }}
+          name: github-pages-${{ inputs.deploy-path }}-attempt-${{ github.run_attempt }}
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
         with:
-          artifact_name: github-pages-${{ inputs.deploy-path }}
+          artifact_name: github-pages-${{ inputs.deploy-path }}-attempt-${{ github.run_attempt }}


### PR DESCRIPTION
## Problem

Two issues with the v0.2.5 docs deployment:

### Issue 1: URL not working despite folder existing in gh-pages
The release v0.2.5 workflow attempt 1 succeeded and deployed Pages correctly. However, when attempt 2 (re-run) was triggered, `deploy-pages` created a new **failed** deployment that superseded the previous successful one, leaving the Pages site without v0.2.5.

### Issue 2: Re-runs fail with 'Multiple artifacts' error
When re-running the workflow, `upload-pages-artifact` creates a new artifact with the same name (`github-pages-v0.2.5`), but the artifact from attempt 1 still exists. `deploy-pages` then finds 2 artifacts with the same name and fails:
```
Error: Multiple artifacts named "github-pages-v0.2.5" were unexpectedly found for this workflow run. Artifact count is 2.
```

## Fix
Include `github.run_attempt` in the artifact name so re-runs create uniquely named artifacts (e.g., `github-pages-v0.2.5-attempt-2`) instead of duplicates.

## Post-merge Action
After merging, trigger the rebuild-docs workflow to redeploy v0.2.5:
```bash
gh workflow run rebuild-docs.yaml -f version=0.2.5
```