### PR TITLE
fix(docs): fix broken pais.jpg reference and add build check to docs-lint

### DIFF
--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -4,18 +4,42 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'docs/examples/**'
+      - 'docs/**'
       - 'examples/**'
       - '.github/workflows/docs-lint.yaml'
   push:
     branches: [main]
     paths:
-      - 'docs/examples/**'
+      - 'docs/**'
       - 'examples/**'
       - '.github/workflows/docs-lint.yaml'
   workflow_dispatch:
 
 jobs:
+  docs-build:
+    name: VitePress Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: docs
+        run: npm install
+
+      - name: Build docs
+        working-directory: docs
+        env:
+          DOCS_VERSION: lint
+          DOCS_BASE: /kaos/lint/
+        run: npm run build
+
   notebook-sync:
     name: Check Notebook Sync
     runs-on: ubuntu-latest

--- a/docs/python-framework/overview.md
+++ b/docs/python-framework/overview.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/pais.jpg" alt="PAIS — Pydantic AI Server" width="180">
+  <img src="/pais-horizontal.jpg" alt="PAIS — Pydantic AI Server" width="300">
 </p>
 
 # PAIS: Pydantic AI Server


### PR DESCRIPTION
## Problem
The Deploy Dev Documentation workflow failed on main after merging PR #88 because `docs/python-framework/overview.md` referenced `/pais.jpg` which doesn't exist in `docs/public/`.

## Fix
- Changed image reference to `/pais-horizontal.jpg` (which exists, 949×486)
- Added VitePress build check (`npm run build`) to `docs-lint.yaml` to catch broken refs at PR time
- Expanded docs-lint path trigger from `docs/examples/**` to `docs/**`

## Verification
- Local `npm run build` passes ✅