### PR TITLE
docs(pais): clean up README and remove stale __init__.py

### DIFF
--- a/pydantic-ai-server/__init__.py
+++ b/pydantic-ai-server/__init__.py
@@ -1,7 +1,0 @@
-"""
-Agentic Agent Runtime Package
-
-This package contains the agent runtime server and MCP tool integration.
-"""
-
-__version__ = "0.1.0"


### PR DESCRIPTION
- Remove stale top-level __init__.py (leftover from data-plane move)
- Move Features table to top, below intro
- Replace CLI Quick Start with 'Deploy and Scale to Kubernetes' end-to-end example
- Replace Module Structure with Architecture internals explanation
- Fix install comment to just say 'With CLI'
- Add pais run examples with flags
- Remove 'Or kaos <command>' mentions
- Update mermaid diagram label