### PR TITLE
refactor: simplify TaskEvent to state transitions only

### DIFF
--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -152,7 +152,7 @@ make format                     # Auto-format code
   2. **A2A-triggered**: `SendMessage` with `configuration.mode: "autonomous"` + optional `budgets`
 - `AutonomousConfig` dataclass: `goal`, `interval_seconds` (0), `max_iter_runtime_seconds` (60)
 - `TaskBudgets` dataclass: `max_iterations` (10), `max_runtime_seconds` (300), `max_tool_calls` (50), `interval_seconds` (0)
-- `TaskEvent` append-only event log per task: submitted, working, iteration.started/completed, budget.exhausted, completed/failed/canceled
+- `TaskEvent` append-only event log per task: submitted, working, budget.exhausted, completed/failed/canceled (state transitions only — iteration detail captured by Memory)
 
 ### A2A JSON-RPC Endpoint (POST /) — a2a.py
 - JSON-RPC 2.0 dispatcher at root path, separate from `/v1/chat/completions`

--- a/docs/python-framework/autonomous.md
+++ b/docs/python-framework/autonomous.md
@@ -119,18 +119,18 @@ Budgets are checked at the **start** of each iteration (before execution). When 
 
 ## Event Log
 
-Each task maintains an append-only event log tracking execution progress:
+Each task maintains an append-only event log tracking state transitions:
 
 | Event Type | Description |
 |-----------|-------------|
 | `task.submitted` | Task created |
 | `task.working` | Execution started |
-| `autonomous.iteration.started` | Begin iteration N |
-| `autonomous.iteration.completed` | Iteration N finished |
 | `autonomous.budget.exhausted` | Budget limit reached |
 | `task.completed` | Execution finished successfully |
 | `task.failed` | Execution failed with error |
 | `task.canceled` | Task was canceled |
+
+Iteration-level detail (tool calls, responses) is captured by the Memory system via `/memory/events`.
 
 Events are returned in `GetTask` responses:
 ```json
@@ -138,8 +138,7 @@ Events are returned in `GetTask` responses:
   "events": [
     {"id": "evt-1", "type": "task.submitted", "timestamp": "2024-01-01T00:00:00Z", "data": {}},
     {"id": "evt-2", "type": "task.working", "timestamp": "2024-01-01T00:00:01Z", "data": {}},
-    {"id": "evt-3", "type": "autonomous.iteration.started", "timestamp": "2024-01-01T00:00:01Z", "data": {"iteration": 0}},
-    {"id": "evt-4", "type": "autonomous.iteration.completed", "timestamp": "2024-01-01T00:00:05Z", "data": {"iteration": 0, "response_preview": "..."}}
+    {"id": "evt-3", "type": "task.completed", "timestamp": "2024-01-01T00:00:05Z", "data": {"output_preview": "..."}}
   ]
 }
 ```

--- a/operator/tests/e2e/test_autonomous_e2e.py
+++ b/operator/tests/e2e/test_autonomous_e2e.py
@@ -178,17 +178,12 @@ async def test_autonomous_a2a_send_message(
 
         assert state == "completed", f"Task ended in state: {state}"
 
-        # Verify events were recorded
+        # Verify state transition events were recorded
         events = get_data["result"].get("events", [])
         event_types = [e["type"] for e in events]
         assert "task.submitted" in event_types
         assert "task.working" in event_types
-        assert "autonomous.iteration.started" in event_types
         assert "task.completed" in event_types
-
-        # Verify at least 2 iterations occurred (tool call then final)
-        iteration_starts = [e for e in events if e["type"] == "autonomous.iteration.started"]
-        assert len(iteration_starts) >= 2, f"Expected >=2 iterations, got {len(iteration_starts)}"
 
         # Verify history contains agent response with final output
         history = get_data["result"].get("history", [])
@@ -321,10 +316,6 @@ async def test_autonomous_budget_enforcement(
         budget_data = budget_event.get("data", {})
         assert "max_iterations" in budget_data.get("reason", ""), \
             f"Expected max_iterations reason, got: {budget_event}"
-
-        # Verify only 1 iteration occurred
-        iteration_starts = [e for e in events if e["type"] == "autonomous.iteration.started"]
-        assert len(iteration_starts) == 1, f"Expected 1 iteration, got {len(iteration_starts)}"
 
 
 @pytest.mark.asyncio

--- a/pydantic-ai-server/pais/a2a.py
+++ b/pydantic-ai-server/pais/a2a.py
@@ -122,8 +122,6 @@ EVENT_TASK_WORKING = "task.working"
 EVENT_TASK_COMPLETED = "task.completed"
 EVENT_TASK_FAILED = "task.failed"
 EVENT_TASK_CANCELED = "task.canceled"
-EVENT_AUTONOMOUS_ITERATION_STARTED = "autonomous.iteration.started"
-EVENT_AUTONOMOUS_ITERATION_COMPLETED = "autonomous.iteration.completed"
 EVENT_AUTONOMOUS_BUDGET_EXHAUSTED = "autonomous.budget.exhausted"
 
 
@@ -629,8 +627,6 @@ class LocalTaskManager(TaskManager):
                             "respond with your final answer without making any tool calls."
                         )
 
-                    task.add_event(EVENT_AUTONOMOUS_ITERATION_STARTED, {"iteration": iteration})
-
                     # Run one iteration
                     with tracer.start_as_current_span(
                         "kaos.autonomous.iteration",
@@ -640,16 +636,6 @@ class LocalTaskManager(TaskManager):
 
                     if tool_call_count > 0:
                         total_tool_calls += tool_call_count
-
-                    task.add_event(
-                        EVENT_AUTONOMOUS_ITERATION_COMPLETED,
-                        {
-                            "iteration": iteration,
-                            "had_tool_calls": tool_call_count > 0,
-                            "tool_call_count": tool_call_count,
-                            "response_preview": last_response[:200],
-                        },
-                    )
 
                     iteration += 1
 

--- a/pydantic-ai-server/tests/test_a2a_integration.py
+++ b/pydantic-ai-server/tests/test_a2a_integration.py
@@ -273,11 +273,9 @@ class TestA2AAutonomousMode:
                 task2 = resp2.json()["result"]
                 assert task2["status"]["state"] == "completed"
 
-                # Validate events show iteration lifecycle
+                # Validate events show state transitions
                 event_types = [e["type"] for e in task2.get("events", [])]
                 assert "task.submitted" in event_types
-                assert "autonomous.iteration.started" in event_types
-                assert "autonomous.iteration.completed" in event_types
                 assert "task.completed" in event_types
 
                 # Validate output content

--- a/pydantic-ai-server/tests/test_autonomous.py
+++ b/pydantic-ai-server/tests/test_autonomous.py
@@ -7,9 +7,9 @@ import pytest
 
 from pais.a2a import (
     TaskBudgets,
-    EVENT_AUTONOMOUS_ITERATION_STARTED,
-    EVENT_AUTONOMOUS_ITERATION_COMPLETED,
     EVENT_AUTONOMOUS_BUDGET_EXHAUSTED,
+    EVENT_TASK_SUBMITTED,
+    EVENT_TASK_COMPLETED,
 )
 from tests.helpers import make_test_server
 
@@ -61,9 +61,7 @@ class TestAutonomousLoop:
         assert completed is not None
         assert completed.output is not None
         assert len(completed.output) > 0
-
-        started = [e for e in completed.events if e.type == EVENT_AUTONOMOUS_ITERATION_STARTED]
-        assert len(started) == 1
+        assert completed.status.state.value == "completed"
 
     @pytest.mark.asyncio
     async def test_budget_max_iterations(self):
@@ -134,13 +132,13 @@ class TestAutonomousLoop:
         completed = await server.task_manager.wait_for_completion(task.id, timeout=5.0)
         assert completed is not None
         assert "final report" in completed.output.lower() or "complete" in completed.output.lower()
-
-        started = [e for e in completed.events if e.type == EVENT_AUTONOMOUS_ITERATION_STARTED]
-        assert len(started) == 3
+        event_types = [e.type for e in completed.events]
+        assert EVENT_TASK_SUBMITTED in event_types
+        assert EVENT_TASK_COMPLETED in event_types
 
     @pytest.mark.asyncio
-    async def test_events_emitted(self):
-        """Verify task events during autonomous execution."""
+    async def test_state_transition_events_emitted(self):
+        """Verify task state transition events during autonomous execution."""
         _set_mock_responses(
             [
                 '{"tool_calls": [{"id": "c1", "name": "echo", "arguments": {"message": "work"}}]}',
@@ -158,13 +156,10 @@ class TestAutonomousLoop:
         assert completed is not None
 
         event_types = [e.type for e in completed.events]
-        assert EVENT_AUTONOMOUS_ITERATION_STARTED in event_types
-        assert EVENT_AUTONOMOUS_ITERATION_COMPLETED in event_types
-
-        completed_events = [
-            e for e in completed.events if e.type == EVENT_AUTONOMOUS_ITERATION_COMPLETED
-        ]
-        assert any(e.data.get("tool_call_count", 0) > 0 for e in completed_events)
+        assert EVENT_TASK_SUBMITTED in event_types
+        assert EVENT_TASK_COMPLETED in event_types
+        assert completed.output is not None
+        assert len(completed.output) > 0
 
     @pytest.mark.asyncio
     async def test_unlimited_iterations_completes_naturally(self):

--- a/pydantic-ai-server/tests/test_taskstore.py
+++ b/pydantic-ai-server/tests/test_taskstore.py
@@ -15,7 +15,6 @@ from pais.a2a import (
     TERMINAL_STATES,
     EVENT_TASK_SUBMITTED,
     EVENT_TASK_COMPLETED,
-    EVENT_AUTONOMOUS_ITERATION_STARTED,
     EVENT_AUTONOMOUS_BUDGET_EXHAUSTED,
 )
 
@@ -97,11 +96,11 @@ class TestTaskEvent:
     def test_task_event_with_data(self):
         event = TaskEvent(
             id="evt_002",
-            type="autonomous.iteration.started",
+            type="autonomous.budget.exhausted",
             timestamp="2024-01-01T00:00:00+00:00",
-            data={"iteration": 1},
+            data={"reason": "max_iterations"},
         )
-        assert event.data == {"iteration": 1}
+        assert event.data == {"reason": "max_iterations"}
 
     def test_task_event_to_dict(self):
         event = TaskEvent(
@@ -136,11 +135,11 @@ class TestTaskEvent:
             status=TaskStatus(state=TaskState.SUBMITTED),
         )
         task.add_event(EVENT_TASK_SUBMITTED)
-        task.add_event(EVENT_AUTONOMOUS_ITERATION_STARTED, {"iteration": 0})
+        task.add_event(EVENT_AUTONOMOUS_BUDGET_EXHAUSTED, {"reason": "max_iterations"})
         task.add_event(EVENT_TASK_COMPLETED)
         assert len(task.events) == 3
         assert task.events[0].type == EVENT_TASK_SUBMITTED
-        assert task.events[1].type == EVENT_AUTONOMOUS_ITERATION_STARTED
+        assert task.events[1].type == EVENT_AUTONOMOUS_BUDGET_EXHAUSTED
         assert task.events[2].type == EVENT_TASK_COMPLETED
 
     def test_task_add_event_no_data(self):
@@ -389,7 +388,6 @@ class TestLocalTaskManagerAutonomous:
         assert completed is not None
         event_types = [e.type for e in completed.events]
         assert EVENT_TASK_SUBMITTED in event_types
-        assert EVENT_AUTONOMOUS_ITERATION_STARTED in event_types
         assert EVENT_TASK_COMPLETED in event_types
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Simplifies the TaskEvent system to track only state transitions, removing iteration-level events.

### Changes

**TaskEvent keeps (6 types — state transitions + budget):**
- `task.submitted`, `task.working`, `task.completed`, `task.failed`, `task.canceled`
- `autonomous.budget.exhausted`

**TaskEvent removes (2 types — iteration detail):**
- `autonomous.iteration.started` — iteration boundaries are implicit in Memory conversation events
- `autonomous.iteration.completed` — tool counts and response previews already captured by Memory

### Rationale

TaskEvent and Memory serve different purposes:
- **TaskEvent** answers "what state is this task in?" (A2A protocol contract)
- **Memory** answers "what happened during execution?" (agent context + observability)

The iteration-level events were duplicating information already captured by Memory's conversation events (`user_message`, `agent_response`, `tool_call`, `tool_result`). Removing them simplifies the code and clarifies the boundary between the two systems.

### Files Changed

- `pydantic-ai-server/pais/a2a.py` — Remove iteration event constants and writes from `_execute_autonomous`
- `pydantic-ai-server/tests/test_autonomous.py` — Update assertions to use state transition events
- `pydantic-ai-server/tests/test_taskstore.py` — Remove iteration event references
- `pydantic-ai-server/tests/test_a2a_integration.py` — Update event type assertions
- `operator/tests/e2e/test_autonomous_e2e.py` — Remove iteration event assertions
- `docs/python-framework/autonomous.md` — Update event log documentation
- `.github/instructions/python.instructions.md` — Update TaskEvent description

Closes #94 (partially)