### PR TITLE
ci: add Dependabot config with weekly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,91 @@
+version: 2
+updates:
+  # Python - kaos-cli
+  - package-ecosystem: "pip"
+    directory: "/kaos-cli"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]
+
+  # Python - pydantic-ai-server
+  - package-ecosystem: "pip"
+    directory: "/pydantic-ai-server"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]
+
+  # Python - MCP python-string
+  - package-ecosystem: "pip"
+    directory: "/mcp-servers/python-string"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]
+
+  # Python - MCP fastmcp-codemode
+  - package-ecosystem: "pip"
+    directory: "/mcp-servers/fastmcp-codemode"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]
+
+  # Python - E2E test deps
+  - package-ecosystem: "pip"
+    directory: "/operator/tests"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]
+
+  # npm - kaos-ui
+  - package-ecosystem: "npm"
+    directory: "/kaos-ui"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]
+
+  # npm - docs
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]
+
+  # Go - operator
+  - package-ecosystem: "gomod"
+    directory: "/operator"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all:
+        patterns: ["*"]


### PR DESCRIPTION
Add `.github/dependabot.yml` to keep dependencies up to date automatically.

## Configuration
- **9 ecosystem entries**: 5× pip, 2× npm, 1× gomod, 1× github-actions
- **Weekly on Wednesdays** schedule
- **Grouped updates**: all deps per directory bundled into a single PR (via `patterns: ["*"]`)
- **No Docker**: image tags managed by release pipeline

## Directories covered
| Ecosystem | Directory |
|-----------|-----------|
| pip | `/kaos-cli` |
| pip | `/pydantic-ai-server` |
| pip | `/mcp-servers/python-string` |
| pip | `/mcp-servers/fastmcp-codemode` |
| pip | `/operator/tests` |
| npm | `/kaos-ui` |
| npm | `/docs` |
| gomod | `/operator` |
| github-actions | `/` |