### PR TITLE
ci: group security updates in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # Python - pydantic-ai-server
@@ -18,6 +22,10 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # Python - MCP python-string
@@ -28,6 +36,10 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # Python - MCP fastmcp-codemode
@@ -38,6 +50,10 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # Python - E2E test deps
@@ -48,6 +64,10 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # npm - kaos-ui
@@ -58,6 +78,10 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # npm - docs
@@ -68,6 +92,10 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # Go - operator
@@ -78,6 +106,10 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # GitHub Actions
@@ -88,4 +120,8 @@ updates:
       day: "wednesday"
     groups:
       all:
+        applies-to: version-updates
+        patterns: ["*"]
+      all-security:
+        applies-to: security-updates
         patterns: ["*"]


### PR DESCRIPTION
## Problem

After adding `.github/dependabot.yml`, security updates from GitHub Advisory Database created 10+ individual PRs for kaos-ui (#130-139) instead of bundling them.

## Root Cause

Dependabot `groups` only apply to **version updates** by default. Security updates always get individual PRs unless explicitly configured with `applies-to: security-updates`.

## Fix

Add `applies-to: security-updates` group to each ecosystem entry, so both version and security updates are bundled into single PRs per directory.

## After Merge

The 10 individual security PRs (#130-139) should be closed — Dependabot will recreate them as one grouped PR.