### PR TITLE
ci(dependabot): exclude majors from kaos-ui all group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,9 @@ updates:
         patterns: ["*"]
 
   # npm - kaos-ui
+  # Major bumps are excluded from the `all` group so each major gets its own
+  # PR — framework migrations (React, React Router, Vite, Zod, Zustand, etc.)
+  # need individual review and are unsafe to bundle.
   - package-ecosystem: "npm"
     directory: "/kaos-ui"
     schedule:
@@ -80,6 +83,7 @@ updates:
       all:
         applies-to: version-updates
         patterns: ["*"]
+        update-types: ["minor", "patch"]
       all-security:
         applies-to: security-updates
         patterns: ["*"]


### PR DESCRIPTION
## Problem

PRs #143 (59 updates) and #146 (12 security updates) both bundled `kaos-ui/` changes that include framework-migration majors:

- **#143**: React 18→19, React Router 6→7, Zod 3→4, Zustand 4→5, ESLint 9→10, `@hookform/resolvers` 3→5, `sonner` 1→2, `tailwind-merge` 2→3, `lucide-react` 0.4→1, `next-themes` 0.3→0.4
- **#146**: Vite 5→8 (three majors)

These are **framework migrations**, not routine dependency bumps. Bundling them into a single PR makes them unreviewable and unmergeable — any single bump could break the UI in ways invisible to CI.

## Fix

Add `update-types: ["minor", "patch"]` to the `kaos-ui` `all` version-updates group. Majors will now get their own PRs automatically (one per major).

Security updates (`all-security`) are intentionally unchanged — security majors are rare but time-sensitive, and we'd rather see them bundled than delayed.

## Follow-up

Once merged, #143 and #146 will be closed as superseded. Next Wednesday Dependabot will reopen:
- A smaller `all` PR (minor/patch bumps only, mostly Radix)
- Individual PRs for each pending major (React 19, Router 7, Vite 8, Zod 4, etc.)

Each major can then be reviewed and tested in isolation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>