### PR TITLE
docs(skill): add lockfile-desync fix to kaos-ui dependabot-fix appendix

### DIFF
--- a/.github/skills/dependabot-fix/SKILL.md
+++ b/.github/skills/dependabot-fix/SKILL.md
@@ -258,6 +258,7 @@ Common failure modes observed on bundled Dependabot PRs in this repo. Treat thes
 - **Playwright required**, not optional: `npm run test:e2e` against a running dev server + `kaos ui --no-browser` proxy + KIND cluster (per `kaos-ui-testing.instructions.md`). CI's E2E alone is not sufficient evidence.
 - **Host smoke before merge**: use `ask_user` with a concrete click-through script (Agents list → create dialog dry-run → Visual Map pan/zoom → MCP list → ModelAPI list → Chat drawer → detail drawer tabs → theme toggle; check console for errors). Wait for confirmation.
 - Common breakage: `vitest` majors change config shape and matcher behaviour; `react-router` majors change route definitions; `@tanstack/react-query` majors change `useQuery` signature; ESLint 9 flat-config drift when `eslint-*` plugins bump.
+- **Lockfile desync** is the dominant failure mode on routine grouped PRs — every UI check fails at `npm ci` with `Missing: <pkg> from lock file`. Fix: delete **both** `node_modules` **and** `package-lock.json`, then `npm install`. Deleting only `node_modules` can trigger a secondary `Cannot find native binding` error from `rolldown`/vitest 4.x optional deps.
 
 ### `npm` in `docs/` or root
 - VitePress / mermaid plugin API drift — verify `npm run build` under `docs/`


### PR DESCRIPTION
Follow-up from PR #154 (merged). One-line addition to the `npm in kaos-ui/` appendix of the dependabot-fix skill.

## Learning

The first post-split kaos-ui Dependabot PR (#154) failed all 6 UI checks at `npm ci` with `Missing: esbuild@0.28.0 from lock file`. The naive fix (`npm install` keeping the lockfile) silently carried forward the bad state and triggered a secondary `Cannot find native binding` rolldown error from vitest 4.x optional deps. Working fix: delete **both** `node_modules` and `package-lock.json`, then `npm install`.

This will likely be the dominant failure mode for weekly grouped kaos-ui PRs going forward, so worth one line in the appendix.

## Anti-bloat check

One line, high signal-to-noise. The first sentence could arguably be inferred from the error message itself ("update your lock file with `npm install`"), but the **delete-both-files** part is the non-obvious trap — that's what cost extra diagnosis time.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>