### PR TITLE
ci(sync-repos): fail fast when CROSS_REPO_TOKEN is empty

### DIFF
--- a/.github/workflows/sync-repos.yaml
+++ b/.github/workflows/sync-repos.yaml
@@ -34,6 +34,10 @@ jobs:
         env:
           CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
         run: |
+          if [ -z "${CROSS_REPO_TOKEN}" ]; then
+            echo "::error::CROSS_REPO_TOKEN secret is empty or missing. Refresh the PAT in repo settings (needs 'repo' scope on axsaucedo/pydantic-ai-server)."
+            exit 1
+          fi
           # Remove default credential helper set by actions/checkout so our token is used
           git config --unset-all http.https://github.com/.extraheader || true
           git remote add pydantic-ai-server https://x-access-token:${CROSS_REPO_TOKEN}@github.com/axsaucedo/pydantic-ai-server.git 2>/dev/null || true
@@ -57,6 +61,10 @@ jobs:
         env:
           CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
         run: |
+          if [ -z "${CROSS_REPO_TOKEN}" ]; then
+            echo "::error::CROSS_REPO_TOKEN secret is empty or missing. Refresh the PAT in repo settings (needs 'repo' scope on axsaucedo/kaos-ui)."
+            exit 1
+          fi
           # Remove default credential helper set by actions/checkout so our token is used
           git config --unset-all http.https://github.com/.extraheader || true
           git remote add kaos-ui https://x-access-token:${CROSS_REPO_TOKEN}@github.com/axsaucedo/kaos-ui.git 2>/dev/null || true


### PR DESCRIPTION
The Sync Standalone Repos workflow has been failing on every main push with an opaque 403 from 'github-actions[bot]'. Root cause: CROSS_REPO_TOKEN PAT expired/cleared, so git falls back silently to the default GITHUB_TOKEN (which lacks cross-repo push).

This PR adds an explicit empty-check on the secret in both jobs so future expirations surface a clear error.

**Still requires a manual action to unblock main**: refresh `CROSS_REPO_TOKEN` in https://github.com/axsaucedo/kaos/settings/secrets/actions with a new PAT (classic with `repo` scope, or fine-grained with contents:write on axsaucedo/kaos-ui and axsaucedo/pydantic-ai-server).