### PR TITLE
ci(sync-repos): fix actions/checkout v6 credential persistence

### DIFF
--- a/.github/workflows/sync-repos.yaml
+++ b/.github/workflows/sync-repos.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Push subtree to pydantic-ai-server
         env:
@@ -38,8 +39,6 @@ jobs:
             echo "::error::CROSS_REPO_TOKEN secret is empty or missing. Refresh the PAT in repo settings (needs 'repo' scope on axsaucedo/pydantic-ai-server)."
             exit 1
           fi
-          # Remove default credential helper set by actions/checkout so our token is used
-          git config --unset-all http.https://github.com/.extraheader || true
           git remote add pydantic-ai-server https://x-access-token:${CROSS_REPO_TOKEN}@github.com/axsaucedo/pydantic-ai-server.git 2>/dev/null || true
           # Fetch remote so subtree split can resolve upstream commit references
           git fetch pydantic-ai-server main
@@ -56,6 +55,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Push subtree to kaos-ui
         env:
@@ -65,8 +65,6 @@ jobs:
             echo "::error::CROSS_REPO_TOKEN secret is empty or missing. Refresh the PAT in repo settings (needs 'repo' scope on axsaucedo/kaos-ui)."
             exit 1
           fi
-          # Remove default credential helper set by actions/checkout so our token is used
-          git config --unset-all http.https://github.com/.extraheader || true
           git remote add kaos-ui https://x-access-token:${CROSS_REPO_TOKEN}@github.com/axsaucedo/kaos-ui.git 2>/dev/null || true
           # Fetch remote so subtree split can resolve upstream commit references
           git fetch kaos-ui main


### PR DESCRIPTION
Fixes the two persistent `Sync Standalone Repos` failures on main — **token is fine**, issue is `actions/checkout@v6`.

## Root cause

`actions/checkout@v6` changed how it persists credentials. It now writes the default `GITHUB_TOKEN` extraheader to an **external credentials file** referenced via an `includeIf.gitdir:` entry:

```
git config --file /tmp/git-credentials-xxx.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
git config --local includeIf.gitdir:.../.git.path /tmp/git-credentials-xxx.config
```

The workflow's existing `git config --unset-all http.https://github.com/.extraheader` only targets the local config — it's a **no-op** with v6 because the header isn't there. The surviving GITHUB_TOKEN Authorization header then overrides the PAT embedded in the push URL, producing:

```
remote: Permission to axsaucedo/<repo>.git denied to github-actions[bot].
fatal: ... 403
```

## Fix

Set `persist-credentials: false` on both `actions/checkout@v6` steps. The push uses CROSS_REPO_TOKEN in an explicitly-added remote; no credential persistence is needed.

## Timeline

- PR #141 (2026-04-17 15:07Z) — last successful sync (on `actions/checkout@v4`)
- PR #147 (2026-04-17 18:42Z) — merged `actions/checkout v4→v6` bump (as part of #142 rebase)
- Every push since — both sync jobs fail with 403

## Relation to PR #157

PR #157's CROSS_REPO_TOKEN empty-check guard stays — it's orthogonal defensive code for a different failure mode (actual token expiry).