### PR TITLE
ci(sync-repos): use unscoped http.extraheader

### DIFF
--- a/.github/workflows/sync-repos.yaml
+++ b/.github/workflows/sync-repos.yaml
@@ -39,14 +39,12 @@ jobs:
             echo "::error::CROSS_REPO_TOKEN secret is empty or missing. Refresh the PAT in repo settings (needs Contents: write on axsaucedo/pydantic-ai-server)."
             exit 1
           fi
-          # Use Basic auth extraheader (same pattern actions/checkout uses internally) —
-          # GitHub reliably accepts Basic auth with x-access-token:<PAT> for both classic
-          # and fine-grained PATs. Generic https://github.com/ match is safe because
-          # persist-credentials:false on checkout removes any conflicting runner-token header.
+          # Use unscoped http.extraheader with Basic auth (same pattern actions/checkout uses).
+          # Unscoped form reliably applies to all git HTTP requests; URL-scoped form
+          # (http.https://github.com/.extraheader) proved not to match in practice.
+          # Safe because persist-credentials:false on checkout removes the runner-token header.
           AUTH_B64=$(printf "x-access-token:%s" "${CROSS_REPO_TOKEN}" | base64 -w0)
-          git config --local http.https://github.com/.extraheader "Authorization: Basic ${AUTH_B64}"
-          # Debug: confirm config is set (value redacted by Actions secret masking)
-          git config --local --get http.https://github.com/.extraheader | sed 's/Basic.*/Basic [redacted]/'
+          git config --local http.extraheader "Authorization: Basic ${AUTH_B64}"
           git remote add pydantic-ai-server https://github.com/axsaucedo/pydantic-ai-server.git 2>/dev/null || true
           # Fetch remote so subtree split can resolve upstream commit references
           git fetch pydantic-ai-server main
@@ -73,14 +71,12 @@ jobs:
             echo "::error::CROSS_REPO_TOKEN secret is empty or missing. Refresh the PAT in repo settings (needs Contents: write on axsaucedo/kaos-ui)."
             exit 1
           fi
-          # Use Basic auth extraheader (same pattern actions/checkout uses internally) —
-          # GitHub reliably accepts Basic auth with x-access-token:<PAT> for both classic
-          # and fine-grained PATs. Generic https://github.com/ match is safe because
-          # persist-credentials:false on checkout removes any conflicting runner-token header.
+          # Use unscoped http.extraheader with Basic auth (same pattern actions/checkout uses).
+          # Unscoped form reliably applies to all git HTTP requests; URL-scoped form
+          # (http.https://github.com/.extraheader) proved not to match in practice.
+          # Safe because persist-credentials:false on checkout removes the runner-token header.
           AUTH_B64=$(printf "x-access-token:%s" "${CROSS_REPO_TOKEN}" | base64 -w0)
-          git config --local http.https://github.com/.extraheader "Authorization: Basic ${AUTH_B64}"
-          # Debug: confirm config is set (value redacted by Actions secret masking)
-          git config --local --get http.https://github.com/.extraheader | sed 's/Basic.*/Basic [redacted]/'
+          git config --local http.extraheader "Authorization: Basic ${AUTH_B64}"
           git remote add kaos-ui https://github.com/axsaucedo/kaos-ui.git 2>/dev/null || true
           # Fetch remote so subtree split can resolve upstream commit references
           git fetch kaos-ui main


### PR DESCRIPTION
URL-scoped extraheader wasn't matching in practice. Use unscoped `http.extraheader`.