### PR TITLE
ci(tests): pin controller-gen and setup-envtest versions

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Install Go tools
         run: |
-          go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
-          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+          go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.1
+          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 
       - name: Run Go tests
         working-directory: operator


### PR DESCRIPTION
Root cause: `setup-envtest@latest` now requires Go >= 1.26.0, which broke unit-tests on the v0.4.2 release run (go.mod is on 1.25). Pinning both Go tools to versions compatible with Go 1.25, avoiding future `@latest` toolchain drift.