### PR TITLE
fix(pais): bump pydantic-ai floor to >=1.0.0

### DIFF
--- a/pydantic-ai-server/pyproject.toml
+++ b/pydantic-ai-server/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
-    "pydantic-ai>=0.2.0",
+    "pydantic-ai>=1.0.0",
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
     "httpx>=0.25.0",


### PR DESCRIPTION
Pip resolver was backtracking to pydantic-ai 0.8.1 (lacks `description` kwarg on `Agent.tool_plain`), breaking unit-tests on the v0.4.2 release run. Bumping the floor to >=1.0.0 prevents resolver backtracking past the 1.x API that the tests rely on.