### PR TITLE
ci(tests): use uv for unit-tests Python install

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -40,6 +40,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Install Go tools
         run: |
           go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.1
@@ -51,13 +54,16 @@ jobs:
 
       - name: Install Python dependencies
         working-directory: pydantic-ai-server
+        timeout-minutes: 10
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          uv venv
+          uv pip install -e ".[dev]"
 
       - name: Run Python tests
         working-directory: pydantic-ai-server
-        run: python -m pytest tests/ -v
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests/ -v
 
   # E2E tests (sharded)
   e2e-tests:


### PR DESCRIPTION
Pip resolver was hanging (>50min) when installing pydantic-ai-server[dev] in the release pipeline's unit-tests job, blocking v0.4.2 release. uv resolves the same deps in seconds.

Adds 10min timeout as a safeguard.

Refs release attempt 3 of v0.4.2 (run 24929534936).