### PR TITLE
fix(pais): constrain pydantic-ai dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,6 +248,14 @@ jobs:
           sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
           python -m build
 
+      - name: Validate pydantic-ai-server wheel install
+        if: steps.check-pypi.outputs.skip != 'true'
+        run: |
+          python -m venv /tmp/pais-wheel-venv
+          /tmp/pais-wheel-venv/bin/python -m pip install --upgrade pip
+          /tmp/pais-wheel-venv/bin/python -m pip install pydantic-ai-server/dist/*.whl
+          /tmp/pais-wheel-venv/bin/python -c "import pais, importlib.metadata as metadata; print(metadata.version('pydantic-ai-server'))"
+
       - name: Publish to PyPI
         if: steps.check-pypi.outputs.skip != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pydantic-ai-server/pyproject.toml
+++ b/pydantic-ai-server/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
-    "pydantic-ai>=1.0.0",
+    "pydantic-ai>=1.75.0,<2.0.0",
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
     "httpx>=0.25.0",

--- a/pydantic-ai-server/uv.lock
+++ b/pydantic-ai-server/uv.lock
@@ -2125,7 +2125,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-server"
-version = "0.4.2.dev0"
+version = "0.4.4.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -2174,7 +2174,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-starlette", specifier = ">=0.41b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pydantic-ai", specifier = ">=0.2.0" },
+    { name = "pydantic-ai", specifier = ">=1.75.0,<2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },


### PR DESCRIPTION
## Summary
- tighten pydantic-ai-server's pydantic-ai dependency to a recent 1.x range so plain pip avoids old broken resolver candidates
- refresh pydantic-ai-server uv.lock metadata
- add a release workflow guard that installs the built pydantic-ai-server wheel with plain pip before PyPI publish

## Root cause
Plain pip installing pydantic-ai-server==0.4.3 on Python 3.12 backtracked through old pydantic-ai dependency graphs and eventually tried to build legacy pyparsing==2.0.2, which fails because collections.MutableMapping was removed.

## Testing
- python3 -m venv tmp/pais-pip-install-venv && pip install ./pydantic-ai-server && import/version check
- cd pydantic-ai-server && uv run --extra dev pytest tests/ -v
- cd pydantic-ai-server && uv run --extra dev black --check .
- cd pydantic-ai-server && uvx ty check (reported one pre-existing warning, exit 0)
- cd pydantic-ai-server && uv run --with build python -m build, then plain pip install dist/*.whl and import/version check