### PR TITLE
feat(a2a): list retained tasks in debug UI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,3 +115,4 @@ Detailed instructions are in `.github/instructions/`:
 
 ### Skills
 - `/release-kaos`: Invoke with a version (e.g., "Use /release-kaos to release v0.5.0") — executes full release pipeline
+- `/planned-implementation`: Use for complex staged KAOS work that needs backend/UI context gathering, a written plan, task-scoped commits, PR/CI validation, and an uncommitted REPORT.md PR comment

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -118,8 +118,8 @@ make format                     # Auto-format code
 - `AgentDeps`: Per-run dependencies (session_id, memory) injected via RunContext
 - `DelegationToolset`: AbstractToolset that exposes sub-agents as delegate_to_ tools
 - `RemoteAgent`: HTTP client for sub-agent delegation — tries A2A SendMessage first, falls back to /v1/chat/completions
-- `TaskManager`: ABC for task lifecycle — `send_message()`, `get_task()`, `cancel_task()`, `wait_for_completion()`, `shutdown()`
-- `LocalTaskManager`: In-memory implementation with synchronous execution, OTel instrumentation
+- `TaskManager`: ABC for task lifecycle — `send_message()`, `list_tasks()`, `get_task()`, `cancel_task()`, `wait_for_completion()`, `shutdown()`
+- `LocalTaskManager`: In-memory implementation with retained task listing, synchronous execution, OTel instrumentation
 - `NullTaskManager`: No-op implementation (like NullMemory)
 - `Task`: Task dataclass with id, session_id, status, history, metadata, timestamps
 - `TaskState`: Enum — submitted, working, completed, failed, canceled
@@ -131,8 +131,8 @@ make format                     # Auto-format code
 - `_MockResponseState`: Mutable mock response state shared via closure (workaround for ContextVar + FunctionModel issue)
 
 ### TaskManager
-- **TaskManager** ABC: `send_message()`, `submit_autonomous()`, `get_task()`, `cancel_task()`, `wait_for_completion()`, `shutdown()`
-- **LocalTaskManager**: In-memory dict storage, synchronous process_fn execution, async autonomous execution, OTel spans/metrics
+- **TaskManager** ABC: `send_message()`, `submit_autonomous()`, `list_tasks()`, `get_task()`, `cancel_task()`, `wait_for_completion()`, `shutdown()`
+- **LocalTaskManager**: In-memory dict storage, retained task listing, synchronous process_fn execution, async autonomous execution, OTel spans/metrics
 - **NullTaskManager**: No-op — `send_message()` returns a stub task, nothing persisted
 - State transitions enforced via `VALID_TRANSITIONS` dict — terminal states allow no further transitions
 - `TASK_STORE_TYPE` env var controls backend selection (`local` default, `null` to disable)
@@ -156,8 +156,8 @@ make format                     # Auto-format code
 
 ### A2A JSON-RPC Endpoint (POST /) — a2a.py
 - JSON-RPC 2.0 dispatcher at root path, separate from `/v1/chat/completions`
-- A2A RC v1.0 methods: `SendMessage`, `GetTask`, `CancelTask` (PascalCase)
-- Legacy aliases: `tasks/send`, `tasks/get`, `tasks/cancel` (backward compatible)
+- A2A RC v1.0 methods: `SendMessage`, `ListTasks`, `GetTask`, `CancelTask` (PascalCase)
+- Legacy aliases: `tasks/send`, `tasks/list`, `tasks/get`, `tasks/cancel` (backward compatible)
 - `SendMessage` supports two modes: synchronous (default) returns completed/failed task, autonomous (`configuration.mode: "autonomous"`) spawns background task
 - `contextId` param maps to session_id
 - Standard error codes: -32700 (parse), -32600 (invalid request), -32601 (method not found), -32602 (invalid params), -32603 (internal), -32001 (task not found)
@@ -222,6 +222,6 @@ Pydantic AI runs `FunctionModel` handlers in a copied context — `ContextVar` s
 - `GET /ready`: Readiness probe
 - `GET /.well-known/agent.json`: A2A-compliant agent card (discovers tools from MCP servers)
 - `POST /v1/chat/completions`: OpenAI-compatible chat endpoint
-- `POST /`: A2A JSON-RPC 2.0 endpoint (SendMessage, GetTask, CancelTask + legacy aliases)
+- `POST /`: A2A JSON-RPC 2.0 endpoint (SendMessage, ListTasks, GetTask, CancelTask + legacy aliases)
 - `GET /memory/events?session_id=X`: Memory events for a session
 - `GET /memory/sessions`: List all memory sessions

--- a/.github/skills/planned-implementation/SKILL.md
+++ b/.github/skills/planned-implementation/SKILL.md
@@ -18,6 +18,7 @@ IMPORTANT INSRTUCTIONS: This is quite a comprehensive request, so please ensure 
 - Create or overwrite `REPORT.md` at the end, but never commit it. Post its contents as a PR comment.
 - Commit each numbered TODO separately with a succinct conventional commit message and the required co-author trailer.
 - Do not skip validation for a TODO before committing it. If validation cannot run locally, document why in `REPORT.md` and rely on PR CI.
+- Prefer real local validation when the host already has Docker, Kubernetes, KAOS, UI dev servers, or proxy configuration running. Detect and reuse that setup before falling back to mocked tests or CI-only validation.
 
 ## Phase 0 - Scope and setup
 
@@ -37,6 +38,23 @@ git --no-pager status --short --branch
 ```
 
 Stop and ask the user if existing unrelated changes conflict with the requested work.
+
+5. Detect reusable local runtime configuration and record what is available:
+
+```bash
+{
+  echo "## Local validation environment"
+  command -v docker >/dev/null && docker ps --format 'docker: {{.Names}} {{.Status}}' || true
+  command -v kubectl >/dev/null && kubectl config current-context 2>./tmp/null || true
+  command -v kubectl >/dev/null && kubectl cluster-info 2>./tmp/null || true
+  command -v kaos >/dev/null && kaos version 2>./tmp/null || true
+  curl -sS -o ./tmp/null -w 'ui:%{http_code}\n' http://localhost:8080/ || true
+  curl -sS -o ./tmp/null -w 'ui-alt:%{http_code}\n' http://localhost:8081/ || true
+  curl -sS -o ./tmp/null -w 'proxy:%{http_code}\n' http://localhost:8010/ || true
+} | tee ./tmp/local-validation-context.txt
+```
+
+If the user says a local KAOS cluster is running, treat the local runtime as the primary E2E validation target. Do not skip local E2E solely because CI will run later.
 
 ## Phase 1 - Backend context
 
@@ -134,6 +152,15 @@ Do not batch unrelated TODOs into one commit.
 
 Use targeted local validation first, then PR CI for broader coverage.
 
+Before running E2E, inspect `./tmp/local-validation-context.txt` and reuse available configuration:
+
+- If `kubectl cluster-info` works, use the current kube context; do not create a new KIND cluster unless tests require isolation.
+- If `kaos ui --no-browser` or another proxy is already serving on `localhost:8010`, use that proxy.
+- If the UI is already serving on `localhost:8080` or `localhost:8081`, use the matching Playwright base URL or config instead of starting a duplicate server.
+- If Docker is running and a KAOS cluster is installed, prefer a small real-browser Playwright path through the local UI and proxy for UI changes.
+- If the proxy or UI is missing, start only the missing process, capture logs under `./tmp`, and stop only processes you started.
+- Keep all temporary logs/config under `./tmp`.
+
 Common commands:
 
 ```bash
@@ -156,6 +183,17 @@ make test-unit
 ```
 
 For end-to-end coverage, prefer GitHub Actions on a PR. If many CI failures occur, reproduce 1-3 relevant tests locally before pushing follow-up fixes.
+
+For UI work against an existing local KAOS cluster, run at least one targeted Playwright test against the real local setup when available, for example:
+
+```bash
+cd kaos-ui
+KAOS_UI_BASE_URL=http://localhost:8080 \
+KAOS_PROXY_URL=http://localhost:8010 \
+npm run test:e2e -- tests/functional/<relevant-test>.spec.ts
+```
+
+If the repo's Playwright config does not read those environment variables, either use the default ports expected by the config or pass an equivalent Playwright `--config`/environment setup already used in the repo. Record the exact command and observed result in `REPORT.md`.
 
 ## Phase 8 - REPORT.md and PR comment
 

--- a/.github/skills/planned-implementation/SKILL.md
+++ b/.github/skills/planned-implementation/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: planned-implementation
+description: Plan and execute complex KAOS implementation work with staged context gathering, backend/UI synthesis, validation, PR/CI checks, and REPORT.md PR-comment output.
+allowed-tools: shell
+---
+
+# Planned Implementation
+
+Use this skill for complex KAOS changes that span multiple domains, especially backend plus UI work. The goal is to keep working context focused by gathering domain knowledge in staged passes, documenting only the relevant findings, then executing numbered tasks one by one with validation and commits.
+
+IMPORTANT INSRTUCTIONS: This is quite a comprehensive request, so please ensure that before starting you put together a comprehensive plan to move forward, and a design plan on how this will fit the existing codebase. Create a set of tasks from the TODOs outlined below by number, and make sure you carry them out one by one without skipping any, each of them should ensure the tests are validated and passing, and committed with using commits using "comprehensive commit" style with succint and functional descriptions each individual task is done. Ensure that all tests pass. You have access to github CI, so whenever you create a set of commits, make sure to push to a PR (if not there create one) and validate that they all run correctly; if any major refactors make sure that you run the python and golang tests locally, and you have a KIND cluster available so run 1-3 tests locally before pushing to run the end to end tests in the CI; prefer to run the complete set of tests in the CI github actions, but if you see many failing again run 1-3 locally to validate before; be efficient when it comes to testing.  We are still in alpha so breaking changes can be done and migration does not need to be documented.
+
+## Ground rules
+
+- Do not start implementation before a written plan exists and the user has approved it.
+- Use focused context phases. Prefer subagents for broad research; otherwise gather one domain at a time and write compact notes before moving to the next domain.
+- Use `./tmp` for scratch files and suppressed output. Do not use `/tmp` unless external-host access is truly required.
+- Create or overwrite `REPORT.md` at the end, but never commit it. Post its contents as a PR comment.
+- Commit each numbered TODO separately with a succinct conventional commit message and the required co-author trailer.
+- Do not skip validation for a TODO before committing it. If validation cannot run locally, document why in `REPORT.md` and rely on PR CI.
+
+## Phase 0 - Scope and setup
+
+1. Restate the user request in one paragraph.
+2. Identify touched domains: Python backend, Go operator, UI, docs, CLI, workflows, or skills.
+3. Create scratch space:
+
+```bash
+mkdir -p ./tmp
+touch ./tmp/null
+```
+
+4. Check repository state before editing:
+
+```bash
+git --no-pager status --short --branch
+```
+
+Stop and ask the user if existing unrelated changes conflict with the requested work.
+
+## Phase 1 - Backend context
+
+Read only backend-relevant instructions, docs, source, and tests first. Use this mapping:
+
+- `pydantic-ai-server/**` -> `.github/instructions/python.instructions.md`
+- `operator/**/*.go` -> `.github/instructions/operator.instructions.md`
+- `operator/tests/**` -> `.github/instructions/e2e.instructions.md`
+- `kaos-cli/**` -> Python instructions plus CLI docs/tests
+
+Capture:
+
+- Entry points and public APIs.
+- Existing data models and serialization contracts.
+- Tests that currently cover the behavior.
+- Validation commands and any known gotchas.
+- Risks, migration notes, and compatibility decisions.
+
+Do not start UI research until backend notes are complete.
+
+## Phase 2 - UI context
+
+Read only UI-relevant instructions, source, and tests:
+
+- `.github/instructions/kaos-ui.instructions.md`
+- `.github/instructions/kaos-ui-testing.instructions.md`
+- `.github/instructions/kaos-ui-components.instructions.md` when components are touched
+- `.github/instructions/kaos-ui-kubernetes-types.instructions.md` when Kubernetes/CRD types are touched
+
+Capture:
+
+- Component/state ownership.
+- Client/API boundaries.
+- Existing UX patterns and test selectors.
+- Unit, functional, and Playwright validation paths.
+- Manual validation needs.
+
+Do not start cross-domain design until UI notes are complete.
+
+## Phase 3 - Docs, skills, and workflow context
+
+Read docs and repo instructions that describe the public surface or workflow being changed:
+
+- `.github/copilot-instructions.md`
+- `.github/skills/*/SKILL.md` for skill conventions
+- `.github/instructions/docs.instructions.md` for docs changes
+- Relevant pages under `docs/`
+
+Capture:
+
+- Public documentation that must change with the implementation.
+- Instruction files that should stay in sync.
+- Skill or workflow conventions to preserve.
+
+## Phase 4 - Cross-domain synthesis
+
+Create a compact design that answers:
+
+- What contract connects backend and UI?
+- What behavior is intentionally changed?
+- What defaults keep the implementation simple?
+- What tests prove the contract end-to-end?
+- What is explicitly out of scope?
+
+Prefer the smallest complete design that fits existing code. KAOS is alpha, so breaking changes can be accepted when useful, but do not break unrelated behavior casually.
+
+## Phase 5 - Plan and TODOs
+
+Write a plan with:
+
+- Problem statement.
+- Current-state summary by domain.
+- Design plan.
+- Numbered TODOs.
+- Validation per TODO.
+- Commit and PR/CI strategy.
+- `REPORT.md` requirements.
+
+Reflect the TODOs into any available task tracker and keep status updated as work progresses.
+
+## Phase 6 - Execute one TODO at a time
+
+For each numbered TODO:
+
+1. Mark the TODO in progress.
+2. Make only the changes needed for that TODO.
+3. Run targeted validation for that TODO.
+4. Fix failures before moving on.
+5. Commit the completed TODO.
+6. Mark the TODO done.
+
+Do not batch unrelated TODOs into one commit.
+
+## Phase 7 - Validation and PR/CI
+
+Use targeted local validation first, then PR CI for broader coverage.
+
+Common commands:
+
+```bash
+# Python backend
+cd pydantic-ai-server && source .venv/bin/activate
+python -m pytest tests/ -v
+make lint
+
+# UI
+cd kaos-ui
+npm run test:unit
+npm run lint
+npm run build
+npm run test:e2e -- tests/functional/
+
+# Operator, only when operator code changes
+cd operator
+make generate manifests
+make test-unit
+```
+
+For end-to-end coverage, prefer GitHub Actions on a PR. If many CI failures occur, reproduce 1-3 relevant tests locally before pushing follow-up fixes.
+
+## Phase 8 - REPORT.md and PR comment
+
+Create or overwrite `REPORT.md` in the repository root with:
+
+- Original request and numbered TODOs.
+- Implementation status for each TODO.
+- Commits created.
+- Validation run locally.
+- CI/PR status.
+- Risks, follow-ups, and anything incomplete.
+
+Do not commit `REPORT.md`. Post its contents as a PR comment:
+
+```bash
+gh pr comment <pr-number> --body-file REPORT.md
+```

--- a/docs/python-framework/a2a-tasks.md
+++ b/docs/python-framework/a2a-tasks.md
@@ -8,6 +8,7 @@ The A2A subsystem provides:
 - **TaskManager ABC** with `LocalTaskManager` (in-memory) and `NullTaskManager` (no-op) implementations
 - **Synchronous task execution** — `SendMessage` returns a completed task
 - **JSON-RPC 2.0 endpoint** at `POST /` with A2A spec-compliant methods
+- **Task listing** — `ListTasks` returns all tasks retained by the current agent process
 - **Agent card** discovery at `/.well-known/agent.json` with A2A capabilities
 - **A2A-compliant delegation** — RemoteAgent uses `SendMessage` for inter-agent communication
 
@@ -84,6 +85,40 @@ curl -X POST http://agent:8000/ \
   -d '{"jsonrpc": "2.0", "method": "GetTask", "id": 2, "params": {"id": "task-uuid"}}'
 ```
 
+### ListTasks
+
+Retrieve all tasks retained by the current agent process, including terminal tasks. Results are sorted newest-first by status timestamp. `LocalTaskManager` stores tasks in memory, so this list is ephemeral and does not survive pod restarts.
+
+```bash
+curl -X POST http://agent:8000/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "ListTasks", "id": 3}'
+```
+
+Response:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "tasks": [
+      {
+        "id": "task-uuid",
+        "sessionId": "session-uuid",
+        "status": {"state": "completed", "message": "Done", "timestamp": "..."},
+        "history": [],
+        "artifacts": [],
+        "metadata": {},
+        "events": [],
+        "autonomous": false,
+        "output": ""
+      }
+    ],
+    "count": 1
+  }
+}
+```
+
 ### CancelTask
 
 Cancel a task. Returns the task in its current state. Since execution is synchronous, tasks are typically already completed.
@@ -99,6 +134,7 @@ curl -X POST http://agent:8000/ \
 For backward compatibility, lowercase aliases are supported:
 - `tasks/send` → `SendMessage`
 - `tasks/get` → `GetTask`
+- `tasks/list` → `ListTasks`
 - `tasks/cancel` → `CancelTask`
 
 ## Error Codes
@@ -142,7 +178,7 @@ When TaskManager is active (not NullTaskManager), the agent card reflects A2A ca
 
 ### TaskManager ABC
 
-TaskManager ABC defines the interface: `send_message()`, `get_task()`, `cancel_task()`, `wait_for_completion()`, `shutdown()`.
+TaskManager ABC defines the interface: `send_message()`, `list_tasks()`, `get_task()`, `cancel_task()`, `wait_for_completion()`, `shutdown()`.
 
 - **LocalTaskManager**: In-memory dict storage, synchronous process_fn execution, OTel instrumentation
 - **NullTaskManager**: No-op implementation (like NullMemory)
@@ -152,8 +188,9 @@ TaskManager ABC defines the interface: `send_message()`, `get_task()`, `cancel_t
 1. `SendMessage` → `TaskManager.send_message()` creates task, executes process_fn inline
 2. Task transitions: submitted → working → completed/failed
 3. Completed task returned immediately to caller
-4. `GetTask` → retrieves stored task
-5. `CancelTask` → no-op for completed tasks (synchronous execution)
+4. `ListTasks` → retrieves all retained tasks, newest-first
+5. `GetTask` → retrieves stored task
+6. `CancelTask` → no-op for completed tasks (synchronous execution)
 
 ### A2A Delegation
 

--- a/kaos-ui/playwright.config.ts
+++ b/kaos-ui/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
   /* Shared settings for all the projects below */
   use: {
     /* Base URL to use in actions like `await page.goto('/')` */
-    baseURL: 'http://localhost:8080',
+    baseURL: process.env.KAOS_UI_BASE_URL || 'http://localhost:8080',
 
     /* Collect trace when retrying the failed test */
     trace: 'on-first-retry',

--- a/kaos-ui/src/components/agent/AgentA2ADebug.tsx
+++ b/kaos-ui/src/components/agent/AgentA2ADebug.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Radio, Clock, Loader2 } from 'lucide-react';
+import { Radio, Clock, Loader2, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -31,12 +32,13 @@ export function AgentA2ADebug({ agent }: AgentA2ADebugProps) {
     currentTask, isLoadingTask, taskError,
     isPolling, stopPolling, startPolling,
     fetchTask, cancelTask,
-    taskHistory, loadTaskFromHistory,
+    taskHistory, isLoadingTaskList, taskListError, refreshTasks, loadTaskFromHistory,
   } = useA2ADebug(agent);
 
   useEffect(() => {
     fetchAgentCard();
-  }, [fetchAgentCard]);
+    refreshTasks();
+  }, [fetchAgentCard, refreshTasks]);
 
   const handleLoadTaskFromHistory = (entry: TaskHistoryEntry) => {
     loadTaskFromHistory(entry);
@@ -99,21 +101,42 @@ export function AgentA2ADebug({ agent }: AgentA2ADebugProps) {
 
       {/* Task history sidebar */}
       <div className="w-56 shrink-0 border-l pl-3">
-        <div className="flex items-center gap-2 mb-3">
-          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Task History</h4>
-          {taskHistory.length > 0 && (
-            <Badge variant="outline" className="text-[10px] h-4 px-1.5">{taskHistory.length}</Badge>
-          )}
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Task History</h4>
+            {taskHistory.length > 0 && (
+              <Badge variant="outline" className="text-[10px] h-4 px-1.5">{taskHistory.length}</Badge>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 shrink-0"
+            onClick={refreshTasks}
+            disabled={isLoadingTaskList}
+            data-testid="a2a-refresh-tasks"
+            title="Refresh task history"
+          >
+            <RefreshCw className={`h-3 w-3 ${isLoadingTaskList ? 'animate-spin' : ''}`} />
+          </Button>
         </div>
+
+        {taskListError && (
+          <p className="text-[10px] text-destructive mb-2" data-testid="a2a-task-list-error">
+            {taskListError}
+          </p>
+        )}
 
         <ScrollArea className="h-[calc(100%-32px)]">
           {taskHistory.length === 0 ? (
-            <p className="text-[10px] text-muted-foreground italic py-2">No tasks yet</p>
+            <p className="text-[10px] text-muted-foreground italic py-2">
+              {isLoadingTaskList ? 'Loading tasks...' : 'No retained tasks'}
+            </p>
           ) : (
             <div className="space-y-1.5">
               {taskHistory.map((entry, i) => (
                 <button
-                  key={i}
+                  key={entry.taskId}
                   onClick={() => handleLoadTaskFromHistory(entry)}
                   className={`w-full text-left p-2 rounded-md border text-xs transition-colors hover:bg-muted/50 ${
                     currentTask?.id === entry.taskId ? 'bg-muted border-primary/30' : ''

--- a/kaos-ui/src/components/agent/useA2ADebug.ts
+++ b/kaos-ui/src/components/agent/useA2ADebug.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { getAgentCard, sendA2AMessage, getA2ATask, cancelA2ATask } from '@/lib/k8s/a2a';
+import { getAgentCard, sendA2AMessage, getA2ATask, cancelA2ATask, listA2ATasks } from '@/lib/k8s/a2a';
 import type { Agent } from '@/types/kubernetes';
 import type { AgentCard, A2ATask, SendMessageParams } from '@/types/a2a';
 
@@ -9,6 +9,42 @@ export interface TaskHistoryEntry {
   mode: string;
   createdAt: Date;
   message: string;
+}
+
+const TERMINAL_STATES = ['completed', 'failed', 'canceled'];
+
+function parseTaskDate(timestamp?: string): Date {
+  if (!timestamp) return new Date();
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+function getTaskMessage(task: A2ATask): string {
+  const userMessage = task.history?.find(message => message.role === 'user');
+  const text = userMessage?.parts
+    ?.map(part => part.text)
+    .filter(Boolean)
+    .join(' ') || '';
+  return text.slice(0, 100);
+}
+
+function taskToHistoryEntry(task: A2ATask): TaskHistoryEntry {
+  return {
+    taskId: task.id,
+    state: task.status?.state || 'unknown',
+    mode: task.autonomous ? 'autonomous' : 'interactive',
+    createdAt: parseTaskDate(task.status?.timestamp),
+    message: getTaskMessage(task),
+  };
+}
+
+function mergeTaskHistory(prev: TaskHistoryEntry[], tasks: A2ATask[]): TaskHistoryEntry[] {
+  const byId = new Map(prev.map(entry => [entry.taskId, entry]));
+  for (const task of tasks) {
+    const next = taskToHistoryEntry(task);
+    byId.set(task.id, { ...byId.get(task.id), ...next });
+  }
+  return Array.from(byId.values()).sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 }
 
 export function useA2ADebug(agent: Agent) {
@@ -31,6 +67,8 @@ export function useA2ADebug(agent: Agent) {
 
   // Task history
   const [taskHistory, setTaskHistory] = useState<TaskHistoryEntry[]>([]);
+  const [isLoadingTaskList, setIsLoadingTaskList] = useState(false);
+  const [taskListError, setTaskListError] = useState<string | null>(null);
 
   // Auto-poll
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -61,6 +99,26 @@ export function useA2ADebug(agent: Agent) {
     }
   }, [serviceName, namespace]);
 
+  const refreshTasks = useCallback(async () => {
+    setIsLoadingTaskList(true);
+    setTaskListError(null);
+    try {
+      const result = await listA2ATasks(serviceName, namespace);
+      const tasks = result.tasks || [];
+      setTaskHistory(prev => mergeTaskHistory(prev, tasks));
+      setCurrentTask(prev => {
+        if (!prev) return prev;
+        return tasks.find(task => task.id === prev.id) || prev;
+      });
+      return tasks;
+    } catch (err) {
+      setTaskListError(err instanceof Error ? err.message : 'Failed to list tasks');
+      return [];
+    } finally {
+      setIsLoadingTaskList(false);
+    }
+  }, [serviceName, namespace]);
+
   const startPolling = useCallback((taskId: string) => {
     stopPolling();
     setIsPolling(true);
@@ -68,11 +126,8 @@ export function useA2ADebug(agent: Agent) {
       try {
         const task = await getA2ATask(serviceName, taskId, namespace);
         setCurrentTask(task);
-        setTaskHistory(prev => prev.map(entry =>
-          entry.taskId === taskId ? { ...entry, state: task.status?.state || entry.state } : entry
-        ));
-        const terminalStates = ['completed', 'failed', 'canceled'];
-        if (task.status && terminalStates.includes(task.status.state)) {
+        setTaskHistory(prev => mergeTaskHistory(prev, [task]));
+        if (task.status && TERMINAL_STATES.includes(task.status.state)) {
           stopPolling();
         }
       } catch {
@@ -87,19 +142,10 @@ export function useA2ADebug(agent: Agent) {
     try {
       const task = await sendA2AMessage(serviceName, params, namespace);
       setCurrentTask(task);
-      // Add to history
-      const messageText = params.message?.parts?.[0]?.text || '';
-      setTaskHistory(prev => [{
-        taskId: task.id,
-        state: task.status?.state || 'unknown',
-        mode: params.configuration?.mode === 'autonomous' ? 'autonomous' : 'interactive',
-        createdAt: new Date(),
-        message: messageText.slice(0, 100),
-      }, ...prev]);
+      setTaskHistory(prev => mergeTaskHistory(prev, [task]));
 
       // Start polling if task is not terminal
-      const terminalStates = ['completed', 'failed', 'canceled'];
-      if (task.status && !terminalStates.includes(task.status.state)) {
+      if (task.status && !TERMINAL_STATES.includes(task.status.state)) {
         startPolling(task.id);
       }
 
@@ -118,10 +164,7 @@ export function useA2ADebug(agent: Agent) {
     try {
       const task = await getA2ATask(serviceName, taskId, namespace);
       setCurrentTask(task);
-      // Update history entry
-      setTaskHistory(prev => prev.map(entry =>
-        entry.taskId === taskId ? { ...entry, state: task.status?.state || entry.state } : entry
-      ));
+      setTaskHistory(prev => mergeTaskHistory(prev, [task]));
       return task;
     } catch (err) {
       setTaskError(err instanceof Error ? err.message : 'Failed to fetch task');
@@ -138,10 +181,7 @@ export function useA2ADebug(agent: Agent) {
       const task = await cancelA2ATask(serviceName, taskId, namespace);
       setCurrentTask(task);
       stopPolling();
-      // Update history
-      setTaskHistory(prev => prev.map(entry =>
-        entry.taskId === taskId ? { ...entry, state: 'canceled' } : entry
-      ));
+      setTaskHistory(prev => mergeTaskHistory(prev, [task]));
       return task;
     } catch (err) {
       setTaskError(err instanceof Error ? err.message : 'Failed to cancel task');
@@ -181,6 +221,9 @@ export function useA2ADebug(agent: Agent) {
 
     // History
     taskHistory,
+    isLoadingTaskList,
+    taskListError,
+    refreshTasks,
     loadTaskFromHistory,
   };
 }

--- a/kaos-ui/src/lib/k8s/a2a.ts
+++ b/kaos-ui/src/lib/k8s/a2a.ts
@@ -3,7 +3,7 @@
  * Uses K8s service proxy to communicate with agent pods.
  */
 
-import type { AgentCard, A2ATask, JsonRpcResponse } from '@/types/a2a';
+import type { AgentCard, A2ATask, JsonRpcResponse, ListTasksResult } from '@/types/a2a';
 import { k8sClient } from './index';
 
 /**
@@ -113,6 +113,29 @@ export async function getA2ATask(
   }
 
   return rpcResponse.result as A2ATask;
+}
+
+/**
+ * List retained A2A tasks for an agent.
+ */
+export async function listA2ATasks(
+  serviceName: string,
+  namespace?: string,
+  port: number = 8000
+): Promise<ListTasksResult> {
+  const rpcResponse = await sendA2AJsonRpc(
+    serviceName,
+    'ListTasks',
+    {},
+    namespace,
+    port
+  );
+
+  if (rpcResponse.error) {
+    throw new Error(rpcResponse.error.message || 'A2A ListTasks failed');
+  }
+
+  return rpcResponse.result as ListTasksResult;
 }
 
 /**

--- a/kaos-ui/src/types/a2a.ts
+++ b/kaos-ui/src/types/a2a.ts
@@ -65,6 +65,11 @@ export interface A2ATask {
   output: string;
 }
 
+export interface ListTasksResult {
+  tasks: A2ATask[];
+  count: number;
+}
+
 // ============= JSON-RPC Types =============
 
 export interface JsonRpcRequest {

--- a/kaos-ui/tests/fixtures/test-utils.ts
+++ b/kaos-ui/tests/fixtures/test-utils.ts
@@ -6,9 +6,9 @@ import { Page, expect } from '@playwright/test';
 
 /** Default test configuration */
 export const TEST_CONFIG = {
-  proxyUrl: 'http://localhost:8010',
-  namespace: 'kaos-hierarchy',
-  baseUrl: 'http://localhost:8080',
+  proxyUrl: process.env.KAOS_PROXY_URL || 'http://localhost:8010',
+  namespace: process.env.KAOS_TEST_NAMESPACE || 'kaos-hierarchy',
+  baseUrl: process.env.KAOS_UI_BASE_URL || 'http://localhost:8080',
 };
 
 /**

--- a/kaos-ui/tests/functional/agent-a2a.spec.ts
+++ b/kaos-ui/tests/functional/agent-a2a.spec.ts
@@ -23,6 +23,23 @@ async function navigateToA2ATab(page: import('@playwright/test').Page): Promise<
   return true;
 }
 
+function mockTask(id: string, text: string, state = 'completed') {
+  return {
+    id,
+    sessionId: `session-${id}`,
+    status: { state, timestamp: new Date().toISOString(), message: 'Done' },
+    history: [
+      { role: 'user', parts: [{ type: 'text', text }] },
+      { role: 'agent', parts: [{ type: 'text', text: 'Mock response from agent' }] },
+    ],
+    artifacts: [],
+    metadata: {},
+    events: [],
+    autonomous: false,
+    output: 'Mock response from agent',
+  };
+}
+
 test.describe('A2A Debug Screen', () => {
   test.beforeEach(async ({ page }) => {
     page.on('pageerror', (err) => {
@@ -84,6 +101,59 @@ test.describe('A2A Debug Screen', () => {
       const hasBudgetAfter = await body.getByText(/max iterations/i).count();
       expect(hasBudgetAfter).toBe(0);
     }
+  });
+
+  test('task history loads retained tasks and refreshes from ListTasks', async ({ page }) => {
+    let listCalls = 0;
+
+    await page.route('**/proxy/', async (route) => {
+      if (route.request().method() === 'POST') {
+        let body: Record<string, unknown> = {};
+        try { body = route.request().postDataJSON(); } catch { /* ignore */ }
+        if (body?.jsonrpc === '2.0' && (body?.method === 'ListTasks' || body?.method === 'tasks/list')) {
+          listCalls += 1;
+          const task = listCalls === 1
+            ? mockTask('task_retained_pw_001', 'Retained task from backend')
+            : mockTask('task_retained_pw_002', 'Refreshed retained task');
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: { tasks: [task], count: 1 },
+            }),
+          });
+          return;
+        }
+        if (body?.jsonrpc === '2.0' && (body?.method === 'GetTask' || body?.method === 'tasks/get')) {
+          const params = body.params as Record<string, unknown> | undefined;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: mockTask(String(params?.id || 'task_retained_pw_001'), 'Retained task from backend'),
+            }),
+          });
+          return;
+        }
+      }
+      await route.continue();
+    });
+
+    if (!(await navigateToA2ATab(page))) {
+      test.skip(true, 'A2A tab not available');
+      return;
+    }
+
+    const historyEntry = page.locator('[data-testid="a2a-history-0"]');
+    await expect(historyEntry).toBeVisible({ timeout: 10000 });
+    await expect(historyEntry).toContainText('Retained task from backend');
+
+    await page.locator('[data-testid="a2a-refresh-tasks"]').click();
+    await expect(page.locator('[data-testid="a2a-history-0"]')).toContainText('Refreshed retained task', { timeout: 10000 });
   });
 
   test('send message → task appears in history → clicking history auto-switches to task tab', async ({ page }) => {

--- a/kaos-ui/tests/unit/components/agent/useA2ADebug.test.ts
+++ b/kaos-ui/tests/unit/components/agent/useA2ADebug.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useA2ADebug } from '@/components/agent/useA2ADebug';
+import type { A2ATask } from '@/types/a2a';
+import type { Agent } from '@/types/kubernetes';
+import {
+  getAgentCard,
+  sendA2AMessage,
+  getA2ATask,
+  cancelA2ATask,
+  listA2ATasks,
+} from '@/lib/k8s/a2a';
+
+vi.mock('@/lib/k8s/a2a', () => ({
+  getAgentCard: vi.fn(),
+  sendA2AMessage: vi.fn(),
+  getA2ATask: vi.fn(),
+  cancelA2ATask: vi.fn(),
+  listA2ATasks: vi.fn(),
+}));
+
+const mockedListA2ATasks = vi.mocked(listA2ATasks);
+const mockedSendA2AMessage = vi.mocked(sendA2AMessage);
+const mockedGetA2ATask = vi.mocked(getA2ATask);
+const mockedCancelA2ATask = vi.mocked(cancelA2ATask);
+const mockedGetAgentCard = vi.mocked(getAgentCard);
+
+const agent = {
+  metadata: {
+    name: 'demo',
+    namespace: 'kaos-system',
+  },
+} as Agent;
+
+function makeTask(id: string, text: string, timestamp: string, state: A2ATask['status']['state'] = 'completed'): A2ATask {
+  return {
+    id,
+    sessionId: `session-${id}`,
+    status: { state, timestamp },
+    history: [{ role: 'user', parts: [{ type: 'text', text }] }],
+    artifacts: [],
+    metadata: {},
+    events: [],
+    autonomous: false,
+    output: '',
+  };
+}
+
+describe('useA2ADebug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetAgentCard.mockResolvedValue({
+      name: 'demo',
+      description: '',
+      url: '',
+      version: '0.1.0',
+      protocolVersion: '0.3.0',
+      skills: [],
+      capabilities: {
+        streaming: true,
+        pushNotifications: false,
+        stateTransitionHistory: true,
+      },
+      supportedProtocols: ['jsonrpc'],
+      defaultInputModes: ['text'],
+      defaultOutputModes: ['text'],
+    });
+  });
+
+  it('refreshes retained tasks into newest-first history', async () => {
+    mockedListA2ATasks.mockResolvedValue({
+      tasks: [
+        makeTask('task-old', 'Older task', '2026-01-01T00:00:00Z'),
+        makeTask('task-new', 'Newer task', '2026-01-02T00:00:00Z'),
+      ],
+      count: 2,
+    });
+
+    const { result } = renderHook(() => useA2ADebug(agent));
+
+    await act(async () => {
+      await result.current.refreshTasks();
+    });
+
+    expect(mockedListA2ATasks).toHaveBeenCalledWith('agent-demo', 'kaos-system');
+    expect(result.current.taskHistory.map(entry => entry.taskId)).toEqual(['task-new', 'task-old']);
+    expect(result.current.taskHistory[0].message).toBe('Newer task');
+  });
+
+  it('dedupes refreshed tasks and keeps the newest backend state', async () => {
+    const submitted = makeTask('task-1', 'Work in progress', '2026-01-01T00:00:00Z', 'working');
+    const completed = makeTask('task-1', 'Work in progress', '2026-01-02T00:00:00Z', 'completed');
+    mockedListA2ATasks.mockResolvedValue({ tasks: [submitted], count: 1 });
+    mockedSendA2AMessage.mockResolvedValue(completed);
+
+    const { result } = renderHook(() => useA2ADebug(agent));
+
+    await act(async () => {
+      await result.current.refreshTasks();
+      await result.current.sendMessage({
+        message: { role: 'user', parts: [{ type: 'text', text: 'Work in progress' }] },
+      });
+    });
+
+    expect(result.current.taskHistory).toHaveLength(1);
+    expect(result.current.taskHistory[0].taskId).toBe('task-1');
+    expect(result.current.taskHistory[0].state).toBe('completed');
+  });
+
+  it('keeps manual task lookup working after list failures', async () => {
+    const task = makeTask('task-manual', 'Manual lookup', '2026-01-01T00:00:00Z');
+    mockedListA2ATasks.mockRejectedValue(new Error('List unavailable'));
+    mockedGetA2ATask.mockResolvedValue(task);
+
+    const { result } = renderHook(() => useA2ADebug(agent));
+
+    await act(async () => {
+      await result.current.refreshTasks();
+    });
+
+    expect(result.current.taskListError).toBe('List unavailable');
+
+    await act(async () => {
+      await result.current.fetchTask('task-manual');
+    });
+
+    expect(mockedGetA2ATask).toHaveBeenCalledWith('agent-demo', 'task-manual', 'kaos-system');
+    expect(result.current.currentTask?.id).toBe('task-manual');
+    expect(result.current.taskHistory[0].taskId).toBe('task-manual');
+  });
+
+  it('merges canceled task state into history', async () => {
+    const working = makeTask('task-cancel', 'Cancel me', '2026-01-01T00:00:00Z', 'working');
+    const canceled = makeTask('task-cancel', 'Cancel me', '2026-01-02T00:00:00Z', 'canceled');
+    mockedListA2ATasks.mockResolvedValue({ tasks: [working], count: 1 });
+    mockedCancelA2ATask.mockResolvedValue(canceled);
+
+    const { result } = renderHook(() => useA2ADebug(agent));
+
+    await act(async () => {
+      await result.current.refreshTasks();
+      await result.current.cancelTask('task-cancel');
+    });
+
+    expect(result.current.taskHistory).toHaveLength(1);
+    expect(result.current.taskHistory[0].state).toBe('canceled');
+  });
+});

--- a/kaos-ui/tests/unit/lib/a2a.test.ts
+++ b/kaos-ui/tests/unit/lib/a2a.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listA2ATasks } from '@/lib/k8s/a2a';
+import { k8sClient } from '@/lib/k8s/index';
+
+vi.mock('@/lib/k8s/index', () => ({
+  k8sClient: {
+    proxyServiceRequest: vi.fn(),
+  },
+}));
+
+const mockedProxyServiceRequest = vi.mocked(k8sClient.proxyServiceRequest);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('A2A K8s client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists retained tasks with ListTasks JSON-RPC', async () => {
+    mockedProxyServiceRequest.mockResolvedValue(jsonResponse({
+      jsonrpc: '2.0',
+      id: 'ui-1',
+      result: {
+        tasks: [
+          {
+            id: 'task-1',
+            sessionId: 'session-1',
+            status: { state: 'completed', timestamp: '2026-01-01T00:00:00Z' },
+            history: [],
+            artifacts: [],
+            metadata: {},
+            events: [],
+            autonomous: false,
+            output: '',
+          },
+        ],
+        count: 1,
+      },
+    }));
+
+    const result = await listA2ATasks('agent-demo', 'kaos-system');
+    const [serviceName, path, options, namespace, port] = mockedProxyServiceRequest.mock.calls[0];
+    const body = JSON.parse(String(options.body));
+
+    expect(result.count).toBe(1);
+    expect(result.tasks[0].id).toBe('task-1');
+    expect(serviceName).toBe('agent-demo');
+    expect(path).toBe('/');
+    expect(namespace).toBe('kaos-system');
+    expect(port).toBe(8000);
+    expect(body.method).toBe('ListTasks');
+    expect(body.params).toEqual({});
+  });
+
+  it('throws JSON-RPC list errors', async () => {
+    mockedProxyServiceRequest.mockResolvedValue(jsonResponse({
+      jsonrpc: '2.0',
+      id: 'ui-1',
+      error: { code: -32601, message: 'Method not found' },
+    }));
+
+    await expect(listA2ATasks('agent-demo', 'default')).rejects.toThrow('Method not found');
+  });
+});

--- a/pydantic-ai-server/pais/a2a.py
+++ b/pydantic-ai-server/pais/a2a.py
@@ -2,7 +2,7 @@
 
 Provides:
 - Task data model (TaskState, TaskStatus, TaskMessage, TaskEvent, Task, AutonomousConfig, TaskBudgets)
-- TaskManager ABC: send_message, get_task, cancel_task, shutdown
+- TaskManager ABC: send_message, list_tasks, get_task, cancel_task, shutdown
 - LocalTaskManager: in-process execution with internal dict storage and OTel
 - NullTaskManager: no-op implementation
 - JSON-RPC 2.0 models and error codes
@@ -263,6 +263,11 @@ class TaskManager(ABC):
         ...
 
     @abstractmethod
+    async def list_tasks(self) -> List[Task]:
+        """Return all retained tasks, newest first."""
+        ...
+
+    @abstractmethod
     async def cancel_task(self, task_id: str) -> bool:
         """Cancel a task. Returns True if cancellation was initiated."""
         ...
@@ -371,6 +376,13 @@ class LocalTaskManager(TaskManager):
 
     async def get_task(self, task_id: str) -> Optional[Task]:
         return self._tasks.get(task_id)
+
+    async def list_tasks(self) -> List[Task]:
+        return sorted(
+            list(self._tasks.values()),
+            key=lambda task: task.status.timestamp,
+            reverse=True,
+        )
 
     async def cancel_task(self, task_id: str) -> bool:
         tracer = trace_api.get_tracer(SERVICE_NAME)
@@ -769,6 +781,9 @@ class NullTaskManager(TaskManager):
     async def get_task(self, task_id: str) -> Optional[Task]:
         return None
 
+    async def list_tasks(self) -> List[Task]:
+        return []
+
     async def cancel_task(self, task_id: str) -> bool:
         return False
 
@@ -853,6 +868,8 @@ async def _handle_jsonrpc(request: Request, task_manager: TaskManager) -> JSONRe
         return await _jsonrpc_send_message(task_manager, params, rpc_id)
     elif method in ("GetTask", "tasks/get"):
         return await _jsonrpc_get_task(task_manager, params, rpc_id)
+    elif method in ("ListTasks", "tasks/list"):
+        return await _jsonrpc_list_tasks(task_manager, rpc_id)
     elif method in ("CancelTask", "tasks/cancel"):
         return await _jsonrpc_cancel_task(task_manager, params, rpc_id)
     else:
@@ -971,6 +988,16 @@ async def _jsonrpc_get_task(
         )
 
     return JSONResponse(JsonRpcResponse(id=rpc_id, result=task.to_dict()).to_dict())
+
+
+async def _jsonrpc_list_tasks(
+    task_manager: TaskManager,
+    rpc_id: Optional[Union[str, int]],
+) -> JSONResponse:
+    """Handle ListTasks: retrieve all retained task statuses."""
+    tasks = await task_manager.list_tasks()
+    result = {"tasks": [task.to_dict() for task in tasks], "count": len(tasks)}
+    return JSONResponse(JsonRpcResponse(id=rpc_id, result=result).to_dict())
 
 
 async def _jsonrpc_cancel_task(

--- a/pydantic-ai-server/tests/test_a2a_integration.py
+++ b/pydantic-ai-server/tests/test_a2a_integration.py
@@ -79,6 +79,28 @@ class TestA2AIntegrationLifecycle:
         assert len(set(r["id"] for r in results)) == 3  # unique task ids
 
     @pytest.mark.asyncio
+    async def test_list_tasks_returns_all_retained_tasks(self):
+        """Test ListTasks returns all tasks retained by the task manager."""
+        model = TestModel(custom_output_text="Listed result")
+        server = make_test_server(model=model, task_manager_type="local")
+        transport = ASGITransport(app=server.app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first_resp = await client.post("/", json=_send_message("First retained task", req_id=1))
+            second_resp = await client.post(
+                "/", json=_send_message("Second retained task", req_id=2)
+            )
+            list_resp = await client.post("/", json=_jsonrpc("ListTasks", req_id=3))
+
+        first_task = _get_result(first_resp)
+        second_task = _get_result(second_resp)
+        result = _get_result(list_resp)
+
+        assert result["count"] == 2
+        assert [task["id"] for task in result["tasks"]] == [second_task["id"], first_task["id"]]
+        assert {task["id"] for task in result["tasks"]} == {first_task["id"], second_task["id"]}
+
+    @pytest.mark.asyncio
     async def test_task_with_shared_session(self):
         """Test multiple tasks sharing a sessionId."""
         model = TestModel(custom_output_text="Session result")
@@ -216,6 +238,19 @@ class TestA2AIntegrationLifecycle:
 
         # NullTaskManager.send_message returns a stub task
         assert "result" in data
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_without_task_manager_returns_empty_list(self):
+        """Test ListTasks with NullTaskManager returns an empty task list."""
+        model = TestModel(custom_output_text="test")
+        server = make_test_server(model=model)
+        transport = ASGITransport(app=server.app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/", json=_jsonrpc("ListTasks"))
+            data = resp.json()
+
+        assert data["result"] == {"tasks": [], "count": 0}
 
 
 class TestA2AAutonomousMode:

--- a/pydantic-ai-server/tests/test_a2a_jsonrpc.py
+++ b/pydantic-ai-server/tests/test_a2a_jsonrpc.py
@@ -1,6 +1,6 @@
 """Tests for A2A JSON-RPC endpoint (POST /).
 
-Tests the JSON-RPC 2.0 dispatcher with tasks/send, tasks/get, tasks/cancel.
+Tests the JSON-RPC 2.0 dispatcher with tasks/send, tasks/list, tasks/get, tasks/cancel.
 """
 
 import pytest
@@ -185,6 +185,88 @@ class TestJsonRpcEndpoint:
         data = response.json()
         assert "error" in data
         assert data["error"]["code"] == -32001  # TASK_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_tasks_list_returns_retained_tasks_newest_first(self):
+        """Test ListTasks returns retained tasks sorted newest first."""
+        server = _make_server_with_task_manager()
+        transport = ASGITransport(app=server.app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first_resp = await client.post(
+                "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "SendMessage",
+                    "id": 1,
+                    "params": {
+                        "message": {
+                            "role": "user",
+                            "parts": [{"type": "text", "text": "First task"}],
+                        }
+                    },
+                },
+            )
+            second_resp = await client.post(
+                "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "SendMessage",
+                    "id": 2,
+                    "params": {
+                        "message": {
+                            "role": "user",
+                            "parts": [{"type": "text", "text": "Second task"}],
+                        }
+                    },
+                },
+            )
+            list_resp = await client.post(
+                "/",
+                json={"jsonrpc": "2.0", "method": "ListTasks", "id": 3},
+            )
+
+        first_task = first_resp.json()["result"]
+        second_task = second_resp.json()["result"]
+        data = list_resp.json()
+        assert data["jsonrpc"] == "2.0"
+        assert data["id"] == 3
+        assert data["result"]["count"] == 2
+        assert [task["id"] for task in data["result"]["tasks"]] == [
+            second_task["id"],
+            first_task["id"],
+        ]
+        assert data["result"]["tasks"][0]["history"][0]["parts"][0]["text"] == "Second task"
+
+    @pytest.mark.asyncio
+    async def test_tasks_list_legacy_alias(self):
+        """Test tasks/list returns retained tasks using the legacy alias."""
+        server = _make_server_with_task_manager()
+        transport = ASGITransport(app=server.app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post(
+                "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "tasks/send",
+                    "id": 1,
+                    "params": {
+                        "message": {
+                            "role": "user",
+                            "parts": [{"type": "text", "text": "Alias task"}],
+                        }
+                    },
+                },
+            )
+            response = await client.post(
+                "/",
+                json={"jsonrpc": "2.0", "method": "tasks/list", "id": 2},
+            )
+
+        data = response.json()
+        assert data["result"]["count"] == 1
+        assert data["result"]["tasks"][0]["status"]["state"] == "completed"
 
     @pytest.mark.asyncio
     async def test_tasks_get_missing_id(self):


### PR DESCRIPTION
## Summary

- add A2A ListTasks/tasks/list support to pydantic-ai-server
- hydrate KAOS UI A2A debug task history from retained backend tasks
- add staged planned-implementation skill and local E2E configuration support
 
## Validation

- python A2A tests + lint
- UI unit/lint/build
- local Playwright A2A functional test against KIND KAOS cluster