### PR TITLE
fix(modelapi): use official latest ollama image

### DIFF
--- a/.github/workflows/kaos-ui-tests.yaml
+++ b/.github/workflows/kaos-ui-tests.yaml
@@ -227,7 +227,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Pull Ollama image
-        run: docker pull alpine/ollama:0.22.1
+        run: docker pull ollama/ollama:latest
 
       - name: Tag MCP server image
         run: |
@@ -250,7 +250,7 @@ jobs:
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-server:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-python-string:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ghcr.io/berriai/litellm:main-stable --name ${{ env.KIND_CLUSTER_NAME }} &
-          kind load docker-image alpine/ollama:0.22.1 --name ${{ env.KIND_CLUSTER_NAME }} &
+          kind load docker-image ollama/ollama:latest --name ${{ env.KIND_CLUSTER_NAME }} &
           wait
 
       - name: Install KAOS operator

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -161,7 +161,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Pull Ollama image
-        run: docker pull alpine/ollama:0.22.1
+        run: docker pull ollama/ollama:latest
 
       - name: Pull Redis image
         run: docker pull redis:7-alpine
@@ -211,7 +211,7 @@ jobs:
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-pctx-codemode:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-fastmcp-codemode:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ghcr.io/berriai/litellm:main-stable --name ${{ env.KIND_CLUSTER_NAME }} &
-          kind load docker-image alpine/ollama:0.22.1 --name ${{ env.KIND_CLUSTER_NAME }} &
+          kind load docker-image ollama/ollama:latest --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image redis:7-alpine --name ${{ env.KIND_CLUSTER_NAME }} &
           wait
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -47,7 +47,7 @@ Key configurable values in `chart/values.yaml`:
 | `defaultImages.agentRuntime` | Default agent container image | `axsauze/kaos-agent:latest` |
 | `defaultImages.mcpServer` | Default MCP server image | `axsauze/kaos-agent:latest` |
 | `defaultImages.litellm` | Default LiteLLM proxy image | `ghcr.io/berriai/litellm:main-latest` |
-| `defaultImages.ollama` | Default Ollama image | `alpine/ollama:0.22.1` |
+| `defaultImages.ollama` | Default Ollama image | `ollama/ollama:latest` |
 | `gateway.defaultTimeouts.agent` | Default timeout for Agent HTTPRoutes | `120s` |
 | `gateway.defaultTimeouts.modelAPI` | Default timeout for ModelAPI HTTPRoutes | `120s` |
 | `gateway.defaultTimeouts.mcp` | Default timeout for MCPServer HTTPRoutes | `30s` |

--- a/docs/operator/modelapi-crd.md
+++ b/docs/operator/modelapi-crd.md
@@ -223,7 +223,7 @@ spec:
 
 Runs Ollama in-cluster with the specified model.
 
-**Container:** `alpine/ollama:0.22.1`
+**Container:** `ollama/ollama:latest`
 **Port:** 11434
 
 ```yaml

--- a/docs/reference/docker-images.md
+++ b/docs/reference/docker-images.md
@@ -37,7 +37,7 @@ defaultImages:
   agentRuntime: "axsauze/kaos-agent:latest"
   mcpServer: "axsauze/kaos-agent:latest"
   litellm: "ghcr.io/berriai/litellm:main-latest"
-  ollama: "alpine/ollama:0.22.1"
+  ollama: "ollama/ollama:latest"
 ```
 
 ## Overriding Images
@@ -130,6 +130,6 @@ KAOS uses these third-party images:
 | Image | Used By | Purpose |
 |-------|---------|---------|
 | `ghcr.io/berriai/litellm:main-latest` | ModelAPI (Proxy mode) | LLM API proxy |
-| `alpine/ollama:0.22.1` | ModelAPI (Hosted mode) | In-cluster Ollama |
+| `ollama/ollama:latest` | ModelAPI (Hosted mode) | In-cluster Ollama |
 
 These can be overridden in the Helm chart values.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -94,7 +94,7 @@ VERSION := $(shell cat $(shell pwd)/../VERSION 2>/dev/null || echo "dev")
 OPERATOR_TAG ?= $(VERSION)
 AGENT_TAG ?= $(VERSION)
 LITELLM_IMAGE ?= ghcr.io/berriai/litellm:main-stable
-OLLAMA_IMAGE ?= alpine/ollama:0.22.1
+OLLAMA_IMAGE ?= ollama/ollama:latest
 
 # Create KIND cluster with registry
 kind-create:

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -38,7 +38,7 @@ defaultImages:
   mcpKubernetes: quay.io/containers/kubernetes_mcp_server:latest
   mcpSlack: zencoderai/slack-mcp:latest
   litellm: ghcr.io/berriai/litellm:main-stable
-  ollama: alpine/ollama:0.22.1
+  ollama: ollama/ollama:latest
 
 # MCP Runtime registry configuration
 mcpRuntimes:

--- a/operator/controllers/integration/modelapi_test.go
+++ b/operator/controllers/integration/modelapi_test.go
@@ -268,7 +268,7 @@ var _ = Describe("ModelAPI Controller", func() {
 
 		// Verify main container uses ollama
 		container := deployment.Spec.Template.Spec.Containers[0]
-		Expect(container.Image).To(Equal("alpine/ollama:0.22.1"))
+		Expect(container.Image).To(Equal("ollama/ollama:latest"))
 		Expect(container.Command).To(Equal([]string{"ollama"}))
 		Expect(container.Args).To(Equal([]string{"serve"}))
 

--- a/operator/controllers/integration/suite_test.go
+++ b/operator/controllers/integration/suite_test.go
@@ -102,7 +102,7 @@ runtimes:
 	os.Setenv("DEFAULT_AGENT_IMAGE", "axsauze/kaos-agent:test")
 	os.Setenv("DEFAULT_MCP_SERVER_IMAGE", "axsauze/kaos-mcp-server:test")
 	os.Setenv("DEFAULT_LITELLM_IMAGE", "ghcr.io/berriai/litellm:test")
-	os.Setenv("DEFAULT_OLLAMA_IMAGE", "alpine/ollama:0.22.1")
+	os.Setenv("DEFAULT_OLLAMA_IMAGE", "ollama/ollama:latest")
 
 	// Start controller manager with all controllers
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{

--- a/operator/hack/build-push-images.sh
+++ b/operator/hack/build-push-images.sh
@@ -10,7 +10,7 @@
 #   OPERATOR_TAG - Tag for operator image (default: from VERSION file)
 #   AGENT_TAG - Tag for agent image (default: from VERSION file)
 #   LITELLM_IMAGE - Full LiteLLM image tag (default: ghcr.io/berriai/litellm:main-stable)
-#   OLLAMA_IMAGE - Full Ollama image (default: alpine/ollama:0.22.1)
+#   OLLAMA_IMAGE - Full Ollama image (default: ollama/ollama:latest)
 #
 # Note: LiteLLM is built from our minimal Dockerfile (~200MB) and tagged to override
 # the upstream image (1.5GB). This keeps the same image reference in values.yaml.
@@ -34,7 +34,7 @@ KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kaos-e2e}"
 OPERATOR_TAG="${OPERATOR_TAG:-${DEFAULT_VERSION}}"
 AGENT_TAG="${AGENT_TAG:-${DEFAULT_VERSION}}"
 LITELLM_IMAGE="${LITELLM_IMAGE:-ghcr.io/berriai/litellm:main-stable}"
-OLLAMA_IMAGE="${OLLAMA_IMAGE:-alpine/ollama:0.22.1}"
+OLLAMA_IMAGE="${OLLAMA_IMAGE:-ollama/ollama:latest}"
 
 echo "Building images..."
 echo "  REGISTRY: ${REGISTRY}"


### PR DESCRIPTION
## Summary
- Restore Hosted ModelAPI defaults and CI preloads to a latest-tagged Ollama image by switching from `alpine/ollama:0.22.1` to `ollama/ollama:latest`.
- Keep the explicit `ollama serve` controller behavior from the prior fix.
- Update integration expectations and docs to match the official image.

Closes #224

## Validation
- `docker image inspect ollama/ollama:latest` confirmed `/usr/lib/ollama/llama-server` is present.
- `go test ./controllers/integration -run TestControllers -v`
- `OPERATOR_MANAGED_EXTERNALLY=1 GATEWAY_URL=http://localhost:8888 python -m pytest e2e/test_modelapi_e2e.py::test_modelapi_proxy_with_hosted_backend -v -s`
- `OPERATOR_MANAGED_EXTERNALLY=1 GATEWAY_URL=http://localhost:8888 python -m pytest e2e/test_base_func_e2e.py::test_agent_health_discovery_and_invocation -v -s`