### PR TITLE
ci(e2e): load large external images sequentially

### DIFF
--- a/.github/workflows/kaos-ui-tests.yaml
+++ b/.github/workflows/kaos-ui-tests.yaml
@@ -226,6 +226,13 @@ jobs:
           cache-to: type=gha,scope=litellm-ui-e2e,mode=max
           github-token: ${{ github.token }}
 
+      - name: Free runner disk for E2E images
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost
+          docker builder prune -af || true
+          df -h
+
       - name: Pull Ollama image
         run: docker pull ollama/ollama:latest
 
@@ -249,9 +256,9 @@ jobs:
           kind load docker-image ${{ env.REGISTRY }}/kaos-agent:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-server:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-python-string:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
-          kind load docker-image ghcr.io/berriai/litellm:main-stable --name ${{ env.KIND_CLUSTER_NAME }} &
-          kind load docker-image ollama/ollama:latest --name ${{ env.KIND_CLUSTER_NAME }} &
           wait
+          kind load docker-image ghcr.io/berriai/litellm:main-stable --name ${{ env.KIND_CLUSTER_NAME }}
+          kind load docker-image ollama/ollama:latest --name ${{ env.KIND_CLUSTER_NAME }}
 
       - name: Install KAOS operator
         run: make -C operator kind-e2e-install-kaos IMAGE_TAG=${{ env.OPERATOR_TAG }} REGISTRY=${{ env.REGISTRY }}

--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -160,6 +160,13 @@ jobs:
           cache-to: type=gha,scope=litellm-e2e,mode=max
           github-token: ${{ github.token }}
 
+      - name: Free runner disk for E2E images
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost
+          docker builder prune -af || true
+          df -h
+
       - name: Pull Ollama image
         run: docker pull ollama/ollama:latest
 
@@ -203,17 +210,18 @@ jobs:
 
       - name: Load images into KIND
         run: |
-          # Load images in parallel for faster execution
+          # Load KAOS images in parallel, then load larger external images
+          # sequentially to avoid multiple temporary docker-save tarballs.
           kind load docker-image ${{ env.REGISTRY }}/kaos-operator:${{ env.OPERATOR_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-agent:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-server:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-python-string:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-pctx-codemode:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
           kind load docker-image ${{ env.REGISTRY }}/kaos-mcp-fastmcp-codemode:${{ env.AGENT_TAG }} --name ${{ env.KIND_CLUSTER_NAME }} &
-          kind load docker-image ghcr.io/berriai/litellm:main-stable --name ${{ env.KIND_CLUSTER_NAME }} &
-          kind load docker-image ollama/ollama:latest --name ${{ env.KIND_CLUSTER_NAME }} &
-          kind load docker-image redis:7-alpine --name ${{ env.KIND_CLUSTER_NAME }} &
           wait
+          kind load docker-image ghcr.io/berriai/litellm:main-stable --name ${{ env.KIND_CLUSTER_NAME }}
+          kind load docker-image ollama/ollama:latest --name ${{ env.KIND_CLUSTER_NAME }}
+          kind load docker-image redis:7-alpine --name ${{ env.KIND_CLUSTER_NAME }}
 
 
       - name: Install KAOS operator


### PR DESCRIPTION
## Summary
- Free unused runner disk before pulling the large official Ollama image for E2E.
- Load KAOS images in parallel, then load large external images sequentially to avoid concurrent `docker save` tarballs exhausting disk.
- Apply the same pattern to KAOS UI E2E/visual workflow image loading.

## Context
Release `v0.4.7` run 27665760941 failed in `tests / E2E (core)` because `kind load docker-image ollama/ollama:latest` failed during `docker save`, and the Hosted ModelAPI pod then hit `ImagePullBackOff` with `no space left on device`.

## Validation
- `git diff --check`
- PR CI will validate the E2E runner-space fix before retrying the release.