### PR TITLE
PR-ADR-KAOS-1: feat(aib): two-identity propagation SDK and runtime wiring

### DIFF
--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -153,3 +153,9 @@ For infrastructure changes:
 - [ ] Test with different `DOCS_VERSION` and `DOCS_BASE` values
 - [ ] Verify version dropdown shows correct items
 - [ ] Check that `redirect-index.html` still works
+
+## Markdown authoring style
+
+- **No hard line wraps inside paragraphs or list items.** Write each paragraph and each list item as a single continuous line; let the renderer/editor soft-wrap. Do not insert manual newlines mid-sentence to keep a fixed column width — these break flow and produce noisy diffs.
+- Use blank lines to separate paragraphs, list blocks, headings, tables, and code fences.
+- ADRs and other long-form docs follow the same rule: prose flows as single-line paragraphs.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -37,7 +37,7 @@ make format                     # Auto-format code
 The `aib` SDK propagates two identities across agent hops (ADR-KAOS-003): the user **subject** (`Authorization` bearer + `x-principal`), forwarded unchanged, and the calling agent **actor** (`x-agent-authorization` bearer + `x-actor`), set to *this* agent on every outbound hop so each agent authenticates as itself. The SDK only propagates — it is not the enforcement boundary (the gateway enforces, later phases).
 
 - `AgentServer.__init__` calls `aib.instrument_fastapi(self.app, actor=...)` (extracts inbound context, generates `x-request-id` when absent) and `aib.instrument_httpx()` (injects context onto outbound calls). A single httpx patch covers A2A, MCP, and ModelAPI because all use httpx; injection is at request time, so clients built at startup still propagate, and it is **strictly additive** — an existing header (e.g. the ModelAPI API-key `Authorization`) is never overwritten.
-- The local actor defaults to `kaos://agent/{agent_name}`; override via `AIB_ACTOR`/`aib_actor` (and `AIB_ACTOR_TOKEN`, `AIB_PRINCIPAL`). Tokens are dummy/static at this stage — real minting + the machine-token lifecycle land in a later phase.
+- The local actor defaults to `kaos://agent/{agent_name}`; override via the `actor` kwarg or the provider-agnostic `AGENT_AUTH_IDENTITY` env var (and `AGENT_AUTH_TOKEN`, `AGENT_AUTH_PRINCIPAL`). Tokens are dummy/static at this stage — real minting + the machine-token lifecycle land in a later phase.
 - `AgentDeps.security_context` carries the non-secret context (request_id/session_id/principal/actor/scopes) for tools; raw bearer tokens are never placed on `AgentDeps` or persisted to memory.
 
 ## Key Environment Variables

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -22,6 +22,7 @@ make format                     # Auto-format code
 - `pais/tools.py`: DelegationToolset (AbstractToolset), execute_delegation, format_progress_event, build_string_mode_handler
 - `pais/memory.py`: Memory ABC, LocalMemory, RedisMemory, NullMemory + build_message_history/store_pydantic_message utilities
 - `pais/telemetry.py`: OpenTelemetry instrumentation (tracing, metrics, SERVICE_NAME)
+- `aib/`: AIB propagation SDK (temporary home; upstreams to the AIB project later). `aib/instrument.py` holds the request-local security context and the FastAPI/httpx instrumentation; `import aib` is the public surface.
 - `pyproject.toml`: Dependencies — `pydantic-ai`, `opentelemetry-*`
 
 **Module layout rationale:**
@@ -30,6 +31,14 @@ make format                     # Auto-format code
 - `a2a.py` owns A2A protocol: TaskManager ABC + LocalTaskManager/NullTaskManager, Task data model, JSON-RPC models/dispatcher/handlers, route setup
 - `tools.py` owns tool extensions: DelegationToolset (AbstractToolset subclass), string-mode model handler, progress event formatting
 - `memory.py` owns persistence: Memory ABC + all backends, plus build_message_history/store_pydantic_message utilities on the base class
+
+### AIB identity propagation (`aib`)
+
+The `aib` SDK propagates two identities across agent hops (ADR-KAOS-003): the user **subject** (`Authorization` bearer + `x-principal`), forwarded unchanged, and the calling agent **actor** (`x-agent-authorization` bearer + `x-actor`), set to *this* agent on every outbound hop so each agent authenticates as itself. The SDK only propagates — it is not the enforcement boundary (the gateway enforces, later phases).
+
+- `AgentServer.__init__` calls `aib.instrument_fastapi(self.app, actor=...)` (extracts inbound context, generates `x-request-id` when absent) and `aib.instrument_httpx()` (injects context onto outbound calls). A single httpx patch covers A2A, MCP, and ModelAPI because all use httpx; injection is at request time, so clients built at startup still propagate, and it is **strictly additive** — an existing header (e.g. the ModelAPI API-key `Authorization`) is never overwritten.
+- The local actor defaults to `kaos://agent/{agent_name}`; override via `AIB_ACTOR`/`aib_actor` (and `AIB_ACTOR_TOKEN`, `AIB_PRINCIPAL`). Tokens are dummy/static at this stage — real minting + the machine-token lifecycle land in a later phase.
+- `AgentDeps.security_context` carries the non-secret context (request_id/session_id/principal/actor/scopes) for tools; raw bearer tokens are never placed on `AgentDeps` or persisted to memory.
 
 ## Key Environment Variables
 | Variable | Description |

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run type checking
         working-directory: pydantic-ai-server
-        run: uvx ty check
+        run: uvx ty@0.0.55 check
 
   python-tests:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ ROADMAP.md
 tmp/
 REPORT*
 PLAN*
+
+# Nested clone of the Agentic Identity Broker (separate repo; not part of KAOS)
+agentic-identity-broker/

--- a/pydantic-ai-server/Dockerfile
+++ b/pydantic-ai-server/Dockerfile
@@ -17,6 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Copy source code (changes frequently, so copied last)
 COPY pais/ pais/
+COPY aib/ aib/
 
 # Install package (no deps - already installed above) for importlib.metadata
 RUN uv pip install --system --no-deps .

--- a/pydantic-ai-server/aib/__init__.py
+++ b/pydantic-ai-server/aib/__init__.py
@@ -29,6 +29,7 @@ from .instrument import (
     ctx,
     current,
     instrument_fastapi,
+    instrument_httpx,
     to_headers,
 )
 
@@ -37,6 +38,7 @@ __all__ = [
     "current",
     "to_headers",
     "instrument_fastapi",
+    "instrument_httpx",
     "HEADER_REQUEST_ID",
     "HEADER_SESSION_ID",
     "HEADER_PRINCIPAL",

--- a/pydantic-ai-server/aib/__init__.py
+++ b/pydantic-ai-server/aib/__init__.py
@@ -28,6 +28,7 @@ from .instrument import (
     HEADER_SUBJECT_TOKEN,
     ctx,
     current,
+    instrument_fastapi,
     to_headers,
 )
 
@@ -35,6 +36,7 @@ __all__ = [
     "ctx",
     "current",
     "to_headers",
+    "instrument_fastapi",
     "HEADER_REQUEST_ID",
     "HEADER_SESSION_ID",
     "HEADER_PRINCIPAL",

--- a/pydantic-ai-server/aib/__init__.py
+++ b/pydantic-ai-server/aib/__init__.py
@@ -1,8 +1,8 @@
 """AIB propagation SDK (KAOS temporary home).
 
-Two-identity request-context propagation for agentic runtimes — the propagation slice of
-ADR-AIB-001 / ADR-KAOS-003. Instrument once and the user subject + agent actor identities
-flow across A2A, MCP, and ModelAPI calls automatically.
+Two-identity request-context propagation for agentic runtimes. Instrument once and the
+user subject + agent actor identities flow across A2A, MCP, and ModelAPI calls
+automatically.
 
 Public API::
 

--- a/pydantic-ai-server/aib/__init__.py
+++ b/pydantic-ai-server/aib/__init__.py
@@ -30,12 +30,14 @@ from .instrument import (
     current,
     instrument_fastapi,
     instrument_httpx,
+    security_context,
     to_headers,
 )
 
 __all__ = [
     "ctx",
     "current",
+    "security_context",
     "to_headers",
     "instrument_fastapi",
     "instrument_httpx",

--- a/pydantic-ai-server/aib/__init__.py
+++ b/pydantic-ai-server/aib/__init__.py
@@ -1,0 +1,45 @@
+"""AIB propagation SDK (KAOS temporary home).
+
+Two-identity request-context propagation for agentic runtimes — the propagation slice of
+ADR-AIB-001 / ADR-KAOS-003. Instrument once and the user subject + agent actor identities
+flow across A2A, MCP, and ModelAPI calls automatically.
+
+Public API::
+
+    import aib
+
+    aib.ctx                      # request-local context (ContextVar-backed, dict-like)
+    aib.instrument_fastapi(app)  # extract trusted inbound context at the server boundary
+    aib.instrument_httpx()       # inject subject + actor on outbound httpx calls
+    aib.ctx.to_headers()         # manual escape hatch for non-instrumented transports
+
+The SDK is *not* the enforcement boundary; it only propagates.
+"""
+
+from __future__ import annotations
+
+from .instrument import (
+    HEADER_ACTOR,
+    HEADER_ACTOR_TOKEN,
+    HEADER_PRINCIPAL,
+    HEADER_REQUEST_ID,
+    HEADER_SCOPES,
+    HEADER_SESSION_ID,
+    HEADER_SUBJECT_TOKEN,
+    ctx,
+    current,
+    to_headers,
+)
+
+__all__ = [
+    "ctx",
+    "current",
+    "to_headers",
+    "HEADER_REQUEST_ID",
+    "HEADER_SESSION_ID",
+    "HEADER_PRINCIPAL",
+    "HEADER_ACTOR",
+    "HEADER_SCOPES",
+    "HEADER_SUBJECT_TOKEN",
+    "HEADER_ACTOR_TOKEN",
+]

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -273,17 +273,18 @@ def instrument_fastapi(
     """Instrument a FastAPI/Starlette app to populate :data:`ctx` per request.
 
     Local runtime identity (``actor``/``actor_token``/``principal``) falls back to the
-    ``AIB_ACTOR`` / ``AIB_ACTOR_TOKEN`` / ``AIB_PRINCIPAL`` environment variables. The
+    ``AGENT_AUTH_IDENTITY`` / ``AGENT_AUTH_TOKEN`` / ``AGENT_AUTH_PRINCIPAL`` environment
+    variables (provider-agnostic; populated by the operator from the configured broker). The
     user principal is normally taken from the inbound ``x-principal`` header or the
     ``principal_resolver``; the fixed ``principal`` is only a fallback for processes with
     a constant trusted principal.
     """
     app.add_middleware(
         _PropagationMiddleware,
-        actor=actor or os.environ.get("AIB_ACTOR"),
-        actor_token=actor_token or os.environ.get("AIB_ACTOR_TOKEN"),
+        actor=actor or os.environ.get("AGENT_AUTH_IDENTITY"),
+        actor_token=actor_token or os.environ.get("AGENT_AUTH_TOKEN"),
         principal_resolver=principal_resolver,
-        default_principal=principal or os.environ.get("AIB_PRINCIPAL"),
+        default_principal=principal or os.environ.get("AGENT_AUTH_PRINCIPAL"),
     )
     return app
 

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -271,3 +271,53 @@ def instrument_fastapi(
         default_principal=os.environ.get("AIB_PRINCIPAL"),
     )
     return app
+
+
+# --- Outbound injection instrumentation ---------------------------------------------
+
+_httpx_patched = False
+
+
+def _inject_request_headers(request: Any) -> None:
+    """Merge the current context's propagation headers into an outbound request.
+
+    Strictly **additive**: a header already present on the request (for example the
+    ModelAPI/LLM provider's own ``Authorization`` API key) is never overwritten.
+    """
+    for header, value in ctx.to_headers().items():
+        if header not in request.headers:
+            request.headers[header] = value
+
+
+def instrument_httpx() -> None:
+    """Patch ``httpx`` so outbound requests carry the propagation headers.
+
+    Both ``httpx.Client`` and ``httpx.AsyncClient`` route ``get``/``post``/``request``
+    through ``send``, so patching ``send`` covers every transport — A2A, MCP, and
+    ModelAPI clients alike — and injection happens at request time, so clients built once
+    at startup still propagate per-request context. Idempotent.
+
+    Injection is additive and reads from :data:`ctx`; in internet-facing deployments,
+    callers are responsible for not placing sensitive tokens in :data:`ctx` for requests
+    bound to untrusted destinations.
+    """
+    global _httpx_patched
+    if _httpx_patched:
+        return
+
+    import httpx
+
+    sync_send = httpx.Client.send
+    async_send = httpx.AsyncClient.send
+
+    def _patched_sync_send(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+        _inject_request_headers(request)
+        return sync_send(self, request, *args, **kwargs)
+
+    async def _patched_async_send(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+        _inject_request_headers(request)
+        return await async_send(self, request, *args, **kwargs)
+
+    httpx.Client.send = _patched_sync_send  # type: ignore[method-assign]
+    httpx.AsyncClient.send = _patched_async_send  # type: ignore[method-assign]
+    _httpx_patched = True

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -121,6 +121,20 @@ def current() -> Dict[str, Any]:
     return dict(_ctx_var.get())
 
 
+#: Context fields safe to expose to application code / persist (no raw bearer tokens).
+_NON_SECRET_FIELDS = ("request_id", "session_id", "principal", "actor", "scopes")
+
+
+def security_context() -> Dict[str, Any]:
+    """Return the non-secret subset of the current context.
+
+    Excludes raw bearer tokens (``subject_token``/``actor_token``) so the result is safe
+    to expose to tools or persist for audit/correlation (ADR-KAOS-003).
+    """
+    data = _ctx_var.get()
+    return {key: data[key] for key in _NON_SECRET_FIELDS if data.get(key)}
+
+
 def to_headers() -> Dict[str, str]:
     """Module-level convenience for :meth:`ctx.to_headers`."""
     return ctx.to_headers()
@@ -254,21 +268,23 @@ def instrument_fastapi(
     *,
     actor: Optional[str] = None,
     actor_token: Optional[str] = None,
+    principal: Optional[str] = None,
     principal_resolver: Optional[PrincipalResolver] = None,
 ) -> Any:
     """Instrument a FastAPI/Starlette app to populate :data:`ctx` per request.
 
-    Local runtime identity (``actor``/``actor_token``) falls back to the ``AIB_ACTOR`` /
-    ``AIB_ACTOR_TOKEN`` environment variables; an optional fixed principal falls back to
-    ``AIB_PRINCIPAL``. The user principal otherwise comes from the inbound ``x-principal``
-    header or the ``principal_resolver``.
+    Local runtime identity (``actor``/``actor_token``/``principal``) falls back to the
+    ``AIB_ACTOR`` / ``AIB_ACTOR_TOKEN`` / ``AIB_PRINCIPAL`` environment variables. The
+    user principal is normally taken from the inbound ``x-principal`` header or the
+    ``principal_resolver``; the fixed ``principal`` is only a fallback for processes with
+    a constant trusted principal.
     """
     app.add_middleware(
         _PropagationMiddleware,
         actor=actor or os.environ.get("AIB_ACTOR"),
         actor_token=actor_token or os.environ.get("AIB_ACTOR_TOKEN"),
         principal_resolver=principal_resolver,
-        default_principal=os.environ.get("AIB_PRINCIPAL"),
+        default_principal=principal or os.environ.get("AIB_PRINCIPAL"),
     )
     return app
 

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -16,7 +16,9 @@ a header serializer (:meth:`_Context.to_headers`), and the inbound/outbound inst
 from __future__ import annotations
 
 import contextvars
-from typing import Any, Dict, Iterator, MutableMapping, Optional
+import os
+import uuid
+from typing import Any, Callable, Dict, Iterator, MutableMapping, Optional
 
 # --- Header model (ADR-AIB-001) -----------------------------------------------------
 # Generic headers for concepts not owned by AIB; ``x-aib-*`` reserved for AIB-owned context.
@@ -145,3 +147,127 @@ def _build_context(
         "scopes": scopes,
     }
     return {key: value for key, value in fields.items() if value}
+
+
+# --- Inbound boundary instrumentation -----------------------------------------------
+
+# Inbound header an upstream/UI uses to carry the session when AIB's own is absent.
+_LEGACY_SESSION_HEADER = "x-session-id"
+
+# Resolver derives the verified user principal from inbound headers (e.g. gateway-set).
+PrincipalResolver = Callable[[Dict[str, str]], Optional[str]]
+
+
+def _strip_bearer(value: Optional[str]) -> Optional[str]:
+    """Return the raw token from an ``Authorization: Bearer <token>`` value."""
+    if value and value.lower().startswith("bearer "):
+        return value[7:]
+    return value
+
+
+def _scope_headers(scope: Dict[str, Any]) -> Dict[str, str]:
+    """Lower-cased header map from an ASGI scope (last value wins)."""
+    headers: Dict[str, str] = {}
+    for raw_key, raw_value in scope.get("headers", []):
+        headers[raw_key.decode("latin-1").lower()] = raw_value.decode("latin-1")
+    return headers
+
+
+def _extract_inbound(
+    headers: Dict[str, str],
+    *,
+    actor: Optional[str],
+    actor_token: Optional[str],
+    principal_resolver: Optional[PrincipalResolver],
+    default_principal: Optional[str],
+) -> Dict[str, Any]:
+    """Build the request context from trusted inbound headers + local defaults.
+
+    The user **subject** (principal + token) is taken from the inbound request and
+    propagated unchanged. The **actor** (this agent's own identity/token) is always the
+    *local* value, never the inbound caller's actor — so each hop authenticates as
+    itself. A ``request_id`` is generated when the caller does not supply one.
+    """
+    request_id = headers.get(HEADER_REQUEST_ID) or f"req-{uuid.uuid4().hex[:16]}"
+    session_id = headers.get(HEADER_SESSION_ID) or headers.get(_LEGACY_SESSION_HEADER)
+
+    principal = headers.get(HEADER_PRINCIPAL)
+    if not principal and principal_resolver is not None:
+        principal = principal_resolver(headers)
+    if not principal:
+        principal = default_principal
+
+    return _build_context(
+        request_id=request_id,
+        session_id=session_id,
+        principal=principal,
+        subject_token=_strip_bearer(headers.get(HEADER_SUBJECT_TOKEN)),
+        scopes=headers.get(HEADER_SCOPES),
+        actor=actor,
+        actor_token=actor_token,
+    )
+
+
+class _PropagationMiddleware:
+    """Pure ASGI middleware that initializes :data:`ctx` per request.
+
+    A pure ASGI middleware (rather than ``BaseHTTPMiddleware``) runs the downstream app
+    in the *same* task, so the ``ContextVar`` set here is visible to the endpoint and to
+    every outbound call it makes.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        actor: Optional[str],
+        actor_token: Optional[str],
+        principal_resolver: Optional[PrincipalResolver],
+        default_principal: Optional[str],
+    ) -> None:
+        self.app = app
+        self._actor = actor
+        self._actor_token = actor_token
+        self._principal_resolver = principal_resolver
+        self._default_principal = default_principal
+
+    async def __call__(self, scope: Dict[str, Any], receive: Any, send: Any) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        context = _extract_inbound(
+            _scope_headers(scope),
+            actor=self._actor,
+            actor_token=self._actor_token,
+            principal_resolver=self._principal_resolver,
+            default_principal=self._default_principal,
+        )
+        token = ctx.replace(context)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            ctx.reset(token)
+
+
+def instrument_fastapi(
+    app: Any,
+    *,
+    actor: Optional[str] = None,
+    actor_token: Optional[str] = None,
+    principal_resolver: Optional[PrincipalResolver] = None,
+) -> Any:
+    """Instrument a FastAPI/Starlette app to populate :data:`ctx` per request.
+
+    Local runtime identity (``actor``/``actor_token``) falls back to the ``AIB_ACTOR`` /
+    ``AIB_ACTOR_TOKEN`` environment variables; an optional fixed principal falls back to
+    ``AIB_PRINCIPAL``. The user principal otherwise comes from the inbound ``x-principal``
+    header or the ``principal_resolver``.
+    """
+    app.add_middleware(
+        _PropagationMiddleware,
+        actor=actor or os.environ.get("AIB_ACTOR"),
+        actor_token=actor_token or os.environ.get("AIB_ACTOR_TOKEN"),
+        principal_resolver=principal_resolver,
+        default_principal=os.environ.get("AIB_PRINCIPAL"),
+    )
+    return app

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -334,6 +334,6 @@ def instrument_httpx() -> None:
         _inject_request_headers(request)
         return await async_send(self, request, *args, **kwargs)
 
-    httpx.Client.send = _patched_sync_send  # ty: ignore[invalid-assignment]
-    httpx.AsyncClient.send = _patched_async_send  # ty: ignore[invalid-assignment]
+    httpx.Client.send = _patched_sync_send
+    httpx.AsyncClient.send = _patched_async_send
     _httpx_patched = True

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -1,7 +1,6 @@
 """AIB propagation SDK — request-local security context and header propagation.
 
-This module is the propagation slice of the AIB Python SDK (ADR-AIB-001 /
-ADR-KAOS-003). It carries two identities across agent hops:
+This module carries two identities across agent hops:
 
 * the user **subject** (principal + ``Authorization`` bearer), propagated unchanged, and
 * the calling agent **actor** (the local agent's own identity + ``x-agent-authorization``
@@ -20,7 +19,7 @@ import os
 import uuid
 from typing import Any, Callable, Dict, Iterator, MutableMapping, Optional
 
-# --- Header model (ADR-AIB-001) -----------------------------------------------------
+# --- Header model -----------------------------------------------------
 # Generic headers for concepts not owned by AIB; ``x-aib-*`` reserved for AIB-owned context.
 HEADER_REQUEST_ID = "x-request-id"
 HEADER_SESSION_ID = "x-aib-session-id"
@@ -129,7 +128,7 @@ def security_context() -> Dict[str, Any]:
     """Return the non-secret subset of the current context.
 
     Excludes raw bearer tokens (``subject_token``/``actor_token``) so the result is safe
-    to expose to tools or persist for audit/correlation (ADR-KAOS-003).
+    to expose to tools or persist for audit/correlation.
     """
     data = _ctx_var.get()
     return {key: data[key] for key in _NON_SECRET_FIELDS if data.get(key)}

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -1,0 +1,147 @@
+"""AIB propagation SDK — request-local security context and header propagation.
+
+This module is the propagation slice of the AIB Python SDK (ADR-AIB-001 /
+ADR-KAOS-003). It carries two identities across agent hops:
+
+* the user **subject** (principal + ``Authorization`` bearer), propagated unchanged, and
+* the calling agent **actor** (the local agent's own identity + ``x-agent-authorization``
+  bearer), set to *this* workload on every outbound hop so each agent authenticates as
+  itself.
+
+It is intentionally small: a ``ContextVar``-backed request-local mapping (:data:`ctx`),
+a header serializer (:meth:`_Context.to_headers`), and the inbound/outbound instrumentation
+(added in sibling commits). The SDK is *not* the enforcement boundary — it only propagates.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from typing import Any, Dict, Iterator, MutableMapping, Optional
+
+# --- Header model (ADR-AIB-001) -----------------------------------------------------
+# Generic headers for concepts not owned by AIB; ``x-aib-*`` reserved for AIB-owned context.
+HEADER_REQUEST_ID = "x-request-id"
+HEADER_SESSION_ID = "x-aib-session-id"
+HEADER_PRINCIPAL = "x-principal"
+HEADER_ACTOR = "x-actor"
+HEADER_SCOPES = "x-aib-scopes"
+HEADER_SUBJECT_TOKEN = "authorization"
+HEADER_ACTOR_TOKEN = "x-agent-authorization"
+
+# Context keys carrying a raw bearer token; serialized as ``Bearer <value>`` and never logged.
+_TOKEN_FIELDS = {"subject_token": HEADER_SUBJECT_TOKEN, "actor_token": HEADER_ACTOR_TOKEN}
+
+# Context keys carrying plain identifiers/correlation values.
+_PLAIN_FIELDS = {
+    "request_id": HEADER_REQUEST_ID,
+    "session_id": HEADER_SESSION_ID,
+    "principal": HEADER_PRINCIPAL,
+    "actor": HEADER_ACTOR,
+    "scopes": HEADER_SCOPES,
+}
+
+
+def _as_bearer(value: str) -> str:
+    """Wrap a raw token as a ``Bearer`` credential unless it already is one."""
+    if value.lower().startswith("bearer "):
+        return value
+    return f"Bearer {value}"
+
+
+class _Context(MutableMapping[str, Any]):
+    """Dict-like view over a request-local ``ContextVar`` mapping.
+
+    Mutations target the current context only, so concurrent requests (each running in
+    their own ``ContextVar`` context) never see each other's identity.
+    """
+
+    def __init__(self, var: "contextvars.ContextVar[Dict[str, Any]]") -> None:
+        self._var = var
+
+    def _data(self) -> Dict[str, Any]:
+        return self._var.get()
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data()[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        data = dict(self._data())
+        data[key] = value
+        self._var.set(data)
+
+    def __delitem__(self, key: str) -> None:
+        data = dict(self._data())
+        del data[key]
+        self._var.set(data)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data())
+
+    def __len__(self) -> int:
+        return len(self._data())
+
+    def replace(self, values: Dict[str, Any]) -> "contextvars.Token[Dict[str, Any]]":
+        """Replace the whole mapping, returning a token for :meth:`reset`."""
+        return self._var.set(dict(values))
+
+    def reset(self, token: "contextvars.Token[Dict[str, Any]]") -> None:
+        """Restore the mapping captured before a :meth:`replace`."""
+        self._var.reset(token)
+
+    def to_headers(self) -> Dict[str, str]:
+        """Serialize the current context into outbound propagation headers.
+
+        Only non-empty fields are emitted. Token fields are ``Bearer``-wrapped. The
+        result is intended to be merged *additively* into an outbound request (callers
+        must not overwrite headers a user already set).
+        """
+        data = self._data()
+        headers: Dict[str, str] = {}
+        for field, header in _PLAIN_FIELDS.items():
+            value = data.get(field)
+            if value:
+                headers[header] = str(value)
+        for field, header in _TOKEN_FIELDS.items():
+            value = data.get(field)
+            if value:
+                headers[header] = _as_bearer(str(value))
+        return headers
+
+
+_ctx_var: "contextvars.ContextVar[Dict[str, Any]]" = contextvars.ContextVar("aib_ctx", default={})
+
+#: Request-local security context (``ContextVar``-backed, dict-like).
+ctx = _Context(_ctx_var)
+
+
+def current() -> Dict[str, Any]:
+    """Return a shallow copy of the current context mapping."""
+    return dict(_ctx_var.get())
+
+
+def to_headers() -> Dict[str, str]:
+    """Module-level convenience for :meth:`ctx.to_headers`."""
+    return ctx.to_headers()
+
+
+def _build_context(
+    *,
+    request_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    principal: Optional[str] = None,
+    subject_token: Optional[str] = None,
+    actor: Optional[str] = None,
+    actor_token: Optional[str] = None,
+    scopes: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a context mapping from explicit fields, dropping empties."""
+    fields = {
+        "request_id": request_id,
+        "session_id": session_id,
+        "principal": principal,
+        "subject_token": subject_token,
+        "actor": actor,
+        "actor_token": actor_token,
+        "scopes": scopes,
+    }
+    return {key: value for key, value in fields.items() if value}

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -334,6 +334,6 @@ def instrument_httpx() -> None:
         _inject_request_headers(request)
         return await async_send(self, request, *args, **kwargs)
 
-    httpx.Client.send = _patched_sync_send  # type: ignore[method-assign]
-    httpx.AsyncClient.send = _patched_async_send  # type: ignore[method-assign]
+    httpx.Client.send = _patched_sync_send  # ty: ignore[invalid-assignment]
+    httpx.AsyncClient.send = _patched_async_send  # ty: ignore[invalid-assignment]
     _httpx_patched = True

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -8,6 +8,8 @@ import sys
 from typing import Dict, Any, AsyncIterator, List, Optional, Union, TYPE_CHECKING
 from contextlib import asynccontextmanager
 
+import aib
+
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from opentelemetry import trace as trace_api
@@ -132,6 +134,18 @@ class AgentServer:
             description=self.settings.agent_description,
             lifespan=self._lifespan,
         )
+
+        # AIB two-identity propagation (ADR-KAOS-003): extract inbound user context at the
+        # server boundary and inject the user subject + this agent's actor on outbound
+        # A2A/MCP/ModelAPI calls. The SDK is not the enforcement boundary; it propagates.
+        local_actor = self.settings.aib_actor or f"kaos://agent/{self.settings.agent_name}"
+        aib.instrument_fastapi(
+            self.app,
+            actor=local_actor,
+            actor_token=self.settings.aib_actor_token or None,
+            principal=self.settings.aib_principal or None,
+        )
+        aib.instrument_httpx()
 
         self._setup_routes()
         setup_a2a_routes(self.app, self.task_manager)
@@ -380,7 +394,11 @@ class AgentServer:
         message_history = await self.memory.build_message_history(
             session_id, self.settings.memory_context_limit
         )
-        deps = AgentDeps(session_id=session_id, memory=self.memory)
+        deps = AgentDeps(
+            session_id=session_id,
+            memory=self.memory,
+            security_context=aib.security_context(),
+        )
         usage_limits = UsageLimits(request_limit=self.settings.agentic_loop_max_steps)
         return user_prompt, message_history, deps, usage_limits
 

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -138,12 +138,12 @@ class AgentServer:
         # AIB two-identity propagation (ADR-KAOS-003): extract inbound user context at the
         # server boundary and inject the user subject + this agent's actor on outbound
         # A2A/MCP/ModelAPI calls. The SDK is not the enforcement boundary; it propagates.
-        local_actor = self.settings.aib_actor or f"kaos://agent/{self.settings.agent_name}"
+        local_actor = self.settings.security_actor or f"kaos://agent/{self.settings.agent_name}"
         aib.instrument_fastapi(
             self.app,
             actor=local_actor,
-            actor_token=self.settings.aib_actor_token or None,
-            principal=self.settings.aib_principal or None,
+            actor_token=self.settings.security_actor_token or None,
+            principal=self.settings.security_principal or None,
         )
         aib.instrument_httpx()
 

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -135,7 +135,7 @@ class AgentServer:
             lifespan=self._lifespan,
         )
 
-        # AIB two-identity propagation (ADR-KAOS-003): extract inbound user context at the
+        # AIB two-identity propagation: extract inbound user context at the
         # server boundary and inject the user subject + this agent's actor on outbound
         # A2A/MCP/ModelAPI calls. The SDK is not the enforcement boundary; it propagates.
         local_actor = self.settings.security_actor or f"kaos://agent/{self.settings.agent_name}"

--- a/pydantic-ai-server/pais/serverutils.py
+++ b/pydantic-ai-server/pais/serverutils.py
@@ -35,6 +35,9 @@ class AgentDeps:
 
     session_id: str = ""
     memory: Optional["Memory"] = None
+    # Non-secret request security context (request_id/session_id/principal/actor/scopes)
+    # populated from the aib SDK for audit/correlation; never carries raw bearer tokens.
+    security_context: Optional[Dict[str, Any]] = None
 
 
 class _MockResponseState:
@@ -419,6 +422,12 @@ class AgentServerSettings(BaseSettings):
 
     # Logging settings
     agent_access_log: bool = False
+
+    # AIB identity propagation (dummy/static at this stage; real minting comes later).
+    # aib_actor defaults to kaos://agent/{agent_name} when unset.
+    aib_actor: str = ""
+    aib_actor_token: str = ""
+    aib_principal: str = ""
 
     # Pydantic AI OTEL instrumentation settings
     otel_instrumentation_version: int = 4

--- a/pydantic-ai-server/pais/serverutils.py
+++ b/pydantic-ai-server/pais/serverutils.py
@@ -424,10 +424,10 @@ class AgentServerSettings(BaseSettings):
     agent_access_log: bool = False
 
     # AIB identity propagation (dummy/static at this stage; real minting comes later).
-    # aib_actor defaults to kaos://agent/{agent_name} when unset.
-    aib_actor: str = ""
-    aib_actor_token: str = ""
-    aib_principal: str = ""
+    # security_actor defaults to kaos://agent/{agent_name} when unset.
+    security_actor: str = ""
+    security_actor_token: str = ""
+    security_principal: str = ""
 
     # Pydantic AI OTEL instrumentation settings
     otel_instrumentation_version: int = 4

--- a/pydantic-ai-server/pyproject.toml
+++ b/pydantic-ai-server/pyproject.toml
@@ -45,7 +45,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["pais"]
+packages = ["pais", "aib"]
 
 [tool.black]
 line-length = 100

--- a/pydantic-ai-server/pyproject.toml
+++ b/pydantic-ai-server/pyproject.toml
@@ -50,3 +50,8 @@ packages = ["pais", "aib"]
 [tool.black]
 line-length = 100
 target-version = ["py312"]
+
+# Deprecation notices from upstream libraries are informational and must not
+# fail type checking; library migrations are handled as deliberate changes.
+[tool.ty.rules]
+deprecated = "ignore"

--- a/pydantic-ai-server/tests/test_aib_context.py
+++ b/pydantic-ai-server/tests/test_aib_context.py
@@ -1,0 +1,105 @@
+"""Unit tests for the aib request-local context and header serialization."""
+
+import asyncio
+
+import aib
+from aib.instrument import _as_bearer, _build_context
+
+
+def _clear():
+    aib.ctx.replace({})
+
+
+def test_to_headers_maps_fields_to_headers():
+    _clear()
+    aib.ctx.update(
+        {
+            "request_id": "req-1",
+            "session_id": "sess-1",
+            "principal": "keycloak://kaos/alice",
+            "subject_token": "user-token",
+            "actor": "kaos://agent/default/researcher",
+            "actor_token": "actor-token",
+            "scopes": "read write",
+        }
+    )
+    headers = aib.ctx.to_headers()
+    assert headers["x-request-id"] == "req-1"
+    assert headers["x-aib-session-id"] == "sess-1"
+    assert headers["x-principal"] == "keycloak://kaos/alice"
+    assert headers["x-actor"] == "kaos://agent/default/researcher"
+    assert headers["x-aib-scopes"] == "read write"
+    assert headers["authorization"] == "Bearer user-token"
+    assert headers["x-agent-authorization"] == "Bearer actor-token"
+
+
+def test_to_headers_omits_empty_fields():
+    _clear()
+    aib.ctx["request_id"] = "req-only"
+    headers = aib.ctx.to_headers()
+    assert headers == {"x-request-id": "req-only"}
+
+
+def test_bearer_wrapping_is_idempotent():
+    assert _as_bearer("abc") == "Bearer abc"
+    assert _as_bearer("Bearer abc") == "Bearer abc"
+    assert _as_bearer("bearer abc") == "bearer abc"
+
+
+def test_token_already_bearer_not_double_wrapped():
+    _clear()
+    aib.ctx["subject_token"] = "Bearer existing"
+    assert aib.ctx.to_headers()["authorization"] == "Bearer existing"
+
+
+def test_mapping_operations():
+    _clear()
+    aib.ctx.update({"actor": "a", "principal": "p"})
+    assert aib.ctx.get("actor") == "a"
+    assert aib.ctx.get("missing") is None
+    aib.ctx.pop("actor", None)
+    assert "actor" not in aib.ctx
+    assert aib.ctx["principal"] == "p"
+    assert len(aib.ctx) == 1
+
+
+def test_replace_and_reset_round_trip():
+    _clear()
+    aib.ctx["actor"] = "first"
+    token = aib.ctx.replace({"actor": "second"})
+    assert aib.ctx["actor"] == "second"
+    aib.ctx.reset(token)
+    assert aib.ctx["actor"] == "first"
+
+
+def test_current_returns_copy():
+    _clear()
+    aib.ctx["actor"] = "a"
+    snapshot = aib.current()
+    snapshot["actor"] = "mutated"
+    assert aib.ctx["actor"] == "a"
+
+
+def test_build_context_drops_empty():
+    built = _build_context(request_id="r", actor="a", principal=None, scopes="")
+    assert built == {"request_id": "r", "actor": "a"}
+
+
+def test_contextvar_isolation_across_tasks():
+    """Each asyncio task gets its own copy-on-write context — no cross-talk."""
+    _clear()
+    aib.ctx["actor"] = "root"
+    seen = {}
+
+    async def worker(name):
+        aib.ctx["actor"] = name
+        await asyncio.sleep(0)
+        seen[name] = aib.ctx["actor"]
+
+    async def main():
+        await asyncio.gather(worker("a"), worker("b"))
+
+    asyncio.run(main())
+    assert seen == {"a": "a", "b": "b"}
+    # Mutations inside tasks do not leak back into the parent context.
+    assert aib.ctx["actor"] == "root"

--- a/pydantic-ai-server/tests/test_aib_fastapi.py
+++ b/pydantic-ai-server/tests/test_aib_fastapi.py
@@ -1,0 +1,90 @@
+"""Unit tests for aib.instrument_fastapi inbound boundary instrumentation."""
+
+import aib
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _make_app(**kwargs):
+    app = FastAPI()
+    aib.instrument_fastapi(app, **kwargs)
+
+    @app.get("/seen")
+    async def seen():
+        # The context set by the middleware must be visible inside the endpoint
+        # (same task — pure ASGI middleware, not BaseHTTPMiddleware).
+        return aib.current()
+
+    return TestClient(app)
+
+
+def test_generates_request_id_when_absent():
+    client = _make_app(actor="kaos://agent/default/a")
+    seen = client.get("/seen").json()
+    assert seen["request_id"].startswith("req-")
+    assert seen["actor"] == "kaos://agent/default/a"
+
+
+def test_propagates_inbound_subject_and_request_id():
+    client = _make_app(actor="kaos://agent/default/a")
+    seen = client.get(
+        "/seen",
+        headers={
+            "x-request-id": "req-fixed",
+            "x-principal": "keycloak://kaos/alice",
+            "authorization": "Bearer user-token",
+            "x-aib-scopes": "read",
+        },
+    ).json()
+    assert seen["request_id"] == "req-fixed"
+    assert seen["principal"] == "keycloak://kaos/alice"
+    assert seen["subject_token"] == "user-token"  # Bearer stripped on the way in
+    assert seen["scopes"] == "read"
+
+
+def test_local_actor_overrides_inbound_actor():
+    """The actor is always THIS agent — never the inbound caller's actor."""
+    client = _make_app(actor="kaos://agent/default/B", actor_token="b-token")
+    seen = client.get(
+        "/seen",
+        headers={
+            "x-actor": "kaos://agent/default/A",
+            "x-agent-authorization": "Bearer a-token",
+        },
+    ).json()
+    assert seen["actor"] == "kaos://agent/default/B"
+    assert seen["actor_token"] == "b-token"
+
+
+def test_session_from_legacy_header():
+    client = _make_app(actor="kaos://agent/default/a")
+    seen = client.get("/seen", headers={"x-session-id": "sess-legacy"}).json()
+    assert seen["session_id"] == "sess-legacy"
+
+
+def test_principal_resolver_used_when_no_inbound_principal():
+    client = _make_app(
+        actor="kaos://agent/default/a",
+        principal_resolver=lambda headers: "resolved://user",
+    )
+    seen = client.get("/seen").json()
+    assert seen["principal"] == "resolved://user"
+
+
+def test_env_defaults_used(monkeypatch):
+    monkeypatch.setenv("AIB_ACTOR", "kaos://agent/default/env")
+    monkeypatch.setenv("AIB_ACTOR_TOKEN", "env-token")
+    monkeypatch.setenv("AIB_PRINCIPAL", "service://env")
+    client = _make_app()
+    seen = client.get("/seen").json()
+    assert seen["actor"] == "kaos://agent/default/env"
+    assert seen["actor_token"] == "env-token"
+    assert seen["principal"] == "service://env"
+
+
+def test_context_reset_between_requests():
+    client = _make_app(actor="kaos://agent/default/a")
+    client.get("/seen", headers={"x-principal": "keycloak://kaos/alice"})
+    # A subsequent request without a principal must not leak the previous one.
+    seen = client.get("/seen").json()
+    assert "principal" not in seen

--- a/pydantic-ai-server/tests/test_aib_fastapi.py
+++ b/pydantic-ai-server/tests/test_aib_fastapi.py
@@ -72,9 +72,9 @@ def test_principal_resolver_used_when_no_inbound_principal():
 
 
 def test_env_defaults_used(monkeypatch):
-    monkeypatch.setenv("AIB_ACTOR", "kaos://agent/default/env")
-    monkeypatch.setenv("AIB_ACTOR_TOKEN", "env-token")
-    monkeypatch.setenv("AIB_PRINCIPAL", "service://env")
+    monkeypatch.setenv("AGENT_AUTH_IDENTITY", "kaos://agent/default/env")
+    monkeypatch.setenv("AGENT_AUTH_TOKEN", "env-token")
+    monkeypatch.setenv("AGENT_AUTH_PRINCIPAL", "service://env")
     client = _make_app()
     seen = client.get("/seen").json()
     assert seen["actor"] == "kaos://agent/default/env"

--- a/pydantic-ai-server/tests/test_aib_httpx.py
+++ b/pydantic-ai-server/tests/test_aib_httpx.py
@@ -1,0 +1,82 @@
+"""Unit tests for aib.instrument_httpx outbound header injection."""
+
+import aib
+import httpx
+import pytest
+import respx
+
+
+@pytest.fixture(autouse=True)
+def _patch_and_clear():
+    aib.instrument_httpx()  # idempotent — safe to call per test
+    aib.ctx.replace({})
+    yield
+    aib.ctx.replace({})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_injects_both_identities():
+    route = respx.post("http://downstream/run").respond(200)
+    aib.ctx.update(
+        {
+            "request_id": "req-9",
+            "principal": "keycloak://kaos/alice",
+            "subject_token": "user-token",
+            "actor": "kaos://agent/default/researcher",
+            "actor_token": "actor-token",
+        }
+    )
+    async with httpx.AsyncClient() as client:
+        await client.post("http://downstream/run")
+
+    sent = route.calls.last.request.headers
+    assert sent["x-request-id"] == "req-9"
+    assert sent["x-principal"] == "keycloak://kaos/alice"
+    assert sent["authorization"] == "Bearer user-token"
+    assert sent["x-actor"] == "kaos://agent/default/researcher"
+    assert sent["x-agent-authorization"] == "Bearer actor-token"
+
+
+@respx.mock
+def test_sync_client_injects():
+    route = respx.get("http://downstream/data").respond(200)
+    aib.ctx["actor"] = "kaos://agent/default/a"
+    with httpx.Client() as client:
+        client.get("http://downstream/data")
+    assert route.calls.last.request.headers["x-actor"] == "kaos://agent/default/a"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_does_not_overwrite_existing_authorization():
+    """A provider's own Authorization (e.g. ModelAPI API key) is preserved."""
+    route = respx.post("http://modelapi/v1/chat").respond(200)
+    aib.ctx.update({"subject_token": "user-token", "actor": "kaos://agent/default/a"})
+    async with httpx.AsyncClient() as client:
+        await client.post("http://modelapi/v1/chat", headers={"Authorization": "Bearer api-key"})
+
+    sent = route.calls.last.request.headers
+    assert sent["authorization"] == "Bearer api-key"  # not clobbered
+    assert sent["x-actor"] == "kaos://agent/default/a"  # additive header still added
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_empty_context_injects_nothing():
+    route = respx.get("http://downstream/ping").respond(200)
+    async with httpx.AsyncClient() as client:
+        await client.get("http://downstream/ping")
+    headers = route.calls.last.request.headers
+    assert "x-actor" not in headers
+    assert "x-agent-authorization" not in headers
+
+
+def test_instrument_httpx_is_idempotent():
+    import aib.instrument as inst
+
+    send_before = httpx.AsyncClient.send
+    aib.instrument_httpx()
+    aib.instrument_httpx()
+    assert httpx.AsyncClient.send is send_before
+    assert inst._httpx_patched is True

--- a/pydantic-ai-server/tests/test_aib_propagation_e2e.py
+++ b/pydantic-ai-server/tests/test_aib_propagation_e2e.py
@@ -1,0 +1,76 @@
+"""End-to-end two-identity propagation across agent hops (A -> B -> MCP).
+
+Wires three instrumented apps together in-process via httpx ASGITransport and asserts,
+using the real aib SDK, that:
+
+* the user **subject** (principal + Authorization) is propagated unchanged across hops,
+* the **actor** is overridden per hop (each agent authenticates as itself), and
+* a request id is generated at the edge and stays stable down the chain.
+"""
+
+import aib
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+
+
+def _record_app(actor, recorder, downstream=None, downstream_url=None):
+    app = FastAPI()
+    aib.instrument_fastapi(app, actor=actor, actor_token=f"{actor}#token")
+
+    @app.get("/call")
+    async def call(request: Request):
+        recorder.update({k.lower(): v for k, v in request.headers.items()})
+        if downstream is None:
+            return {"leaf": True}
+        resp = await downstream.get(downstream_url)
+        return resp.json()
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_two_identity_propagation_across_hops():
+    aib.instrument_httpx()
+    aib.ctx.replace({})
+
+    seen_b = {}  # headers agent B received from agent A
+    seen_c = {}  # headers the MCP leaf received from agent B
+
+    leaf = _record_app("kaos://mcpserver/default/github", seen_c)
+    client_c = httpx.AsyncClient(transport=httpx.ASGITransport(app=leaf), base_url="http://c")
+
+    agent_b = _record_app("kaos://agent/default/B", seen_b, client_c, "http://c/call")
+    client_b = httpx.AsyncClient(transport=httpx.ASGITransport(app=agent_b), base_url="http://b")
+
+    agent_a = _record_app("kaos://agent/default/A", {}, client_b, "http://b/call")
+    client_a = httpx.AsyncClient(transport=httpx.ASGITransport(app=agent_a), base_url="http://a")
+
+    # Inbound user request to A: user subject only (no actor, no request id).
+    await client_a.get(
+        "http://a/call",
+        headers={
+            "authorization": "Bearer user-subject-alice",
+            "x-principal": "keycloak://kaos/alice",
+        },
+    )
+
+    # User subject is carried unchanged all the way to the leaf.
+    assert seen_c["x-principal"] == "keycloak://kaos/alice"
+    assert seen_c["authorization"] == "Bearer user-subject-alice"
+
+    # Actor is each hop's own identity: A->B carries actor A, B->leaf carries actor B.
+    assert seen_b["x-actor"] == "kaos://agent/default/A"
+    assert seen_b["x-agent-authorization"] == "Bearer kaos://agent/default/A#token"
+    assert seen_c["x-actor"] == "kaos://agent/default/B"
+    assert seen_c["x-agent-authorization"] == "Bearer kaos://agent/default/B#token"
+
+    # The decision would key on the actor (B), never the subject principal.
+    assert seen_c["x-actor"] != seen_c["x-principal"]
+
+    # A request id is generated at the edge and stays stable down the chain.
+    assert seen_b["x-request-id"].startswith("req-")
+    assert seen_b["x-request-id"] == seen_c["x-request-id"]
+
+    for client in (client_a, client_b, client_c):
+        await client.aclose()

--- a/pydantic-ai-server/tests/test_aib_wiring.py
+++ b/pydantic-ai-server/tests/test_aib_wiring.py
@@ -35,8 +35,8 @@ def test_server_wires_fastapi_and_httpx_instrumentation():
     assert aib.instrument._httpx_patched is True
 
 
-def test_aib_actor_setting_overrides_default():
-    server = create_agent_server(_settings(aib_actor="kaos://agent/custom/id"))
+def test_security_actor_setting_overrides_default():
+    server = create_agent_server(_settings(security_actor="kaos://agent/custom/id"))
     mw = _propagation_middleware(server.app)
     assert mw.kwargs["actor"] == "kaos://agent/custom/id"
 

--- a/pydantic-ai-server/tests/test_aib_wiring.py
+++ b/pydantic-ai-server/tests/test_aib_wiring.py
@@ -1,0 +1,91 @@
+"""Wiring tests: the aib SDK is active inside the pais AgentServer."""
+
+import aib
+import pytest
+from aib.instrument import _PropagationMiddleware
+from fastapi.testclient import TestClient
+from pais.serverutils import AgentServerSettings
+from pais.server import create_agent_server
+
+
+def _settings(**overrides):
+    base = dict(
+        agent_name="researcher",
+        model_api_url="http://model.local",
+        model_name="test-model",
+        agent_log_level="WARNING",
+    )
+    base.update(overrides)
+    return AgentServerSettings(**base)
+
+
+def _propagation_middleware(app):
+    for mw in app.user_middleware:
+        if mw.cls is _PropagationMiddleware:
+            return mw
+    return None
+
+
+def test_server_wires_fastapi_and_httpx_instrumentation():
+    server = create_agent_server(_settings())
+    mw = _propagation_middleware(server.app)
+    assert mw is not None
+    # Default local actor derives from the agent name.
+    assert mw.kwargs["actor"] == "kaos://agent/researcher"
+    assert aib.instrument._httpx_patched is True
+
+
+def test_aib_actor_setting_overrides_default():
+    server = create_agent_server(_settings(aib_actor="kaos://agent/custom/id"))
+    mw = _propagation_middleware(server.app)
+    assert mw.kwargs["actor"] == "kaos://agent/custom/id"
+
+
+def test_request_through_server_runs_middleware_and_resets():
+    server = create_agent_server(_settings())
+    aib.ctx.replace({})
+    client = TestClient(server.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    # Context is request-scoped and reset afterwards — no leak into the process.
+    assert aib.current() == {}
+
+
+def test_security_context_excludes_raw_tokens():
+    aib.ctx.replace(
+        {
+            "request_id": "req-1",
+            "principal": "keycloak://kaos/alice",
+            "actor": "kaos://agent/researcher",
+            "subject_token": "user-token",
+            "actor_token": "actor-token",
+        }
+    )
+    sc = aib.security_context()
+    assert sc == {
+        "request_id": "req-1",
+        "principal": "keycloak://kaos/alice",
+        "actor": "kaos://agent/researcher",
+    }
+    assert "subject_token" not in sc
+    assert "actor_token" not in sc
+    aib.ctx.replace({})
+
+
+@pytest.mark.asyncio
+async def test_agent_deps_carry_non_secret_security_context():
+    """AgentDeps built during a run carry the non-secret context, never tokens."""
+    server = create_agent_server(_settings())
+    aib.ctx.replace(
+        {
+            "request_id": "req-x",
+            "actor": "kaos://agent/researcher",
+            "subject_token": "secret",
+        }
+    )
+    _prompt, _history, deps, _limits = await server._prepare_run("hello", "sess-1")
+    assert deps.security_context == {
+        "request_id": "req-x",
+        "actor": "kaos://agent/researcher",
+    }
+    aib.ctx.replace({})

--- a/pydantic-ai-server/tests/test_aib_wiring.py
+++ b/pydantic-ai-server/tests/test_aib_wiring.py
@@ -16,7 +16,7 @@ def _settings(**overrides):
         agent_log_level="WARNING",
     )
     base.update(overrides)
-    return AgentServerSettings(**base)
+    return AgentServerSettings.model_validate(base)
 
 
 def _propagation_middleware(app):

--- a/pydantic-ai-server/tests/test_dockerfile_packaging.py
+++ b/pydantic-ai-server/tests/test_dockerfile_packaging.py
@@ -1,0 +1,41 @@
+"""Guard that the container image ships every packaged module.
+
+The runtime image installs the project with ``--no-deps`` from the copied source
+tree, so every package listed for the wheel build must also be copied into the
+image. A package that is declared but never copied is silently dropped from the
+wheel and only fails at container start with ``ModuleNotFoundError``.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _ROOT / "pyproject.toml"
+_DOCKERFILE = _ROOT / "Dockerfile"
+
+
+def _wheel_packages() -> list[str]:
+    data = tomllib.loads(_PYPROJECT.read_text())
+    return data["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+
+
+def _copied_dirs() -> set[str]:
+    copied: set[str] = set()
+    for line in _DOCKERFILE.read_text().splitlines():
+        match = re.match(r"\s*COPY\s+(\S+)/\s+\S+", line)
+        if match:
+            copied.add(match.group(1).strip("./"))
+    return copied
+
+
+def test_every_wheel_package_is_copied_into_image():
+    packages = _wheel_packages()
+    assert packages, "expected at least one wheel package to be declared"
+
+    copied = _copied_dirs()
+    missing = [pkg for pkg in packages if pkg not in copied]
+    assert not missing, (
+        f"Dockerfile does not COPY wheel package(s) {missing}; they would be "
+        f"dropped from the image and crash the runtime at import. Copied dirs: {sorted(copied)}"
+    )


### PR DESCRIPTION
## Summary

First atomic security component for the KAOS identity workstream (initial piece of the security/identity plan, tracked in #231): the **`aib` Python SDK** for two-identity request-context propagation, wired into the `pais` runtime.

Realises the propagation slice of ADR-AIB-001 and ADR-KAOS-003. The SDK only **propagates** — it is not the enforcement boundary (the gateway enforces, in later phases). Identities/tokens are dummy/static here; real minting + the machine-token lifecycle come later.

## What's included

- **`aib` package** (`pydantic-ai-server/aib/`, a clean unit for later upstreaming to AIB):
  - `aib.ctx` — `ContextVar`-backed, dict-like request-local security context + `to_headers()`.
  - `aib.instrument_fastapi(app, actor=…)` — pure-ASGI middleware that extracts trusted inbound context and generates `x-request-id` when absent.
  - `aib.instrument_httpx()` — patches `httpx` `send` so a single hook covers A2A, MCP, and ModelAPI; injection is at request time and **strictly additive** (never overwrites an existing header such as the ModelAPI API-key `Authorization`).
- **Two identities**: user **subject** (`authorization`/`x-principal`) propagated unchanged; agent **actor** (`x-agent-authorization`/`x-actor`) set to the local agent on every hop, so each agent authenticates as itself → multi-agent decisions key on the actor, never the subject `azp`.
- **Runtime wiring**: `AgentServer` instruments the app + httpx; local actor defaults to `kaos://agent/{name}` (override via `AIB_ACTOR`/`aib_actor`); non-secret context exposed on `AgentDeps.security_context` (no raw tokens persisted).

## Tests

27 new unit/integration tests (context, FastAPI boundary, httpx injection, runtime wiring) plus an end-to-end A→B→MCP test proving subject-unchanged + per-hop actor + stable request-id. Full suite green locally: **224 passed, 10 skipped**; `black --check` clean.

## Out of scope (later phases)

Real `client_credentials` minting + machine-token lifecycle, access-check/decision surface, `instrument_requests`/`instrument_fastmcp`, gateway enforcement, and token-destination allowlisting.
