### PR TITLE
PR-ADR-KAOS-2: Gateway authorization enforcement for protected routes

### DIFF
--- a/operator/chart/templates/kaos-operator-rbac.yaml
+++ b/operator/chart/templates/kaos-operator-rbac.yaml
@@ -62,6 +62,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - securitypolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - kaos.tools
   resources:
   - agents

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -25,15 +25,16 @@ data:
   GATEWAY_DEFAULT_AGENT_TIMEOUT: {{ .Values.gateway.defaultTimeouts.agent | quote }}
   GATEWAY_DEFAULT_MODELAPI_TIMEOUT: {{ .Values.gateway.defaultTimeouts.modelAPI | quote }}
   GATEWAY_DEFAULT_MCP_TIMEOUT: {{ .Values.gateway.defaultTimeouts.mcp | quote }}
-  # Resource-level authorization (access-check) enforcement
-  {{- if .Values.security.enabled }}
-  SECURITY_ENABLED: "true"
-  SECURITY_EXTAUTHZ_SERVICE_NAME: {{ .Values.security.extAuthz.serviceName | quote }}
-  SECURITY_EXTAUTHZ_SERVICE_NAMESPACE: {{ .Values.security.extAuthz.serviceNamespace | default .Release.Namespace | quote }}
-  SECURITY_EXTAUTHZ_SERVICE_PORT: {{ .Values.security.extAuthz.servicePort | quote }}
-  SECURITY_DEFAULT_ACTION: {{ .Values.security.defaultAction | default "access" | quote }}
-  {{- else }}
-  SECURITY_ENABLED: "false"
+  # Operator-wide security configuration. The presence of an agent-auth
+  # ext_authz URL enables gateway authorization enforcement (Envoy ext_authz)
+  # on protected routes; leaving it empty disables enforcement and leaves
+  # existing routing behavior unchanged.
+  {{- with .Values.security }}
+  {{- with .agentAuth }}
+  {{- if .extAuthzUrl }}
+  SECURITY_AGENT_AUTH_EXT_AUTHZ_URL: {{ .extAuthzUrl | quote }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   # Global telemetry configuration (defaults for all components)
   {{- if .Values.telemetry.enabled }}

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -25,6 +25,16 @@ data:
   GATEWAY_DEFAULT_AGENT_TIMEOUT: {{ .Values.gateway.defaultTimeouts.agent | quote }}
   GATEWAY_DEFAULT_MODELAPI_TIMEOUT: {{ .Values.gateway.defaultTimeouts.modelAPI | quote }}
   GATEWAY_DEFAULT_MCP_TIMEOUT: {{ .Values.gateway.defaultTimeouts.mcp | quote }}
+  # Resource-level authorization (access-check) enforcement
+  {{- if .Values.security.enabled }}
+  SECURITY_ENABLED: "true"
+  SECURITY_EXTAUTHZ_SERVICE_NAME: {{ .Values.security.extAuthz.serviceName | quote }}
+  SECURITY_EXTAUTHZ_SERVICE_NAMESPACE: {{ .Values.security.extAuthz.serviceNamespace | default .Release.Namespace | quote }}
+  SECURITY_EXTAUTHZ_SERVICE_PORT: {{ .Values.security.extAuthz.servicePort | quote }}
+  SECURITY_DEFAULT_ACTION: {{ .Values.security.defaultAction | default "access" | quote }}
+  {{- else }}
+  SECURITY_ENABLED: "false"
+  {{- end }}
   # Global telemetry configuration (defaults for all components)
   {{- if .Values.telemetry.enabled }}
   DEFAULT_TELEMETRY_ENABLED: "true"

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -73,14 +73,14 @@ gateway:
 # protected routes so requests are allowed or denied based on the calling
 # agent's granted permissions. Disabled by default — routing is unchanged.
 security:
-  enabled: false
-  # External authorization (access-check) gRPC backend.
-  extAuthz:
-    serviceName: ""
-    serviceNamespace: ""
-    servicePort: 9191
-  # Action recorded for a protected resource when a route does not specify one.
-  defaultAction: "access"
+  # Operator-wide security configuration. Security is enabled by the presence of
+  # an agent-auth ext_authz URL; when unset, the operator generates no
+  # authorization policies and routing behavior is unchanged.
+  agentAuth:
+    # extAuthzUrl is the host:port of the Envoy ext_authz access-check gRPC
+    # backend (AIB by default; OPA is a drop-in via the standard contract).
+    # Example: aib-ext-authz.aib-system.svc.cluster.local:9002
+    extAuthzUrl: ""
 
 serviceAccount:
   annotations: {}

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -68,6 +68,20 @@ gateway:
     modelAPI: "120s"
     mcp: "60s"
 
+# Resource-level authorization (access-check) enforcement at the gateway.
+# When enabled, the operator attaches an external authorization check to
+# protected routes so requests are allowed or denied based on the calling
+# agent's granted permissions. Disabled by default — routing is unchanged.
+security:
+  enabled: false
+  # External authorization (access-check) gRPC backend.
+  extAuthz:
+    serviceName: ""
+    serviceNamespace: ""
+    servicePort: 9191
+  # Action recorded for a protected resource when a route does not specify one.
+  defaultAction: "access"
+
 serviceAccount:
   annotations: {}
   automount: true

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -49,6 +49,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - securitypolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - httproutes

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -25,6 +25,7 @@ import (
 
 	kaosv1alpha1 "github.com/axsaucedo/kaos/operator/api/v1alpha1"
 	"github.com/axsaucedo/kaos/operator/pkg/gateway"
+	"github.com/axsaucedo/kaos/operator/pkg/security"
 	"github.com/axsaucedo/kaos/operator/pkg/util"
 )
 
@@ -321,6 +322,18 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			Timeout:      timeout,
 		}, log); err != nil {
 			log.Error(err, "failed to reconcile HTTPRoute")
+		}
+
+		if secCfg := security.GetConfig(); secCfg.IsOperational() {
+			routeName := gateway.HTTPRouteName(gateway.ResourceTypeAgent, agent.Name)
+			if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, agent, security.PolicyParams{
+				Name:      routeName,
+				Namespace: agent.Namespace,
+				RouteName: routeName,
+				Labels:    map[string]string{"app": "agent", "agent": agent.Name},
+			}, secCfg, log); err != nil {
+				log.Error(err, "failed to reconcile SecurityPolicy")
+			}
 		}
 	}
 

--- a/operator/controllers/mcpserver_controller.go
+++ b/operator/controllers/mcpserver_controller.go
@@ -21,6 +21,7 @@ import (
 
 	kaosv1alpha1 "github.com/axsaucedo/kaos/operator/api/v1alpha1"
 	"github.com/axsaucedo/kaos/operator/pkg/gateway"
+	"github.com/axsaucedo/kaos/operator/pkg/security"
 	"github.com/axsaucedo/kaos/operator/pkg/util"
 )
 
@@ -214,6 +215,18 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Timeout:      timeout,
 	}, log); err != nil {
 		log.Error(err, "failed to reconcile HTTPRoute")
+	}
+
+	if secCfg := security.GetConfig(); secCfg.IsOperational() {
+		routeName := gateway.HTTPRouteName(gateway.ResourceTypeMCP, mcpserver.Name)
+		if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, mcpserver, security.PolicyParams{
+			Name:      routeName,
+			Namespace: mcpserver.Namespace,
+			RouteName: routeName,
+			Labels:    map[string]string{"app": "mcpserver", "mcpserver": mcpserver.Name},
+		}, secCfg, log); err != nil {
+			log.Error(err, "failed to reconcile SecurityPolicy")
+		}
 	}
 
 	// Copy deployment status for rolling update visibility

--- a/operator/controllers/modelapi_controller.go
+++ b/operator/controllers/modelapi_controller.go
@@ -23,6 +23,7 @@ import (
 
 	kaosv1alpha1 "github.com/axsaucedo/kaos/operator/api/v1alpha1"
 	"github.com/axsaucedo/kaos/operator/pkg/gateway"
+	"github.com/axsaucedo/kaos/operator/pkg/security"
 	"github.com/axsaucedo/kaos/operator/pkg/util"
 )
 
@@ -288,6 +289,18 @@ func (r *ModelAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		Timeout:      timeout,
 	}, log); err != nil {
 		log.Error(err, "failed to reconcile HTTPRoute")
+	}
+
+	if secCfg := security.GetConfig(); secCfg.IsOperational() {
+		routeName := gateway.HTTPRouteName(gateway.ResourceTypeModelAPI, modelapi.Name)
+		if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, modelapi, security.PolicyParams{
+			Name:      routeName,
+			Namespace: modelapi.Namespace,
+			RouteName: routeName,
+			Labels:    map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
+		}, secCfg, log); err != nil {
+			log.Error(err, "failed to reconcile SecurityPolicy")
+		}
 	}
 
 	// Copy deployment status for rolling update visibility

--- a/operator/main.go
+++ b/operator/main.go
@@ -30,6 +30,7 @@ var (
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=securitypolicies,verbs=get;list;watch;create;update;patch;delete
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -1,0 +1,79 @@
+// Package security provides operator-wide configuration for resource-level
+// authorization enforcement at the gateway. When enabled, the operator attaches
+// an external authorization check to protected routes so that requests are
+// allowed or denied based on the calling agent's granted permissions.
+package security
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// Config holds operator-wide authorization configuration read from the
+// environment. When Enabled is false the operator generates no authorization
+// policies and existing routing behavior is unchanged.
+type Config struct {
+	// Enabled turns on generation of authorization policies for protected routes.
+	Enabled bool
+	// ExtAuthzServiceName is the in-cluster Service name of the external
+	// authorization (access-check) gRPC backend.
+	ExtAuthzServiceName string
+	// ExtAuthzServiceNamespace is the namespace of the external authorization Service.
+	ExtAuthzServiceNamespace string
+	// ExtAuthzServicePort is the gRPC port of the external authorization Service.
+	ExtAuthzServicePort int
+	// DefaultAction is the action recorded for a protected resource when a route
+	// does not specify a more specific one.
+	DefaultAction string
+}
+
+const (
+	defaultExtAuthzPort  = 9191
+	defaultDefaultAction = "access"
+	envEnabled           = "SECURITY_ENABLED"
+	envExtAuthzName      = "SECURITY_EXTAUTHZ_SERVICE_NAME"
+	envExtAuthzNamespace = "SECURITY_EXTAUTHZ_SERVICE_NAMESPACE"
+	envExtAuthzPort      = "SECURITY_EXTAUTHZ_SERVICE_PORT"
+	envDefaultAction     = "SECURITY_DEFAULT_ACTION"
+)
+
+// GetConfig reads authorization configuration from environment variables.
+func GetConfig() Config {
+	return Config{
+		Enabled:                  os.Getenv(envEnabled) == "true",
+		ExtAuthzServiceName:      os.Getenv(envExtAuthzName),
+		ExtAuthzServiceNamespace: os.Getenv(envExtAuthzNamespace),
+		ExtAuthzServicePort:      getEnvIntOrDefault(envExtAuthzPort, defaultExtAuthzPort),
+		DefaultAction:            getEnvOrDefault(envDefaultAction, defaultDefaultAction),
+	}
+}
+
+// IsOperational reports whether authorization is enabled and the external
+// authorization backend is fully specified. The operator should only generate
+// authorization policies when this returns true.
+func (c Config) IsOperational() bool {
+	return c.Enabled && c.ExtAuthzServiceName != "" && c.ExtAuthzServiceNamespace != "" && c.ExtAuthzServicePort > 0
+}
+
+// ExtAuthzServiceHost returns the fully-qualified in-cluster DNS name of the
+// external authorization Service.
+func (c Config) ExtAuthzServiceHost() string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local", c.ExtAuthzServiceName, c.ExtAuthzServiceNamespace)
+}
+
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func getEnvIntOrDefault(key string, defaultValue int) int {
+	if value := os.Getenv(key); value != "" {
+		if parsed, err := strconv.Atoi(value); err == nil {
+			return parsed
+		}
+	}
+	return defaultValue
+}

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -1,79 +1,69 @@
 // Package security provides operator-wide configuration for resource-level
-// authorization enforcement at the gateway. When enabled, the operator attaches
-// an external authorization check to protected routes so that requests are
-// allowed or denied based on the calling agent's granted permissions.
+// authorization enforcement at the gateway. When configured, the operator
+// attaches an external authorization (ext_authz) check to protected routes so
+// that requests are allowed or denied based on the calling agent's granted
+// permissions.
 package security
 
 import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
-// Config holds operator-wide authorization configuration read from the
-// environment. When Enabled is false the operator generates no authorization
-// policies and existing routing behavior is unchanged.
+// Config holds operator-wide security configuration read from the environment.
+// Security is enabled by the presence of an agent-auth ext_authz URL: when
+// ExtAuthzURL is empty the operator generates no authorization policies and
+// existing routing behavior is unchanged.
 type Config struct {
-	// Enabled turns on generation of authorization policies for protected routes.
-	Enabled bool
-	// ExtAuthzServiceName is the in-cluster Service name of the external
-	// authorization (access-check) gRPC backend.
-	ExtAuthzServiceName string
-	// ExtAuthzServiceNamespace is the namespace of the external authorization Service.
-	ExtAuthzServiceNamespace string
-	// ExtAuthzServicePort is the gRPC port of the external authorization Service.
-	ExtAuthzServicePort int
-	// DefaultAction is the action recorded for a protected resource when a route
-	// does not specify a more specific one.
-	DefaultAction string
+	// ExtAuthzURL is the host:port of the external authorization (ext_authz)
+	// access-check gRPC backend (agentAuth.extAuthzUrl). An empty value means
+	// gateway authorization enforcement is disabled.
+	ExtAuthzURL string
 }
 
-const (
-	defaultExtAuthzPort  = 9191
-	defaultDefaultAction = "access"
-	envEnabled           = "SECURITY_ENABLED"
-	envExtAuthzName      = "SECURITY_EXTAUTHZ_SERVICE_NAME"
-	envExtAuthzNamespace = "SECURITY_EXTAUTHZ_SERVICE_NAMESPACE"
-	envExtAuthzPort      = "SECURITY_EXTAUTHZ_SERVICE_PORT"
-	envDefaultAction     = "SECURITY_DEFAULT_ACTION"
-)
+const envExtAuthzURL = "SECURITY_AGENT_AUTH_EXT_AUTHZ_URL"
 
-// GetConfig reads authorization configuration from environment variables.
+// GetConfig reads security configuration from environment variables.
 func GetConfig() Config {
 	return Config{
-		Enabled:                  os.Getenv(envEnabled) == "true",
-		ExtAuthzServiceName:      os.Getenv(envExtAuthzName),
-		ExtAuthzServiceNamespace: os.Getenv(envExtAuthzNamespace),
-		ExtAuthzServicePort:      getEnvIntOrDefault(envExtAuthzPort, defaultExtAuthzPort),
-		DefaultAction:            getEnvOrDefault(envDefaultAction, defaultDefaultAction),
+		ExtAuthzURL: os.Getenv(envExtAuthzURL),
 	}
 }
 
-// IsOperational reports whether authorization is enabled and the external
-// authorization backend is fully specified. The operator should only generate
-// authorization policies when this returns true.
+// IsOperational reports whether gateway authorization enforcement is configured.
+// The operator only generates authorization policies when this returns true.
 func (c Config) IsOperational() bool {
-	return c.Enabled && c.ExtAuthzServiceName != "" && c.ExtAuthzServiceNamespace != "" && c.ExtAuthzServicePort > 0
+	return strings.TrimSpace(c.ExtAuthzURL) != ""
 }
 
-// ExtAuthzServiceHost returns the fully-qualified in-cluster DNS name of the
-// external authorization Service.
-func (c Config) ExtAuthzServiceHost() string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", c.ExtAuthzServiceName, c.ExtAuthzServiceNamespace)
-}
-
-func getEnvOrDefault(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
+// ExtAuthzBackendRef parses the configured ext_authz host:port URL into the
+// Kubernetes Service name, namespace, and port used to build the SecurityPolicy
+// gRPC backendRef. The host is expected as a Service DNS name in the form
+// "name[.namespace[.svc.cluster.local]]"; the namespace is empty when not present.
+func (c Config) ExtAuthzBackendRef() (name, namespace string, port int, err error) {
+	url := strings.TrimSpace(c.ExtAuthzURL)
+	if url == "" {
+		return "", "", 0, fmt.Errorf("ext_authz URL is empty")
 	}
-	return defaultValue
-}
 
-func getEnvIntOrDefault(key string, defaultValue int) int {
-	if value := os.Getenv(key); value != "" {
-		if parsed, err := strconv.Atoi(value); err == nil {
-			return parsed
-		}
+	host, portStr, found := strings.Cut(url, ":")
+	if !found || host == "" || portStr == "" {
+		return "", "", 0, fmt.Errorf("ext_authz URL %q must be in host:port form", url)
 	}
-	return defaultValue
+	port, err = strconv.Atoi(portStr)
+	if err != nil || port <= 0 {
+		return "", "", 0, fmt.Errorf("ext_authz URL %q has an invalid port", url)
+	}
+
+	labels := strings.Split(host, ".")
+	name = labels[0]
+	if len(labels) > 1 {
+		namespace = labels[1]
+	}
+	if name == "" {
+		return "", "", 0, fmt.Errorf("ext_authz URL %q has an empty service name", url)
+	}
+	return name, namespace, port, nil
 }

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -1,0 +1,86 @@
+package security
+
+import (
+	"testing"
+)
+
+func TestGetConfigDefaults(t *testing.T) {
+	for _, k := range []string{envEnabled, envExtAuthzName, envExtAuthzNamespace, envExtAuthzPort, envDefaultAction} {
+		t.Setenv(k, "")
+	}
+
+	cfg := GetConfig()
+
+	if cfg.Enabled {
+		t.Errorf("expected Enabled false by default, got true")
+	}
+	if cfg.ExtAuthzServicePort != defaultExtAuthzPort {
+		t.Errorf("expected default port %d, got %d", defaultExtAuthzPort, cfg.ExtAuthzServicePort)
+	}
+	if cfg.DefaultAction != defaultDefaultAction {
+		t.Errorf("expected default action %q, got %q", defaultDefaultAction, cfg.DefaultAction)
+	}
+	if cfg.IsOperational() {
+		t.Errorf("expected not operational when disabled and unset")
+	}
+}
+
+func TestGetConfigEnabled(t *testing.T) {
+	t.Setenv(envEnabled, "true")
+	t.Setenv(envExtAuthzName, "aib-access-check")
+	t.Setenv(envExtAuthzNamespace, "kaos-system")
+	t.Setenv(envExtAuthzPort, "9191")
+	t.Setenv(envDefaultAction, "call")
+
+	cfg := GetConfig()
+
+	if !cfg.Enabled {
+		t.Errorf("expected Enabled true")
+	}
+	if cfg.ExtAuthzServiceName != "aib-access-check" {
+		t.Errorf("unexpected service name %q", cfg.ExtAuthzServiceName)
+	}
+	if cfg.ExtAuthzServiceNamespace != "kaos-system" {
+		t.Errorf("unexpected namespace %q", cfg.ExtAuthzServiceNamespace)
+	}
+	if cfg.ExtAuthzServicePort != 9191 {
+		t.Errorf("unexpected port %d", cfg.ExtAuthzServicePort)
+	}
+	if cfg.DefaultAction != "call" {
+		t.Errorf("unexpected action %q", cfg.DefaultAction)
+	}
+	if !cfg.IsOperational() {
+		t.Errorf("expected operational when enabled and fully specified")
+	}
+	if got, want := cfg.ExtAuthzServiceHost(), "aib-access-check.kaos-system.svc.cluster.local"; got != want {
+		t.Errorf("ExtAuthzServiceHost = %q, want %q", got, want)
+	}
+}
+
+func TestIsOperationalRequiresAllFields(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"enabled but no name", Config{Enabled: true, ExtAuthzServiceNamespace: "ns", ExtAuthzServicePort: 9191}, false},
+		{"enabled but no namespace", Config{Enabled: true, ExtAuthzServiceName: "svc", ExtAuthzServicePort: 9191}, false},
+		{"enabled but no port", Config{Enabled: true, ExtAuthzServiceName: "svc", ExtAuthzServiceNamespace: "ns"}, false},
+		{"disabled but fully specified", Config{ExtAuthzServiceName: "svc", ExtAuthzServiceNamespace: "ns", ExtAuthzServicePort: 9191}, false},
+		{"fully specified and enabled", Config{Enabled: true, ExtAuthzServiceName: "svc", ExtAuthzServiceNamespace: "ns", ExtAuthzServicePort: 9191}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.IsOperational(); got != tc.want {
+				t.Errorf("IsOperational() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetConfigInvalidPortFallsBack(t *testing.T) {
+	t.Setenv(envExtAuthzPort, "not-a-number")
+	if got := GetConfig().ExtAuthzServicePort; got != defaultExtAuthzPort {
+		t.Errorf("expected fallback to %d on invalid port, got %d", defaultExtAuthzPort, got)
+	}
+}

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -4,83 +4,78 @@ import (
 	"testing"
 )
 
-func TestGetConfigDefaults(t *testing.T) {
-	for _, k := range []string{envEnabled, envExtAuthzName, envExtAuthzNamespace, envExtAuthzPort, envDefaultAction} {
-		t.Setenv(k, "")
-	}
+func TestGetConfigDisabledByDefault(t *testing.T) {
+	t.Setenv(envExtAuthzURL, "")
 
 	cfg := GetConfig()
 
-	if cfg.Enabled {
-		t.Errorf("expected Enabled false by default, got true")
-	}
-	if cfg.ExtAuthzServicePort != defaultExtAuthzPort {
-		t.Errorf("expected default port %d, got %d", defaultExtAuthzPort, cfg.ExtAuthzServicePort)
-	}
-	if cfg.DefaultAction != defaultDefaultAction {
-		t.Errorf("expected default action %q, got %q", defaultDefaultAction, cfg.DefaultAction)
-	}
 	if cfg.IsOperational() {
-		t.Errorf("expected not operational when disabled and unset")
+		t.Errorf("expected not operational when ext_authz URL is unset")
 	}
 }
 
-func TestGetConfigEnabled(t *testing.T) {
-	t.Setenv(envEnabled, "true")
-	t.Setenv(envExtAuthzName, "aib-access-check")
-	t.Setenv(envExtAuthzNamespace, "kaos-system")
-	t.Setenv(envExtAuthzPort, "9191")
-	t.Setenv(envDefaultAction, "call")
+func TestGetConfigOperationalWhenURLSet(t *testing.T) {
+	t.Setenv(envExtAuthzURL, "aib-ext-authz.aib-system.svc.cluster.local:9002")
 
 	cfg := GetConfig()
 
-	if !cfg.Enabled {
-		t.Errorf("expected Enabled true")
-	}
-	if cfg.ExtAuthzServiceName != "aib-access-check" {
-		t.Errorf("unexpected service name %q", cfg.ExtAuthzServiceName)
-	}
-	if cfg.ExtAuthzServiceNamespace != "kaos-system" {
-		t.Errorf("unexpected namespace %q", cfg.ExtAuthzServiceNamespace)
-	}
-	if cfg.ExtAuthzServicePort != 9191 {
-		t.Errorf("unexpected port %d", cfg.ExtAuthzServicePort)
-	}
-	if cfg.DefaultAction != "call" {
-		t.Errorf("unexpected action %q", cfg.DefaultAction)
-	}
 	if !cfg.IsOperational() {
-		t.Errorf("expected operational when enabled and fully specified")
+		t.Fatalf("expected operational when ext_authz URL is set")
 	}
-	if got, want := cfg.ExtAuthzServiceHost(), "aib-access-check.kaos-system.svc.cluster.local"; got != want {
-		t.Errorf("ExtAuthzServiceHost = %q, want %q", got, want)
+
+	name, namespace, port, err := cfg.ExtAuthzBackendRef()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "aib-ext-authz" {
+		t.Errorf("unexpected service name %q", name)
+	}
+	if namespace != "aib-system" {
+		t.Errorf("unexpected namespace %q", namespace)
+	}
+	if port != 9002 {
+		t.Errorf("unexpected port %d", port)
 	}
 }
 
-func TestIsOperationalRequiresAllFields(t *testing.T) {
+func TestIsOperationalIgnoresWhitespace(t *testing.T) {
+	if (Config{ExtAuthzURL: "   "}).IsOperational() {
+		t.Errorf("expected whitespace-only URL to be non-operational")
+	}
+}
+
+func TestExtAuthzBackendRef(t *testing.T) {
 	cases := []struct {
-		name string
-		cfg  Config
-		want bool
+		name      string
+		url       string
+		wantName  string
+		wantNS    string
+		wantPort  int
+		wantError bool
 	}{
-		{"enabled but no name", Config{Enabled: true, ExtAuthzServiceNamespace: "ns", ExtAuthzServicePort: 9191}, false},
-		{"enabled but no namespace", Config{Enabled: true, ExtAuthzServiceName: "svc", ExtAuthzServicePort: 9191}, false},
-		{"enabled but no port", Config{Enabled: true, ExtAuthzServiceName: "svc", ExtAuthzServiceNamespace: "ns"}, false},
-		{"disabled but fully specified", Config{ExtAuthzServiceName: "svc", ExtAuthzServiceNamespace: "ns", ExtAuthzServicePort: 9191}, false},
-		{"fully specified and enabled", Config{Enabled: true, ExtAuthzServiceName: "svc", ExtAuthzServiceNamespace: "ns", ExtAuthzServicePort: 9191}, true},
+		{"fqdn", "svc.ns.svc.cluster.local:9191", "svc", "ns", 9191, false},
+		{"name and namespace", "svc.ns:9002", "svc", "ns", 9002, false},
+		{"name only", "svc:8080", "svc", "", 8080, false},
+		{"missing port", "svc.ns", "", "", 0, true},
+		{"empty", "", "", "", 0, true},
+		{"invalid port", "svc.ns:nope", "", "", 0, true},
+		{"zero port", "svc.ns:0", "", "", 0, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.cfg.IsOperational(); got != tc.want {
-				t.Errorf("IsOperational() = %v, want %v", got, tc.want)
+			name, ns, port, err := (Config{ExtAuthzURL: tc.url}).ExtAuthzBackendRef()
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.url)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if name != tc.wantName || ns != tc.wantNS || port != tc.wantPort {
+				t.Errorf("got (%q,%q,%d), want (%q,%q,%d)", name, ns, port, tc.wantName, tc.wantNS, tc.wantPort)
 			}
 		})
-	}
-}
-
-func TestGetConfigInvalidPortFallsBack(t *testing.T) {
-	t.Setenv(envExtAuthzPort, "not-a-number")
-	if got := GetConfig().ExtAuthzServicePort; got != defaultExtAuthzPort {
-		t.Errorf("expected fallback to %d on invalid port, got %d", defaultExtAuthzPort, got)
 	}
 }

--- a/operator/pkg/security/securitypolicy.go
+++ b/operator/pkg/security/securitypolicy.go
@@ -46,8 +46,14 @@ type PolicyParams struct {
 // constructSecurityPolicy builds an Envoy Gateway SecurityPolicy (as an
 // unstructured object) that attaches a fail-closed gRPC external authorization
 // check to the target HTTPRoute. The check is performed by the configured
-// access-check backend Service.
-func constructSecurityPolicy(params PolicyParams, cfg Config) *unstructured.Unstructured {
+// access-check backend Service. It returns an error if the configured ext_authz
+// URL cannot be resolved to a Service backend reference.
+func constructSecurityPolicy(params PolicyParams, cfg Config) (*unstructured.Unstructured, error) {
+	name, namespace, port, err := cfg.ExtAuthzBackendRef()
+	if err != nil {
+		return nil, err
+	}
+
 	policy := &unstructured.Unstructured{}
 	policy.SetGroupVersionKind(SecurityPolicyGVK)
 	policy.SetName(params.Name)
@@ -64,20 +70,28 @@ func constructSecurityPolicy(params PolicyParams, cfg Config) *unstructured.Unst
 		},
 	}, "spec", "targetRefs")
 
+	backendRef := map[string]interface{}{
+		"group": "",
+		"kind":  "Service",
+		"name":  name,
+		"port":  int64(port),
+	}
+	if namespace != "" {
+		backendRef["namespace"] = namespace
+	}
+
 	_ = unstructured.SetNestedMap(policy.Object, map[string]interface{}{
 		"failOpen": false,
+		"headersToExtAuth": []interface{}{
+			"authorization",
+			"x-agent-authorization",
+		},
 		"grpc": map[string]interface{}{
-			"backendRef": map[string]interface{}{
-				"group":     "",
-				"kind":      "Service",
-				"name":      cfg.ExtAuthzServiceName,
-				"namespace": cfg.ExtAuthzServiceNamespace,
-				"port":      int64(cfg.ExtAuthzServicePort),
-			},
+			"backendRef": backendRef,
 		},
 	}, "spec", "extAuth")
 
-	return policy
+	return policy, nil
 }
 
 // ReconcileSecurityPolicy creates or updates the SecurityPolicy that guards a
@@ -96,11 +110,14 @@ func ReconcileSecurityPolicy(
 		return nil
 	}
 
-	desired := constructSecurityPolicy(params, cfg)
+	desired, err := constructSecurityPolicy(params, cfg)
+	if err != nil {
+		return fmt.Errorf("construct SecurityPolicy: %w", err)
+	}
 
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(SecurityPolicyGVK)
-	err := c.Get(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace}, existing)
+	err = c.Get(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace}, existing)
 	if err != nil && apierrors.IsNotFound(err) {
 		if err := controllerutil.SetControllerReference(owner, desired, scheme); err != nil {
 			return fmt.Errorf("set controller reference on SecurityPolicy: %w", err)

--- a/operator/pkg/security/securitypolicy.go
+++ b/operator/pkg/security/securitypolicy.go
@@ -1,0 +1,119 @@
+package security
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Envoy Gateway SecurityPolicy group/version/kind used to attach external
+// authorization to a route.
+const (
+	securityPolicyGroup   = "gateway.envoyproxy.io"
+	securityPolicyVersion = "v1alpha1"
+	securityPolicyKind    = "SecurityPolicy"
+	httpRouteGroup        = "gateway.networking.k8s.io"
+	httpRouteKind         = "HTTPRoute"
+)
+
+// SecurityPolicyGVK is the GroupVersionKind of the generated SecurityPolicy.
+var SecurityPolicyGVK = schema.GroupVersionKind{
+	Group:   securityPolicyGroup,
+	Version: securityPolicyVersion,
+	Kind:    securityPolicyKind,
+}
+
+// PolicyParams describes the protected route a SecurityPolicy should guard.
+type PolicyParams struct {
+	// Name is the SecurityPolicy name (typically the guarded HTTPRoute's name).
+	Name string
+	// Namespace is the namespace of the SecurityPolicy and the target route.
+	Namespace string
+	// RouteName is the name of the HTTPRoute the policy targets.
+	RouteName string
+	// Labels are applied to the generated SecurityPolicy.
+	Labels map[string]string
+}
+
+// constructSecurityPolicy builds an Envoy Gateway SecurityPolicy (as an
+// unstructured object) that attaches a fail-closed gRPC external authorization
+// check to the target HTTPRoute. The check is performed by the configured
+// access-check backend Service.
+func constructSecurityPolicy(params PolicyParams, cfg Config) *unstructured.Unstructured {
+	policy := &unstructured.Unstructured{}
+	policy.SetGroupVersionKind(SecurityPolicyGVK)
+	policy.SetName(params.Name)
+	policy.SetNamespace(params.Namespace)
+	if len(params.Labels) > 0 {
+		policy.SetLabels(params.Labels)
+	}
+
+	_ = unstructured.SetNestedSlice(policy.Object, []interface{}{
+		map[string]interface{}{
+			"group": httpRouteGroup,
+			"kind":  httpRouteKind,
+			"name":  params.RouteName,
+		},
+	}, "spec", "targetRefs")
+
+	_ = unstructured.SetNestedMap(policy.Object, map[string]interface{}{
+		"failOpen": false,
+		"grpc": map[string]interface{}{
+			"backendRef": map[string]interface{}{
+				"group":     "",
+				"kind":      "Service",
+				"name":      cfg.ExtAuthzServiceName,
+				"namespace": cfg.ExtAuthzServiceNamespace,
+				"port":      int64(cfg.ExtAuthzServicePort),
+			},
+		},
+	}, "spec", "extAuth")
+
+	return policy
+}
+
+// ReconcileSecurityPolicy creates or updates the SecurityPolicy that guards a
+// protected route. It is a no-op unless authorization is enabled and the
+// external authorization backend is fully specified.
+func ReconcileSecurityPolicy(
+	ctx context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	params PolicyParams,
+	cfg Config,
+	log logr.Logger,
+) error {
+	if !cfg.IsOperational() {
+		return nil
+	}
+
+	desired := constructSecurityPolicy(params, cfg)
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(SecurityPolicyGVK)
+	err := c.Get(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace}, existing)
+	if err != nil && apierrors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(owner, desired, scheme); err != nil {
+			return fmt.Errorf("set controller reference on SecurityPolicy: %w", err)
+		}
+		log.Info("Creating SecurityPolicy", "name", params.Name, "namespace", params.Namespace)
+		return c.Create(ctx, desired)
+	} else if err != nil {
+		return err
+	}
+
+	spec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+	if err := unstructured.SetNestedMap(existing.Object, spec, "spec"); err != nil {
+		return fmt.Errorf("update SecurityPolicy spec: %w", err)
+	}
+	return c.Update(ctx, existing)
+}

--- a/operator/pkg/security/securitypolicy_test.go
+++ b/operator/pkg/security/securitypolicy_test.go
@@ -7,13 +7,7 @@ import (
 )
 
 func operationalConfig() Config {
-	return Config{
-		Enabled:                  true,
-		ExtAuthzServiceName:      "aib-access-check",
-		ExtAuthzServiceNamespace: "kaos-system",
-		ExtAuthzServicePort:      9191,
-		DefaultAction:            "access",
-	}
+	return Config{ExtAuthzURL: "aib-access-check.kaos-system.svc.cluster.local:9191"}
 }
 
 func TestConstructSecurityPolicyShape(t *testing.T) {
@@ -24,7 +18,10 @@ func TestConstructSecurityPolicyShape(t *testing.T) {
 		Labels:    map[string]string{"app": "kaos"},
 	}
 
-	policy := constructSecurityPolicy(params, operationalConfig())
+	policy, err := constructSecurityPolicy(params, operationalConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if gvk := policy.GroupVersionKind(); gvk != SecurityPolicyGVK {
 		t.Fatalf("unexpected GVK %v", gvk)
@@ -50,6 +47,14 @@ func TestConstructSecurityPolicyShape(t *testing.T) {
 		t.Errorf("expected failOpen=false, got %v (found=%v err=%v)", failOpen, found, err)
 	}
 
+	headers, found, err := unstructured.NestedStringSlice(policy.Object, "spec", "extAuth", "headersToExtAuth")
+	if err != nil || !found {
+		t.Fatalf("expected headersToExtAuth, found=%v err=%v", found, err)
+	}
+	if len(headers) != 2 || headers[0] != "authorization" || headers[1] != "x-agent-authorization" {
+		t.Errorf("unexpected headersToExtAuth %#v", headers)
+	}
+
 	backendRef, found, err := unstructured.NestedMap(policy.Object, "spec", "extAuth", "grpc", "backendRef")
 	if err != nil || !found {
 		t.Fatalf("expected grpc backendRef, found=%v err=%v", found, err)
@@ -64,8 +69,17 @@ func TestConstructSecurityPolicyShape(t *testing.T) {
 }
 
 func TestConstructSecurityPolicyNoLabels(t *testing.T) {
-	policy := constructSecurityPolicy(PolicyParams{Name: "a", Namespace: "ns", RouteName: "a"}, operationalConfig())
+	policy, err := constructSecurityPolicy(PolicyParams{Name: "a", Namespace: "ns", RouteName: "a"}, operationalConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(policy.GetLabels()) != 0 {
 		t.Errorf("expected no labels, got %v", policy.GetLabels())
+	}
+}
+
+func TestConstructSecurityPolicyInvalidConfig(t *testing.T) {
+	if _, err := constructSecurityPolicy(PolicyParams{Name: "a", Namespace: "ns", RouteName: "a"}, Config{ExtAuthzURL: "no-port"}); err == nil {
+		t.Errorf("expected error for malformed ext_authz URL")
 	}
 }

--- a/operator/pkg/security/securitypolicy_test.go
+++ b/operator/pkg/security/securitypolicy_test.go
@@ -1,0 +1,71 @@
+package security
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func operationalConfig() Config {
+	return Config{
+		Enabled:                  true,
+		ExtAuthzServiceName:      "aib-access-check",
+		ExtAuthzServiceNamespace: "kaos-system",
+		ExtAuthzServicePort:      9191,
+		DefaultAction:            "access",
+	}
+}
+
+func TestConstructSecurityPolicyShape(t *testing.T) {
+	params := PolicyParams{
+		Name:      "mcp-github",
+		Namespace: "default",
+		RouteName: "mcp-github",
+		Labels:    map[string]string{"app": "kaos"},
+	}
+
+	policy := constructSecurityPolicy(params, operationalConfig())
+
+	if gvk := policy.GroupVersionKind(); gvk != SecurityPolicyGVK {
+		t.Fatalf("unexpected GVK %v", gvk)
+	}
+	if policy.GetName() != "mcp-github" || policy.GetNamespace() != "default" {
+		t.Fatalf("unexpected name/namespace %s/%s", policy.GetName(), policy.GetNamespace())
+	}
+	if policy.GetLabels()["app"] != "kaos" {
+		t.Errorf("expected app=kaos label")
+	}
+
+	targetRefs, found, err := unstructured.NestedSlice(policy.Object, "spec", "targetRefs")
+	if err != nil || !found || len(targetRefs) != 1 {
+		t.Fatalf("expected one targetRef, got found=%v err=%v len=%d", found, err, len(targetRefs))
+	}
+	ref := targetRefs[0].(map[string]interface{})
+	if ref["group"] != "gateway.networking.k8s.io" || ref["kind"] != "HTTPRoute" || ref["name"] != "mcp-github" {
+		t.Errorf("unexpected targetRef %#v", ref)
+	}
+
+	failOpen, found, err := unstructured.NestedBool(policy.Object, "spec", "extAuth", "failOpen")
+	if err != nil || !found || failOpen {
+		t.Errorf("expected failOpen=false, got %v (found=%v err=%v)", failOpen, found, err)
+	}
+
+	backendRef, found, err := unstructured.NestedMap(policy.Object, "spec", "extAuth", "grpc", "backendRef")
+	if err != nil || !found {
+		t.Fatalf("expected grpc backendRef, found=%v err=%v", found, err)
+	}
+	if backendRef["kind"] != "Service" || backendRef["name"] != "aib-access-check" ||
+		backendRef["namespace"] != "kaos-system" {
+		t.Errorf("unexpected backendRef %#v", backendRef)
+	}
+	if port, ok := backendRef["port"].(int64); !ok || port != 9191 {
+		t.Errorf("expected port int64(9191), got %#v", backendRef["port"])
+	}
+}
+
+func TestConstructSecurityPolicyNoLabels(t *testing.T) {
+	policy := constructSecurityPolicy(PolicyParams{Name: "a", Namespace: "ns", RouteName: "a"}, operationalConfig())
+	if len(policy.GetLabels()) != 0 {
+		t.Errorf("expected no labels, got %v", policy.GetLabels())
+	}
+}


### PR DESCRIPTION
Adds operator-generated Envoy Gateway authorization policies so each protected route (Agent, MCPServer, ModelAPI) is gated by an external access-check that decides allow/deny on the calling agent and fails closed.

## What's included
- New `pkg/security` config (Helm values → configmap env → struct), default off; absent config = no behaviour change.
- Per-route `SecurityPolicy` (unstructured `gateway.envoyproxy.io/v1alpha1`) generation targeting the route's HTTPRoute, with `extAuth.grpc` → the configured access-check service and `failOpen: false`.
- Wired into agent/mcpserver/modelapi controllers after HTTPRoute reconcile; owned via SetControllerReference; RBAC for securitypolicies; regenerated manifests and chart RBAC.

## Validation
- `go test ./...` green (controllers, integration/envtest, pkg/security).
- `helm template` both enabled/disabled modes.
- Live KIND: generated SecurityPolicy shape Accepted by EG v1.4.6; real gateway request 200 → 403 (fail-closed) when policy attached, with `x-kaos-access-reason` propagated, → 200 when removed.

Stacked on `feat/p1-sdk-propagation`.