### PR TITLE
PR-ADR-KAOS-3: Install and sync wiring for agent authentication

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'pydantic-ai-server/**'
       - 'kaos-cli/**'
+      - 'sync-service/**'
       - 'operator/config/samples/**'
       - '.github/workflows/python-tests.yaml'
   push:
@@ -13,6 +14,7 @@ on:
     paths:
       - 'pydantic-ai-server/**'
       - 'kaos-cli/**'
+      - 'sync-service/**'
       - 'operator/config/samples/**'
       - '.github/workflows/python-tests.yaml'
   workflow_dispatch:
@@ -102,4 +104,29 @@ jobs:
           source .venv/bin/activate
           uv pip install -e .
           uv pip install pytest pyyaml
+          python -m pytest tests/ -v
+
+  sync-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Run sync service tests
+        working-directory: sync-service
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install -e .
+          uv pip install pytest black
+          black --check kaos_sync tests
           python -m pytest tests/ -v

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -22,6 +22,15 @@ GATEWAY_CLASS_NAME = "envoy-gateway"
 # MetalLB defaults
 METALLB_VERSION = "v0.14.9"
 
+# Agent-auth (identity broker) defaults
+DEFAULT_AUTH_NAMESPACE = "aib-system"
+DEFAULT_AUTH_RELEASE = "aib"
+DEFAULT_CREDENTIAL_SECRET_PREFIX = "kaos-aib"
+# Conventional in-cluster service names exposed by the broker stack.
+AUTH_EXT_AUTHZ_PORT = 9191
+AUTH_ENDUSER_PORT = 8000
+AUTH_ADMIN_PORT = 14000
+DEFAULT_SYNC_RELEASE = "kaos-sync"
 # KAOS CRD names (for explicit install/uninstall)
 KAOS_CRDS = [
     "agents.kaos.tools",
@@ -56,7 +65,9 @@ def run_helm_command(
 MONITORING_BACKENDS = ("signoz", "jaeger")
 
 
-def _run_kubectl(args: list[str], check: bool = True, **kwargs) -> subprocess.CompletedProcess:
+def _run_kubectl(
+    args: list[str], check: bool = True, **kwargs
+) -> subprocess.CompletedProcess:
     """Run a kubectl command and return the result."""
     cmd = ["kubectl"] + args
     return subprocess.run(cmd, capture_output=True, text=True, check=check, **kwargs)
@@ -68,15 +79,21 @@ def _install_gateway_api() -> bool:
 
     # Pre-apply CRDs from the chart to handle field manager conflicts on re-installs
     crds_result = run_helm_command(
-        ["show", "crds", "oci://docker.io/envoyproxy/gateway-helm",
-         "--version", ENVOY_GATEWAY_VERSION],
+        [
+            "show",
+            "crds",
+            "oci://docker.io/envoyproxy/gateway-helm",
+            "--version",
+            ENVOY_GATEWAY_VERSION,
+        ],
         check=False,
     )
     crd_pre_applied = False
     if crds_result.returncode == 0 and crds_result.stdout.strip():
         result = _run_kubectl(
             ["apply", "--server-side", "--force-conflicts", "-f", "-"],
-            check=False, input=crds_result.stdout,
+            check=False,
+            input=crds_result.stdout,
         )
         if result.returncode == 0:
             crd_pre_applied = True
@@ -84,29 +101,45 @@ def _install_gateway_api() -> bool:
             # Stale CRDs with incompatible storedVersions — delete and let helm recreate
             typer.echo("  Cleaning up stale Gateway API CRDs...")
             _run_kubectl(
-                ["delete", "crd", "--ignore-not-found",
-                 "-l", "gateway.networking.k8s.io/policy"],
+                [
+                    "delete",
+                    "crd",
+                    "--ignore-not-found",
+                    "-l",
+                    "gateway.networking.k8s.io/policy",
+                ],
                 check=False,
             )
             _run_kubectl(
-                ["delete", "crd", "--ignore-not-found",
-                 "gatewayclasses.gateway.networking.k8s.io",
-                 "gateways.gateway.networking.k8s.io",
-                 "httproutes.gateway.networking.k8s.io",
-                 "grpcroutes.gateway.networking.k8s.io",
-                 "referencegrants.gateway.networking.k8s.io",
-                 "tcproutes.gateway.networking.k8s.io",
-                 "tlsroutes.gateway.networking.k8s.io",
-                 "udproutes.gateway.networking.k8s.io",
-                 "backendtlspolicies.gateway.networking.k8s.io"],
+                [
+                    "delete",
+                    "crd",
+                    "--ignore-not-found",
+                    "gatewayclasses.gateway.networking.k8s.io",
+                    "gateways.gateway.networking.k8s.io",
+                    "httproutes.gateway.networking.k8s.io",
+                    "grpcroutes.gateway.networking.k8s.io",
+                    "referencegrants.gateway.networking.k8s.io",
+                    "tcproutes.gateway.networking.k8s.io",
+                    "tlsroutes.gateway.networking.k8s.io",
+                    "udproutes.gateway.networking.k8s.io",
+                    "backendtlspolicies.gateway.networking.k8s.io",
+                ],
                 check=False,
             )
 
     result = run_helm_command(
-        ["upgrade", "--install", "envoy-gateway",
-         "oci://docker.io/envoyproxy/gateway-helm",
-         "--version", ENVOY_GATEWAY_VERSION,
-         "--namespace", "envoy-gateway-system", "--create-namespace"]
+        [
+            "upgrade",
+            "--install",
+            "envoy-gateway",
+            "oci://docker.io/envoyproxy/gateway-helm",
+            "--version",
+            ENVOY_GATEWAY_VERSION,
+            "--namespace",
+            "envoy-gateway-system",
+            "--create-namespace",
+        ]
         + (["--skip-crds"] if crd_pre_applied else []),
         check=False,
     )
@@ -137,8 +170,13 @@ def _wait_for_gateway_class() -> bool:
     typer.echo("Waiting for GatewayClass to be accepted...")
     for i in range(30):
         result = _run_kubectl(
-            ["get", "gatewayclass", GATEWAY_CLASS_NAME,
-             "-o", "jsonpath={.status.conditions[?(@.type==\"Accepted\")].status}"],
+            [
+                "get",
+                "gatewayclass",
+                GATEWAY_CLASS_NAME,
+                "-o",
+                'jsonpath={.status.conditions[?(@.type=="Accepted")].status}',
+            ],
             check=False,
         )
         if result.stdout.strip() == "True":
@@ -162,8 +200,14 @@ def _uninstall_gateway_api() -> bool:
     if result.returncode != 0 and "not found" not in result.stderr.lower():
         typer.echo(f"Warning: {result.stderr}", err=True)
 
-    _run_kubectl(["delete", "gatewayclass", GATEWAY_CLASS_NAME, "--ignore-not-found"], check=False)
-    _run_kubectl(["delete", "namespace", "envoy-gateway-system", "--ignore-not-found"], check=False)
+    _run_kubectl(
+        ["delete", "gatewayclass", GATEWAY_CLASS_NAME, "--ignore-not-found"],
+        check=False,
+    )
+    _run_kubectl(
+        ["delete", "namespace", "envoy-gateway-system", "--ignore-not-found"],
+        check=False,
+    )
     typer.echo("✅ Gateway API uninstalled")
     return True
 
@@ -172,8 +216,11 @@ def _install_metallb() -> bool:
     """Install MetalLB for LoadBalancer support (KIND/bare-metal clusters)."""
     typer.echo(f"Installing MetalLB ({METALLB_VERSION})...")
     result = _run_kubectl(
-        ["apply", "-f",
-         f"https://raw.githubusercontent.com/metallb/metallb/{METALLB_VERSION}/config/manifests/metallb-native.yaml"],
+        [
+            "apply",
+            "-f",
+            f"https://raw.githubusercontent.com/metallb/metallb/{METALLB_VERSION}/config/manifests/metallb-native.yaml",
+        ],
         check=False,
     )
     if result.returncode != 0:
@@ -188,9 +235,15 @@ def _configure_metallb() -> bool:
     """Wait for MetalLB to be ready and configure IP address pool."""
     typer.echo("Waiting for MetalLB pods...")
     result = _run_kubectl(
-        ["wait", "--namespace", "metallb-system",
-         "--for=condition=ready", "pod", "--selector=app=metallb",
-         "--timeout=120s"],
+        [
+            "wait",
+            "--namespace",
+            "metallb-system",
+            "--for=condition=ready",
+            "pod",
+            "--selector=app=metallb",
+            "--timeout=120s",
+        ],
         check=False,
     )
     if result.returncode != 0:
@@ -200,9 +253,17 @@ def _configure_metallb() -> bool:
     try:
         # Get all IPAM subnets and find the IPv4 one
         net_result = subprocess.run(
-            ["docker", "network", "inspect", "kind", "--format",
-             "{{range .IPAM.Config}}{{.Subnet}} {{end}}"],
-            capture_output=True, text=True, check=False,
+            [
+                "docker",
+                "network",
+                "inspect",
+                "kind",
+                "--format",
+                "{{range .IPAM.Config}}{{.Subnet}} {{end}}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
         )
         ip_start = "172.18.255.200"
         ip_end = "172.18.255.250"
@@ -236,11 +297,16 @@ def _configure_metallb() -> bool:
         )
         result = _run_kubectl(["apply", "-f", "-"], check=False, input=pool_yaml)
         if result.returncode != 0:
-            typer.echo(f"Warning: Could not configure MetalLB pool: {result.stderr}", err=True)
+            typer.echo(
+                f"Warning: Could not configure MetalLB pool: {result.stderr}", err=True
+            )
         else:
             typer.echo(f"  IP range: {ip_start}-{ip_end}")
     except FileNotFoundError:
-        typer.echo("Warning: docker not found, skipping MetalLB IP pool configuration", err=True)
+        typer.echo(
+            "Warning: docker not found, skipping MetalLB IP pool configuration",
+            err=True,
+        )
 
     return True
 
@@ -249,12 +315,17 @@ def _uninstall_metallb() -> bool:
     """Uninstall MetalLB."""
     typer.echo("Uninstalling MetalLB...")
     _run_kubectl(
-        ["delete", "-f",
-         f"https://raw.githubusercontent.com/metallb/metallb/{METALLB_VERSION}/config/manifests/metallb-native.yaml",
-         "--ignore-not-found"],
+        [
+            "delete",
+            "-f",
+            f"https://raw.githubusercontent.com/metallb/metallb/{METALLB_VERSION}/config/manifests/metallb-native.yaml",
+            "--ignore-not-found",
+        ],
         check=False,
     )
-    _run_kubectl(["delete", "namespace", "metallb-system", "--ignore-not-found"], check=False)
+    _run_kubectl(
+        ["delete", "namespace", "metallb-system", "--ignore-not-found"], check=False
+    )
     typer.echo("✅ MetalLB uninstalled")
     return True
 
@@ -274,7 +345,9 @@ def _create_jaeger_ui_config(namespace: str) -> None:
         text=True,
     )
     if result.returncode != 0:
-        typer.echo(f"Warning: Could not create Jaeger UI config: {result.stderr}", err=True)
+        typer.echo(
+            f"Warning: Could not create Jaeger UI config: {result.stderr}", err=True
+        )
 
 
 def _install_signoz(namespace: str) -> bool:
@@ -383,7 +456,13 @@ def _install_redis(namespace: str) -> bool:
     typer.echo("Installing Redis...")
 
     result = run_helm_command(
-        ["repo", "add", "bitnami", "https://charts.bitnami.com/bitnami", "--force-update"],
+        [
+            "repo",
+            "add",
+            "bitnami",
+            "https://charts.bitnami.com/bitnami",
+            "--force-update",
+        ],
         check=False,
     )
     if result.returncode != 0 and "already exists" not in result.stderr:
@@ -435,6 +514,120 @@ def _uninstall_redis(namespace: str) -> bool:
         return False
 
 
+def _auth_broker_fullname(auth_release: str) -> str:
+    """Return the broker Service/Deployment name produced by the broker chart."""
+    return f"{auth_release}-agentic-identity-broker"
+
+
+def _default_ext_authz_url(auth_namespace: str) -> str:
+    """Default host:port of the broker access-check gRPC backend."""
+    return f"aib-access-check-grpc.{auth_namespace}.svc.cluster.local:{AUTH_EXT_AUTHZ_PORT}"
+
+
+def _default_auth_issuer(auth_namespace: str, auth_release: str) -> str:
+    """Default issuer (broker enduser endpoint) propagated to agent pods."""
+    host = f"{_auth_broker_fullname(auth_release)}.{auth_namespace}.svc.cluster.local"
+    return f"http://{host}:{AUTH_ENDUSER_PORT}"
+
+
+def _default_auth_admin_url(auth_namespace: str, auth_release: str) -> str:
+    """Default broker admin API base URL used by the sync service."""
+    host = f"{_auth_broker_fullname(auth_release)}.{auth_namespace}.svc.cluster.local"
+    return f"http://{host}:{AUTH_ADMIN_PORT}/api"
+
+
+def _build_auth_operator_args(
+    ext_authz_url: str,
+    issuer: str,
+    credential_secret_prefix: str,
+) -> list[str]:
+    """Build the operator Helm --set arguments that enable agent-auth wiring.
+
+    Returns the flat ``--set key=value`` argument list so it can be unit-tested
+    independently of running Helm.
+    """
+    args: list[str] = []
+    args.extend(["--set", f"security.agentAuth.extAuthzUrl={ext_authz_url}"])
+    args.extend(["--set", f"security.agentAuth.issuer={issuer}"])
+    args.extend(
+        [
+            "--set",
+            f"security.agentAuth.credentialSecretPrefix={credential_secret_prefix}",
+        ]
+    )
+    return args
+
+
+def _deploy_sync_service(
+    namespace: str,
+    release: str,
+    chart_path: str,
+    admin_url: str,
+    credential_secret_prefix: str,
+    image_repository: str | None,
+    image_tag: str | None,
+) -> bool:
+    """Deploy the KAOS sync service that projects resources into the broker."""
+    typer.echo("Deploying sync service...")
+    helm_args = [
+        "upgrade",
+        "--install",
+        release,
+        chart_path,
+        "--namespace",
+        namespace,
+        "--create-namespace",
+        "--set",
+        f"broker.adminUrl={admin_url}",
+        "--set",
+        f"sync.credentialSecretPrefix={credential_secret_prefix}",
+    ]
+    if image_repository:
+        helm_args.extend(["--set", f"image.repository={image_repository}"])
+    if image_tag:
+        helm_args.extend(["--set", f"image.tag={image_tag}"])
+
+    result = run_helm_command(helm_args, check=False)
+    if result.returncode != 0:
+        typer.echo(f"Error deploying sync service: {result.stderr}", err=True)
+        return False
+
+    typer.echo(f"✅ Sync service deployed in '{namespace}' namespace")
+    return True
+
+
+def _install_aib(
+    namespace: str,
+    release: str,
+    chart_path: str,
+    values_path: str | None,
+    wait: bool,
+) -> bool:
+    """Install the identity broker from a local chart (unpublished/dev path)."""
+    typer.echo("Installing identity broker...")
+    helm_args = [
+        "upgrade",
+        "--install",
+        release,
+        chart_path,
+        "--namespace",
+        namespace,
+        "--create-namespace",
+    ]
+    if values_path:
+        helm_args.extend(["--values", values_path])
+    if wait:
+        helm_args.append("--wait")
+
+    result = run_helm_command(helm_args, check=False)
+    if result.returncode != 0:
+        typer.echo(f"Error installing identity broker: {result.stderr}", err=True)
+        return False
+
+    typer.echo(f"✅ Identity broker installed in '{namespace}' namespace")
+    return True
+
+
 def _uninstall_monitoring(backend: str, namespace: str) -> bool:
     """Uninstall monitoring stack for the given backend."""
     release = "jaeger" if backend == "jaeger" else "signoz"
@@ -449,15 +642,24 @@ def _uninstall_monitoring(backend: str, namespace: str) -> bool:
         # Clean up Jaeger UI ConfigMap if applicable
         if backend == "jaeger":
             subprocess.run(
-                ["kubectl", "delete", "configmap", "jaeger-ui-config",
-                 "-n", namespace, "--ignore-not-found"],
+                [
+                    "kubectl",
+                    "delete",
+                    "configmap",
+                    "jaeger-ui-config",
+                    "-n",
+                    namespace,
+                    "--ignore-not-found",
+                ],
                 capture_output=True,
                 text=True,
             )
         typer.echo(f"✅ {backend.capitalize()} uninstalled from '{namespace}'")
         return True
     elif "not found" in result.stderr.lower():
-        typer.echo(f"{backend.capitalize()} release not found in namespace '{namespace}'.")
+        typer.echo(
+            f"{backend.capitalize()} release not found in namespace '{namespace}'."
+        )
         return True
     else:
         typer.echo(f"Error uninstalling {backend}: {result.stderr}", err=True)
@@ -482,6 +684,17 @@ def install_command(
     metallb_enabled: bool = False,
     redis_enabled: bool = False,
     chart_path: str | None = None,
+    auth_enabled: bool = False,
+    auth_namespace: str = DEFAULT_AUTH_NAMESPACE,
+    auth_release: str = DEFAULT_AUTH_RELEASE,
+    ext_authz_url: str | None = None,
+    auth_issuer: str | None = None,
+    credential_secret_prefix: str = DEFAULT_CREDENTIAL_SECRET_PREFIX,
+    aib_chart_path: str | None = None,
+    aib_values_path: str | None = None,
+    sync_chart_path: str | None = None,
+    sync_image_repository: str | None = None,
+    sync_image_tag: str | None = None,
 ) -> None:
     """Install the KAOS operator using Helm."""
     if not check_helm_installed():
@@ -496,15 +709,60 @@ def install_command(
 
     if gateway_enabled:
         if not _install_gateway_api():
-            typer.echo("Warning: Gateway API installation failed, continuing...", err=True)
+            typer.echo(
+                "Warning: Gateway API installation failed, continuing...", err=True
+            )
 
     if monitoring_enabled:
         if not _install_monitoring(monitoring_enabled, namespace):
-            typer.echo("Warning: Monitoring installation failed, continuing...", err=True)
+            typer.echo(
+                "Warning: Monitoring installation failed, continuing...", err=True
+            )
 
     if redis_enabled:
         if not _install_redis(namespace):
             typer.echo("Warning: Redis installation failed, continuing...", err=True)
+
+    # Resolve agent-auth endpoints (used for both component installs and operator wiring)
+    if auth_enabled:
+        ext_authz_url = ext_authz_url or _default_ext_authz_url(auth_namespace)
+        auth_issuer = auth_issuer or _default_auth_issuer(auth_namespace, auth_release)
+        auth_admin_url = _default_auth_admin_url(auth_namespace, auth_release)
+
+        # Install the identity broker from a local chart when provided (it is
+        # unpublished, so a chart path is required to install it here).
+        if aib_chart_path:
+            if not _install_aib(
+                auth_namespace, auth_release, aib_chart_path, aib_values_path, wait
+            ):
+                typer.echo(
+                    "Warning: identity broker installation failed, continuing...",
+                    err=True,
+                )
+        else:
+            typer.echo(
+                "Note: --aib-chart-path not provided; assuming the identity broker "
+                f"is already installed in namespace '{auth_namespace}'.",
+            )
+
+        # Deploy the sync service when a chart path is provided.
+        if sync_chart_path:
+            if not _deploy_sync_service(
+                auth_namespace,
+                DEFAULT_SYNC_RELEASE,
+                sync_chart_path,
+                auth_admin_url,
+                credential_secret_prefix,
+                sync_image_repository,
+                sync_image_tag,
+            ):
+                typer.echo(
+                    "Warning: sync service deployment failed, continuing...", err=True
+                )
+        else:
+            typer.echo(
+                "Note: --sync-chart-path not provided; skipping sync service deployment.",
+            )
 
     # Phase 2: Wait for infra that the operator depends on
     if gateway_enabled:
@@ -558,7 +816,8 @@ def install_command(
         if crds_result.returncode == 0 and crds_result.stdout.strip():
             result = _run_kubectl(
                 ["apply", "--server-side", "--force-conflicts", "-f", "-"],
-                check=False, input=crds_result.stdout,
+                check=False,
+                input=crds_result.stdout,
             )
             if result.returncode != 0:
                 typer.echo(f"Warning: CRD apply failed: {result.stderr}", err=True)
@@ -606,6 +865,15 @@ def install_command(
         helm_args.extend(["--set", "agentDefaults.memory.type=redis"])
         redis_url = f"redis://redis-master.{namespace}:6379"
         helm_args.extend(["--set", f"agentDefaults.memory.redisUrl={redis_url}"])
+
+    if auth_enabled:
+        helm_args.extend(
+            _build_auth_operator_args(
+                ext_authz_url or _default_ext_authz_url(auth_namespace),
+                auth_issuer or _default_auth_issuer(auth_namespace, auth_release),
+                credential_secret_prefix,
+            )
+        )
 
     typer.echo(f"Installing chart {HELM_CHART_NAME}...")
     result = run_helm_command(helm_args)

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -92,6 +92,54 @@ def install(
         "--chart-path",
         help="Path to local Helm chart directory (for development). Uses published chart if not set.",
     ),
+    auth_enabled: bool = typer.Option(
+        False,
+        "--auth-enabled",
+        help="Enable agent authentication: wire the operator to the identity broker, "
+        "mount per-agent credentials, and optionally install the broker and sync service.",
+    ),
+    auth_namespace: str = typer.Option(
+        "aib-system",
+        "--auth-namespace",
+        help="Namespace for the identity broker and sync service.",
+    ),
+    ext_authz_url: str | None = typer.Option(
+        None,
+        "--ext-authz-url",
+        help="Override the access-check gRPC backend host:port. Defaults to the "
+        "conventional service in the auth namespace.",
+    ),
+    auth_issuer: str | None = typer.Option(
+        None,
+        "--auth-issuer",
+        help="Override the broker issuer URL propagated to agent pods. Defaults to the "
+        "broker enduser service in the auth namespace.",
+    ),
+    aib_chart_path: str | None = typer.Option(
+        None,
+        "--aib-chart-path",
+        help="Path to a local identity broker Helm chart to install (unpublished/dev path).",
+    ),
+    aib_values_path: str | None = typer.Option(
+        None,
+        "--aib-values",
+        help="Values file for the identity broker chart (e.g. the dev preset).",
+    ),
+    sync_chart_path: str | None = typer.Option(
+        None,
+        "--sync-chart-path",
+        help="Path to the sync service Helm chart to deploy.",
+    ),
+    sync_image_repository: str | None = typer.Option(
+        None,
+        "--sync-image-repository",
+        help="Override the sync service image repository (for local/dev images).",
+    ),
+    sync_image_tag: str | None = typer.Option(
+        None,
+        "--sync-image-tag",
+        help="Override the sync service image tag (for local/dev images).",
+    ),
 ) -> None:
     """Install the KAOS operator using Helm."""
     # Default to signoz if flag provided without value
@@ -112,6 +160,15 @@ def install(
         metallb_enabled=metallb_enabled,
         redis_enabled=redis_enabled,
         chart_path=chart_path,
+        auth_enabled=auth_enabled,
+        auth_namespace=auth_namespace,
+        ext_authz_url=ext_authz_url,
+        auth_issuer=auth_issuer,
+        aib_chart_path=aib_chart_path,
+        aib_values_path=aib_values_path,
+        sync_chart_path=sync_chart_path,
+        sync_image_repository=sync_image_repository,
+        sync_image_tag=sync_image_tag,
     )
 
 
@@ -127,7 +184,8 @@ def uninstall(
         DEFAULT_RELEASE_NAME,
         "--release-name",
         help="Helm release name.",
-    ),    monitoring_enabled: str | None = typer.Option(
+    ),
+    monitoring_enabled: str | None = typer.Option(
         None,
         "--monitoring-enabled",
         help=f"Also uninstall monitoring stack. Options: {', '.join(MONITORING_BACKENDS)}.",

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -11,6 +11,7 @@ from kaos_cli.main import app
 def strip_ansi(text: str) -> str:
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
+
 runner = CliRunner()
 
 
@@ -257,9 +258,15 @@ class TestAgentDeployAutonomous:
         result = runner.invoke(
             app,
             [
-                "agent", "deploy", "auto-agent",
-                "--modelapi", "api", "--model", "m1",
-                "--autonomous", "Monitor system health",
+                "agent",
+                "deploy",
+                "auto-agent",
+                "--modelapi",
+                "api",
+                "--model",
+                "m1",
+                "--autonomous",
+                "Monitor system health",
                 "--dry-run",
             ],
         )
@@ -274,14 +281,25 @@ class TestAgentDeployAutonomous:
         result = runner.invoke(
             app,
             [
-                "agent", "deploy", "auto-agent",
-                "--modelapi", "api", "--model", "m1",
-                "--autonomous", "Check health",
-                "--auto-max-iter-runtime", "120",
-                "--auto-interval", "5.0",
-                "--task-max-iterations", "20",
-                "--task-max-runtime", "600",
-                "--task-max-tool-calls", "100",
+                "agent",
+                "deploy",
+                "auto-agent",
+                "--modelapi",
+                "api",
+                "--model",
+                "m1",
+                "--autonomous",
+                "Check health",
+                "--auto-max-iter-runtime",
+                "120",
+                "--auto-interval",
+                "5.0",
+                "--task-max-iterations",
+                "20",
+                "--task-max-runtime",
+                "600",
+                "--task-max-tool-calls",
+                "100",
                 "--dry-run",
             ],
         )
@@ -302,9 +320,15 @@ class TestAgentDeployAutonomous:
         result = runner.invoke(
             app,
             [
-                "agent", "deploy", "auto-agent",
-                "--modelapi", "api", "--model", "m1",
-                "--task-max-iterations", "0",
+                "agent",
+                "deploy",
+                "auto-agent",
+                "--modelapi",
+                "api",
+                "--model",
+                "m1",
+                "--task-max-iterations",
+                "0",
                 "--dry-run",
             ],
         )
@@ -318,11 +342,19 @@ class TestAgentDeployAutonomous:
         result = runner.invoke(
             app,
             [
-                "agent", "deploy", "auto-agent",
-                "--modelapi", "api", "--model", "m1",
-                "--description", "Auto agent",
-                "--autonomous", "Do work",
-                "--mcp", "echo-mcp",
+                "agent",
+                "deploy",
+                "auto-agent",
+                "--modelapi",
+                "api",
+                "--model",
+                "m1",
+                "--description",
+                "Auto agent",
+                "--autonomous",
+                "Do work",
+                "--mcp",
+                "echo-mcp",
                 "--dry-run",
             ],
         )
@@ -337,8 +369,13 @@ class TestAgentDeployAutonomous:
         result = runner.invoke(
             app,
             [
-                "agent", "deploy", "basic-agent",
-                "--modelapi", "api", "--model", "m1",
+                "agent",
+                "deploy",
+                "basic-agent",
+                "--modelapi",
+                "api",
+                "--model",
+                "m1",
                 "--dry-run",
             ],
         )
@@ -508,7 +545,7 @@ class TestMCPDeployDryRun:
                 "--runtime",
                 "python-string",
                 "--params",
-                'def echo(msg: str) -> str:\n    return msg',
+                "def echo(msg: str) -> str:\n    return msg",
                 "--dry-run",
             ],
         )
@@ -701,9 +738,7 @@ class TestSamples:
         assert "Invalid --api-secret format" in result.output
 
     def test_deploy_nonexistent_sample(self):
-        result = runner.invoke(
-            app, ["samples", "deploy", "nonexistent", "--dry-run"]
-        )
+        result = runner.invoke(app, ["samples", "deploy", "nonexistent", "--dry-run"])
         assert result.exit_code != 0
 
     def test_deploy_hierarchical_dry_run(self):
@@ -741,10 +776,12 @@ class TestSamples:
         docs = list(yaml.safe_load_all(result.output))
         for doc in docs:
             if doc:
-                assert doc["kind"] != "Namespace", "Namespace doc should be filtered out"
-                assert doc["metadata"].get("namespace") == "test-ns", (
-                    f"{doc['kind']} {doc['metadata']['name']} missing namespace override"
-                )
+                assert (
+                    doc["kind"] != "Namespace"
+                ), "Namespace doc should be filtered out"
+                assert (
+                    doc["metadata"].get("namespace") == "test-ns"
+                ), f"{doc['kind']} {doc['metadata']['name']} missing namespace override"
 
     def test_modelapi_override_skips_modelapi_resource(self):
         """When --modelapi is used, ModelAPI resources are filtered out."""
@@ -785,10 +822,12 @@ class TestSamples:
 class TestPackageData:
     def test_samples_dir_resolves(self):
         from kaos_cli.samples import SAMPLES_DIR
+
         assert SAMPLES_DIR.exists(), f"SAMPLES_DIR not found: {SAMPLES_DIR}"
 
     def test_samples_dir_contains_files(self):
         from kaos_cli.samples import _get_sample_files
+
         files = _get_sample_files()
         assert len(files) == 6
         names = [f.stem for f in files]
@@ -812,9 +851,7 @@ class TestMonitoringValidation:
         from unittest.mock import patch
 
         with patch("kaos_cli.ui.check_monitoring_service", return_value=False):
-            result = runner.invoke(
-                app, ["ui", "--monitoring-enabled", "--no-browser"]
-            )
+            result = runner.invoke(app, ["ui", "--monitoring-enabled", "--no-browser"])
         # Should not error on invalid backend; fails on service not found instead
         assert "Invalid monitoring backend" not in result.output
         assert "signoz" in result.output.lower()
@@ -840,21 +877,97 @@ class TestSystemInstallFlags:
         assert "--metallb-enabled" in output
         assert "--redis-enabled" in output
 
-    def test_install_invalid_monitoring_backend(self):
-        result = runner.invoke(
-            app, ["system", "install", "--monitoring-enabled", "invalid"]
+    def test_install_help_shows_auth_flag(self):
+        result = runner.invoke(app, ["system", "install", "--help"])
+        assert result.exit_code == 0
+        output = strip_ansi(result.output)
+        assert "--auth-enabled" in output
+        assert "--auth-namespace" in output
+        assert "--sync-chart-path" in output
+
+
+class TestAuthWiring:
+    def test_build_auth_operator_args(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
         )
-        assert result.exit_code != 0
-        assert "Invalid monitoring backend" in result.output
+        joined = " ".join(args)
+        assert (
+            "security.agentAuth.extAuthzUrl=aib-access-check-grpc.aib-system:9191"
+            in joined
+        )
+        assert "security.agentAuth.issuer=http://aib.aib-system:8000" in joined
+        assert "security.agentAuth.credentialSecretPrefix=kaos-aib" in joined
+        # Each value is preceded by a --set flag.
+        assert args.count("--set") == 3
+
+    def test_default_endpoints_use_auth_namespace(self):
+        from kaos_cli.install import (
+            _default_ext_authz_url,
+            _default_auth_issuer,
+            _default_auth_admin_url,
+        )
+
+        assert _default_ext_authz_url("custom-ns").startswith(
+            "aib-access-check-grpc.custom-ns"
+        )
+        assert _default_ext_authz_url("custom-ns").endswith(":9191")
+        assert "custom-ns" in _default_auth_issuer("custom-ns", "aib")
+        assert _default_auth_admin_url("custom-ns", "aib").endswith("/api")
+        assert "aib-agentic-identity-broker.custom-ns" in _default_auth_admin_url(
+            "custom-ns", "aib"
+        )
+
+    def test_auth_enabled_wires_operator_security_values(self):
+        """--auth-enabled adds the security.agentAuth.* helm --set args."""
+        from unittest.mock import patch
+
+        captured = {}
+
+        def fake_helm(args, check=True, **kwargs):
+            from types import SimpleNamespace
+
+            # Capture the operator upgrade invocation.
+            if "upgrade" in args and any(
+                "kaos-operator" in a or a.endswith("/chart") for a in args
+            ):
+                captured["args"] = args
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("kaos_cli.install.check_helm_installed", return_value=True), patch(
+            "kaos_cli.install.run_helm_command", side_effect=fake_helm
+        ), patch("kaos_cli.install._run_kubectl") as mock_kubectl:
+            from types import SimpleNamespace
+
+            mock_kubectl.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            result = runner.invoke(
+                app,
+                [
+                    "system",
+                    "install",
+                    "--auth-enabled",
+                    "--chart-path",
+                    "operator/chart",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        joined = " ".join(captured.get("args", []))
+        assert "security.agentAuth.extAuthzUrl=" in joined
+        assert "security.agentAuth.credentialSecretPrefix=kaos-aib" in joined
 
     def test_install_monitoring_enabled_without_value(self):
         """--monitoring-enabled without value defaults to signoz (not an invalid backend error)."""
         from unittest.mock import patch
 
         with patch("kaos_cli.install.check_helm_installed", return_value=False):
-            result = runner.invoke(
-                app, ["system", "install", "--monitoring-enabled"]
-            )
+            result = runner.invoke(app, ["system", "install", "--monitoring-enabled"])
         # Should not error on invalid backend (signoz is valid)
         assert "Invalid monitoring backend" not in result.output
 
@@ -863,9 +976,7 @@ class TestSystemInstallFlags:
         from unittest.mock import patch
 
         with patch("kaos_cli.install.check_helm_installed", return_value=False):
-            result = runner.invoke(
-                app, ["system", "uninstall", "--monitoring-enabled"]
-            )
+            result = runner.invoke(app, ["system", "uninstall", "--monitoring-enabled"])
         assert "Invalid monitoring backend" not in result.output
 
 

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -34,6 +34,12 @@ data:
   {{- if .extAuthzUrl }}
   SECURITY_AGENT_AUTH_EXT_AUTHZ_URL: {{ .extAuthzUrl | quote }}
   {{- end }}
+  {{- if .issuer }}
+  SECURITY_AGENT_AUTH_ISSUER: {{ .issuer | quote }}
+  {{- end }}
+  {{- if .credentialSecretPrefix }}
+  SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX: {{ .credentialSecretPrefix | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
   # Global telemetry configuration (defaults for all components)

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -81,6 +81,16 @@ security:
     # backend (AIB by default; OPA is a drop-in via the standard contract).
     # Example: aib-ext-authz.aib-system.svc.cluster.local:9002
     extAuthzUrl: ""
+    # issuer is the agent-auth OIDC issuer (the broker that mints agent actor
+    # tokens). It is propagated to agent pods, which derive the token endpoint
+    # from it. Example: http://aib-enduser.aib-system.svc.cluster.local:8000
+    issuer: ""
+    # credentialSecretPrefix is the name prefix of the per-agent credential
+    # Secret provisioned by the sync service. When set (and extAuthzUrl is set),
+    # the operator mounts the matching Secret into each agent pod as the
+    # AIB_CLIENT_ID/AIB_CLIENT_SECRET environment variables. Empty disables
+    # credential mounting. Example: kaos-aib
+    credentialSecretPrefix: ""
 
 serviceAccount:
   annotations: {}

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -88,7 +88,7 @@ security:
     # credentialSecretPrefix is the name prefix of the per-agent credential
     # Secret provisioned by the sync service. When set (and extAuthzUrl is set),
     # the operator mounts the matching Secret into each agent pod as the
-    # AIB_CLIENT_ID/AIB_CLIENT_SECRET environment variables. Empty disables
+    # AGENT_AUTH_CLIENT_ID/AGENT_AUTH_CLIENT_SECRET environment variables. Empty disables
     # credential mounting. Example: kaos-aib
     credentialSecretPrefix: ""
 

--- a/operator/controllers/agent_auth_env_test.go
+++ b/operator/controllers/agent_auth_env_test.go
@@ -1,0 +1,95 @@
+package controllers
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kaosv1alpha1 "github.com/axsaucedo/kaos/operator/api/v1alpha1"
+)
+
+func newAgent(namespace, name string) *kaosv1alpha1.Agent {
+	return &kaosv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	}
+}
+
+func envByName(env []corev1.EnvVar, name string) (corev1.EnvVar, bool) {
+	for _, e := range env {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return corev1.EnvVar{}, false
+}
+
+func TestBuildAgentAuthEnvVarsDisabled(t *testing.T) {
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "")
+	t.Setenv("SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX", "")
+
+	if env := buildAgentAuthEnvVars(newAgent("demo", "researcher")); env != nil {
+		t.Errorf("expected no agent-auth env when credential mounting is disabled, got %v", env)
+	}
+}
+
+func TestBuildAgentAuthEnvVarsDisabledWithoutExtAuthz(t *testing.T) {
+	// A prefix alone must not enable mounting; ext_authz must also be set.
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "")
+	t.Setenv("SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX", "kaos-aib")
+
+	if env := buildAgentAuthEnvVars(newAgent("demo", "researcher")); env != nil {
+		t.Errorf("expected no agent-auth env without ext_authz, got %v", env)
+	}
+}
+
+func TestBuildAgentAuthEnvVarsEnabled(t *testing.T) {
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "aib-ext-authz.aib-system:9002")
+	t.Setenv("SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX", "kaos-aib")
+	t.Setenv("SECURITY_AGENT_AUTH_ISSUER", "http://aib-enduser.aib-system.svc.cluster.local:8000")
+
+	env := buildAgentAuthEnvVars(newAgent("demo", "researcher"))
+
+	actor, ok := envByName(env, "AIB_ACTOR")
+	if !ok || actor.Value != "kaos://agent/demo/researcher" {
+		t.Errorf("AIB_ACTOR = %q (found=%v), want kaos://agent/demo/researcher", actor.Value, ok)
+	}
+
+	clientID, ok := envByName(env, "AIB_CLIENT_ID")
+	if !ok || clientID.ValueFrom == nil || clientID.ValueFrom.SecretKeyRef == nil {
+		t.Fatalf("AIB_CLIENT_ID missing a secretKeyRef")
+	}
+	ref := clientID.ValueFrom.SecretKeyRef
+	if ref.Name != "kaos-aib-researcher" || ref.Key != "client_id" {
+		t.Errorf("AIB_CLIENT_ID ref = %s/%s, want kaos-aib-researcher/client_id", ref.Name, ref.Key)
+	}
+	if ref.Optional == nil || !*ref.Optional {
+		t.Errorf("AIB_CLIENT_ID secret ref must be optional so the pod can start before the Secret exists")
+	}
+
+	secret, ok := envByName(env, "AIB_CLIENT_SECRET")
+	if !ok || secret.ValueFrom == nil || secret.ValueFrom.SecretKeyRef == nil ||
+		secret.ValueFrom.SecretKeyRef.Key != "client_secret" {
+		t.Errorf("AIB_CLIENT_SECRET missing a client_secret secretKeyRef")
+	}
+
+	endpoint, ok := envByName(env, "AIB_TOKEN_ENDPOINT")
+	if !ok || endpoint.Value != "http://aib-enduser.aib-system.svc.cluster.local:8000/oauth2/token" {
+		t.Errorf("AIB_TOKEN_ENDPOINT = %q, want the issuer token endpoint", endpoint.Value)
+	}
+}
+
+func TestBuildAgentAuthEnvVarsWithoutIssuer(t *testing.T) {
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "aib-ext-authz.aib-system:9002")
+	t.Setenv("SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX", "kaos-aib")
+	t.Setenv("SECURITY_AGENT_AUTH_ISSUER", "")
+
+	env := buildAgentAuthEnvVars(newAgent("demo", "researcher"))
+
+	if _, ok := envByName(env, "AIB_TOKEN_ENDPOINT"); ok {
+		t.Errorf("AIB_TOKEN_ENDPOINT must be omitted when no issuer is configured")
+	}
+	if _, ok := envByName(env, "AIB_CLIENT_ID"); !ok {
+		t.Errorf("credentials must still be mounted without an issuer")
+	}
+}

--- a/operator/controllers/agent_auth_env_test.go
+++ b/operator/controllers/agent_auth_env_test.go
@@ -50,32 +50,32 @@ func TestBuildAgentAuthEnvVarsEnabled(t *testing.T) {
 
 	env := buildAgentAuthEnvVars(newAgent("demo", "researcher"))
 
-	actor, ok := envByName(env, "AIB_ACTOR")
+	actor, ok := envByName(env, "AGENT_AUTH_IDENTITY")
 	if !ok || actor.Value != "kaos://agent/demo/researcher" {
-		t.Errorf("AIB_ACTOR = %q (found=%v), want kaos://agent/demo/researcher", actor.Value, ok)
+		t.Errorf("AGENT_AUTH_IDENTITY = %q (found=%v), want kaos://agent/demo/researcher", actor.Value, ok)
 	}
 
-	clientID, ok := envByName(env, "AIB_CLIENT_ID")
+	clientID, ok := envByName(env, "AGENT_AUTH_CLIENT_ID")
 	if !ok || clientID.ValueFrom == nil || clientID.ValueFrom.SecretKeyRef == nil {
-		t.Fatalf("AIB_CLIENT_ID missing a secretKeyRef")
+		t.Fatalf("AGENT_AUTH_CLIENT_ID missing a secretKeyRef")
 	}
 	ref := clientID.ValueFrom.SecretKeyRef
 	if ref.Name != "kaos-aib-researcher" || ref.Key != "client_id" {
-		t.Errorf("AIB_CLIENT_ID ref = %s/%s, want kaos-aib-researcher/client_id", ref.Name, ref.Key)
+		t.Errorf("AGENT_AUTH_CLIENT_ID ref = %s/%s, want kaos-aib-researcher/client_id", ref.Name, ref.Key)
 	}
 	if ref.Optional == nil || !*ref.Optional {
-		t.Errorf("AIB_CLIENT_ID secret ref must be optional so the pod can start before the Secret exists")
+		t.Errorf("AGENT_AUTH_CLIENT_ID secret ref must be optional so the pod can start before the Secret exists")
 	}
 
-	secret, ok := envByName(env, "AIB_CLIENT_SECRET")
+	secret, ok := envByName(env, "AGENT_AUTH_CLIENT_SECRET")
 	if !ok || secret.ValueFrom == nil || secret.ValueFrom.SecretKeyRef == nil ||
 		secret.ValueFrom.SecretKeyRef.Key != "client_secret" {
-		t.Errorf("AIB_CLIENT_SECRET missing a client_secret secretKeyRef")
+		t.Errorf("AGENT_AUTH_CLIENT_SECRET missing a client_secret secretKeyRef")
 	}
 
-	endpoint, ok := envByName(env, "AIB_TOKEN_ENDPOINT")
+	endpoint, ok := envByName(env, "AGENT_AUTH_TOKEN_ENDPOINT")
 	if !ok || endpoint.Value != "http://aib-enduser.aib-system.svc.cluster.local:8000/oauth2/token" {
-		t.Errorf("AIB_TOKEN_ENDPOINT = %q, want the issuer token endpoint", endpoint.Value)
+		t.Errorf("AGENT_AUTH_TOKEN_ENDPOINT = %q, want the issuer token endpoint", endpoint.Value)
 	}
 }
 
@@ -86,10 +86,10 @@ func TestBuildAgentAuthEnvVarsWithoutIssuer(t *testing.T) {
 
 	env := buildAgentAuthEnvVars(newAgent("demo", "researcher"))
 
-	if _, ok := envByName(env, "AIB_TOKEN_ENDPOINT"); ok {
-		t.Errorf("AIB_TOKEN_ENDPOINT must be omitted when no issuer is configured")
+	if _, ok := envByName(env, "AGENT_AUTH_TOKEN_ENDPOINT"); ok {
+		t.Errorf("AGENT_AUTH_TOKEN_ENDPOINT must be omitted when no issuer is configured")
 	}
-	if _, ok := envByName(env, "AIB_CLIENT_ID"); !ok {
+	if _, ok := envByName(env, "AGENT_AUTH_CLIENT_ID"); !ok {
 		t.Errorf("credentials must still be mounted without an issuer")
 	}
 }

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -700,6 +700,55 @@ func (r *AgentReconciler) constructEnvVars(agent *kaosv1alpha1.Agent, modelapi *
 		env = append(env, logLevelEnv...)
 	}
 
+	// AIB agent identity and credentials (when security credential mounting is enabled)
+	env = append(env, buildAgentAuthEnvVars(agent)...)
+
+	return env
+}
+
+// buildAgentAuthEnvVars returns the agent-auth environment variables that give the
+// agent its AIB actor identity and, when provisioned, the credentials it uses to mint
+// an actor token. The client_id/client_secret are sourced from the per-agent credential
+// Secret as optional references, so the pod can start before the sync service has written
+// the Secret; the values appear once it exists. Returns nil when credential mounting is
+// not enabled, leaving existing pods unchanged.
+func buildAgentAuthEnvVars(agent *kaosv1alpha1.Agent) []corev1.EnvVar {
+	cfg := security.GetConfig()
+	if !cfg.CredentialMountingEnabled() {
+		return nil
+	}
+
+	secretName := cfg.CredentialSecretName(agent.Name)
+	optional := true
+	env := []corev1.EnvVar{
+		{
+			Name:  "AIB_ACTOR",
+			Value: fmt.Sprintf("kaos://agent/%s/%s", agent.Namespace, agent.Name),
+		},
+		{
+			Name: "AIB_CLIENT_ID",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  "client_id",
+					Optional:             &optional,
+				},
+			},
+		},
+		{
+			Name: "AIB_CLIENT_SECRET",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  "client_secret",
+					Optional:             &optional,
+				},
+			},
+		},
+	}
+	if endpoint := cfg.TokenEndpoint(); endpoint != "" {
+		env = append(env, corev1.EnvVar{Name: "AIB_TOKEN_ENDPOINT", Value: endpoint})
+	}
 	return env
 }
 

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -700,18 +700,18 @@ func (r *AgentReconciler) constructEnvVars(agent *kaosv1alpha1.Agent, modelapi *
 		env = append(env, logLevelEnv...)
 	}
 
-	// AIB agent identity and credentials (when security credential mounting is enabled)
+	// Agent identity and credentials (when security credential mounting is enabled)
 	env = append(env, buildAgentAuthEnvVars(agent)...)
 
 	return env
 }
 
 // buildAgentAuthEnvVars returns the agent-auth environment variables that give the
-// agent its AIB actor identity and, when provisioned, the credentials it uses to mint
-// an actor token. The client_id/client_secret are sourced from the per-agent credential
-// Secret as optional references, so the pod can start before the sync service has written
-// the Secret; the values appear once it exists. Returns nil when credential mounting is
-// not enabled, leaving existing pods unchanged.
+// agent its actor identity and, when provisioned, the credentials it uses to mint
+// an actor token, under the provider-agnostic AGENT_AUTH_ prefix. The client_id/client_secret
+// are sourced from the per-agent credential Secret as optional references, so the pod can
+// start before the sync service has written the Secret; the values appear once it exists.
+// Returns nil when credential mounting is not enabled, leaving existing pods unchanged.
 func buildAgentAuthEnvVars(agent *kaosv1alpha1.Agent) []corev1.EnvVar {
 	cfg := security.GetConfig()
 	if !cfg.CredentialMountingEnabled() {
@@ -722,11 +722,11 @@ func buildAgentAuthEnvVars(agent *kaosv1alpha1.Agent) []corev1.EnvVar {
 	optional := true
 	env := []corev1.EnvVar{
 		{
-			Name:  "AIB_ACTOR",
+			Name:  "AGENT_AUTH_IDENTITY",
 			Value: fmt.Sprintf("kaos://agent/%s/%s", agent.Namespace, agent.Name),
 		},
 		{
-			Name: "AIB_CLIENT_ID",
+			Name: "AGENT_AUTH_CLIENT_ID",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
@@ -736,7 +736,7 @@ func buildAgentAuthEnvVars(agent *kaosv1alpha1.Agent) []corev1.EnvVar {
 			},
 		},
 		{
-			Name: "AIB_CLIENT_SECRET",
+			Name: "AGENT_AUTH_CLIENT_SECRET",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
@@ -747,7 +747,7 @@ func buildAgentAuthEnvVars(agent *kaosv1alpha1.Agent) []corev1.EnvVar {
 		},
 	}
 	if endpoint := cfg.TokenEndpoint(); endpoint != "" {
-		env = append(env, corev1.EnvVar{Name: "AIB_TOKEN_ENDPOINT", Value: endpoint})
+		env = append(env, corev1.EnvVar{Name: "AGENT_AUTH_TOKEN_ENDPOINT", Value: endpoint})
 	}
 	return env
 }

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -21,14 +21,30 @@ type Config struct {
 	// access-check gRPC backend (agentAuth.extAuthzUrl). An empty value means
 	// gateway authorization enforcement is disabled.
 	ExtAuthzURL string
+
+	// Issuer is the agent-auth OIDC issuer URL (agentAuth.issuer): the broker
+	// that mints agent actor tokens. It is propagated to agent pods so they can
+	// obtain an actor token from their mounted credentials.
+	Issuer string
+
+	// CredentialSecretPrefix is the name prefix of the per-agent credential
+	// Secret provisioned by the sync service (agentAuth.credentialSecretPrefix).
+	// An empty value disables credential mounting into agent pods.
+	CredentialSecretPrefix string
 }
 
-const envExtAuthzURL = "SECURITY_AGENT_AUTH_EXT_AUTHZ_URL"
+const (
+	envExtAuthzURL            = "SECURITY_AGENT_AUTH_EXT_AUTHZ_URL"
+	envIssuer                 = "SECURITY_AGENT_AUTH_ISSUER"
+	envCredentialSecretPrefix = "SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX"
+)
 
 // GetConfig reads security configuration from environment variables.
 func GetConfig() Config {
 	return Config{
-		ExtAuthzURL: os.Getenv(envExtAuthzURL),
+		ExtAuthzURL:            os.Getenv(envExtAuthzURL),
+		Issuer:                 os.Getenv(envIssuer),
+		CredentialSecretPrefix: os.Getenv(envCredentialSecretPrefix),
 	}
 }
 
@@ -36,6 +52,30 @@ func GetConfig() Config {
 // The operator only generates authorization policies when this returns true.
 func (c Config) IsOperational() bool {
 	return strings.TrimSpace(c.ExtAuthzURL) != ""
+}
+
+// CredentialMountingEnabled reports whether the operator should mount per-agent
+// AIB credentials into agent pods. This requires security to be operational and a
+// credential Secret prefix to be configured.
+func (c Config) CredentialMountingEnabled() bool {
+	return c.IsOperational() && strings.TrimSpace(c.CredentialSecretPrefix) != ""
+}
+
+// CredentialSecretName returns the name of the per-agent credential Secret for the
+// given agent, using the configured prefix. It matches the name the sync service
+// writes, so the operator can mount it without coordination.
+func (c Config) CredentialSecretName(agentName string) string {
+	return fmt.Sprintf("%s-%s", strings.TrimSpace(c.CredentialSecretPrefix), agentName)
+}
+
+// TokenEndpoint returns the agent-auth token endpoint derived from the issuer, or an
+// empty string when no issuer is configured.
+func (c Config) TokenEndpoint() string {
+	issuer := strings.TrimRight(strings.TrimSpace(c.Issuer), "/")
+	if issuer == "" {
+		return ""
+	}
+	return issuer + "/oauth2/token"
 }
 
 // ExtAuthzBackendRef parses the configured ext_authz host:port URL into the

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -44,6 +44,70 @@ func TestIsOperationalIgnoresWhitespace(t *testing.T) {
 	}
 }
 
+func TestCredentialMountingEnabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		extAuth  string
+		prefix   string
+		expected bool
+	}{
+		{"disabled when nothing set", "", "", false},
+		{"disabled without ext_authz", "", "kaos-aib", false},
+		{"disabled without prefix", "svc:9002", "", false},
+		{"disabled with whitespace prefix", "svc:9002", "  ", false},
+		{"enabled when both set", "svc:9002", "kaos-aib", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{ExtAuthzURL: tc.extAuth, CredentialSecretPrefix: tc.prefix}
+			if cfg.CredentialMountingEnabled() != tc.expected {
+				t.Errorf("CredentialMountingEnabled() = %v, want %v", !tc.expected, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCredentialSecretName(t *testing.T) {
+	cfg := Config{CredentialSecretPrefix: "kaos-aib"}
+	if got := cfg.CredentialSecretName("researcher"); got != "kaos-aib-researcher" {
+		t.Errorf("CredentialSecretName = %q, want kaos-aib-researcher", got)
+	}
+}
+
+func TestTokenEndpoint(t *testing.T) {
+	cases := []struct {
+		name   string
+		issuer string
+		want   string
+	}{
+		{"empty issuer", "", ""},
+		{"issuer without slash", "http://aib:8000", "http://aib:8000/oauth2/token"},
+		{"issuer with trailing slash", "http://aib:8000/", "http://aib:8000/oauth2/token"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (Config{Issuer: tc.issuer}).TokenEndpoint(); got != tc.want {
+				t.Errorf("TokenEndpoint() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetConfigReadsAllFields(t *testing.T) {
+	t.Setenv(envExtAuthzURL, "aib-ext-authz.aib-system:9002")
+	t.Setenv(envIssuer, "http://aib-enduser.aib-system.svc.cluster.local:8000")
+	t.Setenv(envCredentialSecretPrefix, "kaos-aib")
+
+	cfg := GetConfig()
+
+	if !cfg.CredentialMountingEnabled() {
+		t.Errorf("expected credential mounting enabled")
+	}
+	if cfg.TokenEndpoint() != "http://aib-enduser.aib-system.svc.cluster.local:8000/oauth2/token" {
+		t.Errorf("unexpected token endpoint %q", cfg.TokenEndpoint())
+	}
+}
+
 func TestExtAuthzBackendRef(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/pydantic-ai-server/pais/a2a.py
+++ b/pydantic-ai-server/pais/a2a.py
@@ -671,6 +671,11 @@ class LocalTaskManager(TaskManager):
                                 iteration += 1
                                 if interval_seconds > 0:
                                     await asyncio.sleep(interval_seconds)
+                                else:
+                                    # Always yield so a cancellation (e.g. shutdown)
+                                    # can be delivered; a zero interval must not turn
+                                    # the retry path into an event-loop-starving spin.
+                                    await asyncio.sleep(0)
                                 continue
                             else:
                                 raise
@@ -690,6 +695,11 @@ class LocalTaskManager(TaskManager):
                     # Inter-iteration interval
                     if interval_seconds > 0:
                         await asyncio.sleep(interval_seconds)
+                    else:
+                        # Always yield so a cancellation (e.g. shutdown) can be
+                        # delivered; a zero interval must not turn the loop into an
+                        # event-loop-starving spin.
+                        await asyncio.sleep(0)
 
                 task.output = last_response
                 task.history.append(TaskMessage(role="agent", text=last_response))

--- a/sync-service/Dockerfile
+++ b/sync-service/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY kaos_sync ./kaos_sync
+
+RUN pip install --no-cache-dir .
+
+USER 1000:1000
+
+ENTRYPOINT ["kaos-sync"]

--- a/sync-service/Makefile
+++ b/sync-service/Makefile
@@ -1,0 +1,22 @@
+.PHONY: help install lint format test
+
+help:
+	@echo "KAOS sync service targets:"
+	@echo "  install - Create venv and install the package with dev extras"
+	@echo "  lint    - Run black --check and ty type checking"
+	@echo "  format  - Format code with black"
+	@echo "  test    - Run unit tests"
+
+install:
+	python -m venv .venv
+	. .venv/bin/activate && pip install -e '.[dev]'
+
+lint:
+	black --check .
+	uvx ty check
+
+format:
+	black .
+
+test:
+	python -m pytest tests/ -v

--- a/sync-service/README.md
+++ b/sync-service/README.md
@@ -1,0 +1,29 @@
+# KAOS sync service
+
+A lightweight external service that synchronizes KAOS custom resources into the Agentic Identity Broker (AIB), giving each agent an AIB-issued identity and the permission grants implied by its declared MCP server usage.
+
+## What it does
+
+The service watches KAOS `Agent` and `MCPServer` resources and projects them into AIB using a stable bootstrap encoding:
+
+- Each `MCPServer` `<ns>/<name>` becomes a synthetic AIB service with `client_id` `kaos-mcpserver-<ns>-<name>` exposing a single `call` scope.
+- Each requested `Agent -> MCPServer` edge becomes an AIB permission set `kaos:mcpserver:<ns>:<mcp>:call`.
+- Each `Agent` becomes an AIB *local* agent (no `client_id`, so AIB mints the actor token locally) bound to the permission sets for its edges.
+
+For every projected agent, the service obtains AIB client credentials and writes them into a Kubernetes Secret named `kaos-aib-<agent-id>` for the operator to mount into the agent pod.
+
+## Layout
+
+- `kaos_sync/projection.py` — pure projection of KAOS resources into desired AIB records (no I/O).
+- `kaos_sync/aib_client.py` — AIB admin API client.
+- `kaos_sync/reconcile.py` — reconcile loop and credential Secret writing.
+- `kaos_sync/config.py` — settings.
+- `kaos_sync/main.py` — entrypoint.
+
+## Development
+
+```bash
+make install
+make lint
+make test
+```

--- a/sync-service/chart/Chart.yaml
+++ b/sync-service/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kaos-sync
+description: KAOS to broker sync service that projects KAOS resources into the identity broker and provisions per-agent credentials.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/sync-service/chart/templates/_helpers.tpl
+++ b/sync-service/chart/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{- define "kaos-sync.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kaos-sync.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kaos-sync.labels" -}}
+app.kubernetes.io/name: {{ include "kaos-sync.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "kaos-sync.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kaos-sync.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "kaos-sync.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "kaos-sync.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/sync-service/chart/templates/deployment.yaml
+++ b/sync-service/chart/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kaos-sync.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kaos-sync.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kaos-sync.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kaos-sync.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kaos-sync.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: sync
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          env:
+            - name: AIB_ADMIN_URL
+              value: {{ .Values.broker.adminUrl | quote }}
+            - name: AIB_PRINCIPAL
+              value: {{ .Values.broker.principal | quote }}
+            - name: AIB_PRINCIPAL_HEADER
+              value: {{ .Values.broker.principalHeader | quote }}
+            - name: KAOS_SYNC_NAMESPACES
+              value: {{ join "," .Values.sync.namespaces | quote }}
+            - name: KAOS_SYNC_CREDENTIAL_SECRET_PREFIX
+              value: {{ .Values.sync.credentialSecretPrefix | quote }}
+            - name: KAOS_SYNC_RECONCILE_INTERVAL_SECONDS
+              value: {{ .Values.sync.reconcileIntervalSeconds | quote }}
+            - name: KAOS_SYNC_REQUEST_TIMEOUT_SECONDS
+              value: {{ .Values.sync.requestTimeoutSeconds | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/sync-service/chart/templates/rbac.yaml
+++ b/sync-service/chart/templates/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kaos-sync.fullname" . }}
+  labels:
+    {{- include "kaos-sync.labels" . | nindent 4 }}
+rules:
+  # Read KAOS resources to project them into the broker.
+  - apiGroups: ["kaos.tools"]
+    resources: ["agents", "mcpservers", "modelapis"]
+    verbs: ["get", "list", "watch"]
+  # Provision and refresh per-agent credential Secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kaos-sync.fullname" . }}
+  labels:
+    {{- include "kaos-sync.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kaos-sync.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kaos-sync.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/sync-service/chart/templates/serviceaccount.yaml
+++ b/sync-service/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kaos-sync.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kaos-sync.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/sync-service/chart/values.yaml
+++ b/sync-service/chart/values.yaml
@@ -1,0 +1,56 @@
+# Default values for the KAOS sync service.
+
+# Number of sync service replicas. A single replica is sufficient: reconcile is
+# idempotent and ordering across replicas is not required.
+replicaCount: 1
+
+image:
+  repository: axsauze/kaos-sync
+  tag: ""  # defaults to chart appVersion when empty
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# Broker admin API configuration.
+broker:
+  # adminUrl is the base URL of the broker admin API (including the /api suffix).
+  adminUrl: "http://aib-admin.aib-system.svc.cluster.local:14000/api"
+  # principal is the pre-authenticated principal sent to the admin API.
+  principal: "kaos-sync"
+  # principalHeader carries the pre-authenticated principal.
+  principalHeader: "X-Remote-User"
+
+sync:
+  # Namespaces to reconcile. Empty means cluster-wide.
+  namespaces: []
+  # Prefix for the per-agent credential Secret names. Must match the operator's
+  # security.agentAuth.credentialSecretPrefix so mounted credentials resolve.
+  credentialSecretPrefix: "kaos-aib"
+  # Delay between reconcile passes, in seconds.
+  reconcileIntervalSeconds: 30
+  # Per-request timeout to the broker admin API, in seconds.
+  requestTimeoutSeconds: 10
+
+resources: {}
+
+podAnnotations: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/sync-service/kaos_sync/__init__.py
+++ b/sync-service/kaos_sync/__init__.py
@@ -1,0 +1,8 @@
+"""KAOS -> AIB synchronization service.
+
+Projects KAOS custom resources (Agent, MCPServer) into the Agentic Identity Broker
+so that agents have an AIB-issued identity and the permission grants implied by their
+declared MCP server usage.
+"""
+
+__version__ = "0.4.8.dev0"

--- a/sync-service/kaos_sync/aib_client.py
+++ b/sync-service/kaos_sync/aib_client.py
@@ -1,0 +1,61 @@
+"""AIB admin API client.
+
+A thin idempotent wrapper over the AIB admin REST API used by the sync reconcile loop.
+Pre-authentication is plain-header based: the configured principal is sent on every
+request via the configured header (``X-Remote-User`` by default).
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+class AIBAdmin:
+    """Idempotent client for the AIB admin API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        principal: str,
+        principal_header: str = "X-Remote-User",
+        timeout: float = 10.0,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._client = client or httpx.Client(
+            base_url=base_url,
+            timeout=timeout,
+            headers={principal_header: principal},
+        )
+
+    def _list(self, collection: str) -> list[dict]:
+        data = self._client.get(f"/{collection}").json()
+        if isinstance(data, dict):
+            return data.get("items", [])
+        return data
+
+    def create_or_get(self, collection: str, match_field: str, match_value: str, body: dict) -> str:
+        """Create a resource, returning its id; if it already exists, return that id.
+
+        Creation is attempted first; on a non-2xx response the collection is scanned for an
+        item whose ``match_field`` equals ``match_value``, which makes the call idempotent
+        across reconcile passes.
+        """
+        response = self._client.post(f"/{collection}", json=body)
+        if response.status_code // 100 == 2:
+            return response.json()["id"]
+        for item in self._list(collection):
+            if item.get(match_field) == match_value:
+                return item["id"]
+        raise RuntimeError(
+            f"failed to create or find {collection} {match_value}: "
+            f"{response.status_code} {response.text}"
+        )
+
+    def mint_credentials(self, agent_id: str) -> dict:
+        """Mint client credentials for an agent and return the credential payload."""
+        response = self._client.post(f"/agents/{agent_id}/client-credentials")
+        response.raise_for_status()
+        return response.json()
+
+    def close(self) -> None:
+        self._client.close()

--- a/sync-service/kaos_sync/config.py
+++ b/sync-service/kaos_sync/config.py
@@ -1,0 +1,49 @@
+"""Runtime configuration for the KAOS sync service."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Settings sourced from the environment.
+
+    aib_admin_url: base URL of the AIB admin API (including the ``/api`` suffix).
+    aib_principal: principal sent in the pre-auth header to the AIB admin API.
+    aib_principal_header: header carrying the pre-authenticated principal.
+    namespaces: namespaces to watch; empty means cluster-wide.
+    credential_secret_prefix: prefix for per-agent credential Secret names.
+    reconcile_interval_seconds: delay between reconcile passes.
+    """
+
+    aib_admin_url: str = "http://localhost:14000/api"
+    aib_principal: str = "kaos-sync"
+    aib_principal_header: str = "X-Remote-User"
+    namespaces: tuple[str, ...] = ()
+    credential_secret_prefix: str = "kaos-aib"
+    reconcile_interval_seconds: int = 30
+    request_timeout_seconds: float = 10.0
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "Settings":
+        env = dict(os.environ if env is None else env)
+        namespaces = tuple(
+            n.strip() for n in env.get("KAOS_SYNC_NAMESPACES", "").split(",") if n.strip()
+        )
+        return cls(
+            aib_admin_url=env.get("AIB_ADMIN_URL", cls.aib_admin_url),
+            aib_principal=env.get("AIB_PRINCIPAL", cls.aib_principal),
+            aib_principal_header=env.get("AIB_PRINCIPAL_HEADER", cls.aib_principal_header),
+            namespaces=namespaces,
+            credential_secret_prefix=env.get(
+                "KAOS_SYNC_CREDENTIAL_SECRET_PREFIX", cls.credential_secret_prefix
+            ),
+            reconcile_interval_seconds=int(
+                env.get("KAOS_SYNC_RECONCILE_INTERVAL_SECONDS", cls.reconcile_interval_seconds)
+            ),
+            request_timeout_seconds=float(
+                env.get("KAOS_SYNC_REQUEST_TIMEOUT_SECONDS", cls.request_timeout_seconds)
+            ),
+        )

--- a/sync-service/kaos_sync/k8s.py
+++ b/sync-service/kaos_sync/k8s.py
@@ -1,0 +1,89 @@
+"""Kubernetes-backed Secret store and resource lister.
+
+Wraps the Kubernetes client so the reconcile loop can read/write per-agent credential
+Secrets and list KAOS custom resources. Imported only by the runtime entrypoint; the
+reconcile logic depends on the :class:`kaos_sync.reconcile.SecretStore` protocol, not on
+this module, so tests need no cluster.
+"""
+
+from __future__ import annotations
+
+from kubernetes import client, config
+
+KAOS_GROUP = "kaos.tools"
+KAOS_VERSION = "v1alpha1"
+AGENT_PLURAL = "agents"
+MCPSERVER_PLURAL = "mcpservers"
+
+
+def load_kube_config() -> None:
+    """Load in-cluster config, falling back to local kubeconfig for development."""
+    try:
+        config.load_incluster_config()
+    except config.ConfigException:
+        config.load_kube_config()
+
+
+class KubeSecretStore:
+    """Reads and upserts Opaque Secrets via the core Kubernetes API."""
+
+    def __init__(self, core_api: client.CoreV1Api | None = None) -> None:
+        self._api = core_api or client.CoreV1Api()
+
+    def get(self, namespace: str, name: str) -> dict[str, str] | None:
+        try:
+            secret = self._api.read_namespaced_secret(name, namespace)
+        except client.ApiException as exc:  # type: ignore[attr-defined]
+            if exc.status == 404:
+                return None
+            raise
+        data = secret.string_data or {}
+        if secret.data:
+            import base64
+
+            for key, value in secret.data.items():
+                data.setdefault(key, base64.b64decode(value).decode("utf-8"))
+        return data
+
+    def upsert(self, namespace: str, name: str, string_data: dict[str, str]) -> None:
+        body = client.V1Secret(
+            metadata=client.V1ObjectMeta(
+                name=name,
+                labels={"app.kubernetes.io/managed-by": "kaos-sync"},
+            ),
+            string_data=string_data,
+            type="Opaque",
+        )
+        try:
+            self._api.create_namespaced_secret(namespace, body)
+        except client.ApiException as exc:  # type: ignore[attr-defined]
+            if exc.status != 409:
+                raise
+            self._api.replace_namespaced_secret(name, namespace, body)
+
+
+class KaosResourceLister:
+    """Lists KAOS Agent and MCPServer resources across the configured namespaces."""
+
+    def __init__(self, custom_api: client.CustomObjectsApi | None = None) -> None:
+        self._api = custom_api or client.CustomObjectsApi()
+
+    def _list(self, plural: str, kind: str, namespaces: tuple[str, ...]) -> list[dict]:
+        items: list[dict] = []
+        if namespaces:
+            for namespace in namespaces:
+                result = self._api.list_namespaced_custom_object(
+                    KAOS_GROUP, KAOS_VERSION, namespace, plural
+                )
+                items.extend(result.get("items", []))
+        else:
+            result = self._api.list_cluster_custom_object(KAOS_GROUP, KAOS_VERSION, plural)
+            items.extend(result.get("items", []))
+        for item in items:
+            item.setdefault("kind", kind)
+        return items
+
+    def list_resources(self, namespaces: tuple[str, ...]) -> list[dict]:
+        return self._list(MCPSERVER_PLURAL, "MCPServer", namespaces) + self._list(
+            AGENT_PLURAL, "Agent", namespaces
+        )

--- a/sync-service/kaos_sync/main.py
+++ b/sync-service/kaos_sync/main.py
@@ -1,0 +1,63 @@
+"""Entrypoint: periodic reconcile loop projecting KAOS resources into AIB."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from kaos_sync.aib_client import AIBAdmin
+from kaos_sync.config import Settings
+from kaos_sync.projection import project
+from kaos_sync.reconcile import ReconcileSummary, reconcile
+
+logger = logging.getLogger("kaos_sync")
+
+
+def run_once(settings: Settings, lister, aib, secrets) -> ReconcileSummary:
+    """Run a single reconcile pass and return its summary."""
+    resources = lister.list_resources(settings.namespaces)
+    desired = project(resources)
+    summary = reconcile(desired, aib, secrets, settings.credential_secret_prefix)
+    minted = sum(1 for a in summary.agents if a.credentials_minted)
+    logger.info(
+        "reconciled services=%d permission_sets=%d agents=%d credentials_minted=%d",
+        summary.services,
+        summary.permission_sets,
+        len(summary.agents),
+        minted,
+    )
+    return summary
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    settings = Settings.from_env()
+
+    from kaos_sync.k8s import KaosResourceLister, KubeSecretStore, load_kube_config
+
+    load_kube_config()
+    lister = KaosResourceLister()
+    secrets = KubeSecretStore()
+    aib = AIBAdmin(
+        base_url=settings.aib_admin_url,
+        principal=settings.aib_principal,
+        principal_header=settings.aib_principal_header,
+        timeout=settings.request_timeout_seconds,
+    )
+
+    logger.info(
+        "starting reconcile loop admin=%s interval=%ds namespaces=%s",
+        settings.aib_admin_url,
+        settings.reconcile_interval_seconds,
+        ",".join(settings.namespaces) or "<all>",
+    )
+    while True:
+        try:
+            run_once(settings, lister, aib, secrets)
+        except Exception:  # noqa: BLE001 - keep the loop alive across transient failures
+            logger.exception("reconcile pass failed")
+        time.sleep(settings.reconcile_interval_seconds)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sync-service/kaos_sync/projection.py
+++ b/sync-service/kaos_sync/projection.py
@@ -1,0 +1,193 @@
+"""Pure projection of KAOS resources into desired AIB records.
+
+This module contains no I/O. It translates KAOS ``Agent`` and ``MCPServer`` resources
+into the desired Agentic Identity Broker (AIB) state using a stable bootstrap encoding:
+
+* Each ``MCPServer`` ``<ns>/<name>`` becomes a synthetic AIB service whose ``client_id``
+  is ``kaos-mcpserver-<ns>-<name>`` and which exposes a single ``call`` scope.
+* Each requested edge ``Agent -> MCPServer`` becomes an AIB permission set named
+  ``kaos:mcpserver:<ns>:<mcp>:call`` that grants the ``call`` scope on that service.
+* Each ``Agent`` ``<ns>/<name>`` becomes an AIB *local* agent (created without a
+  ``client_id`` so AIB itself mints the actor token) bound to the permission sets for
+  its requested edges.
+
+The resource identity an agent is authorized against is ``kaos://mcpserver/<ns>/<name>``,
+which the access-check maps back to the synthetic service ``client_id``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+CALL_SCOPE = "call"
+MCPSERVER_KIND = "MCPServer"
+AGENT_KIND = "Agent"
+
+
+def service_client_id(namespace: str, name: str) -> str:
+    """Synthetic AIB service ``client_id`` for an MCPServer."""
+    return f"kaos-mcpserver-{namespace}-{name}"
+
+
+def permission_set_name(namespace: str, mcp: str) -> str:
+    """AIB permission-set name granting ``call`` on an MCPServer."""
+    return f"kaos:mcpserver:{namespace}:{mcp}:{CALL_SCOPE}"
+
+
+def agent_external_id(namespace: str, name: str) -> str:
+    """Stable external identity for a KAOS agent in AIB."""
+    return f"kaos://agent/{namespace}/{name}"
+
+
+def mcpserver_resource_uri(namespace: str, name: str) -> str:
+    """Resource URI an agent is authorized against for an MCPServer edge."""
+    return f"kaos://mcpserver/{namespace}/{name}"
+
+
+@dataclass(frozen=True)
+class DesiredService:
+    """A synthetic AIB service projected from an MCPServer."""
+
+    namespace: str
+    name: str
+
+    @property
+    def client_id(self) -> str:
+        return service_client_id(self.namespace, self.name)
+
+    def admin_body(self) -> dict:
+        return {
+            "display_name": f"KAOS MCPServer {self.namespace}/{self.name} (synthetic)",
+            "client_id": self.client_id,
+            "client_secret": "synthetic",
+            "issuer_uri": f"https://kaos.local/mcpserver/{self.namespace}/{self.name}",
+            "discovery": {"enable_discovery": False},
+            "endpoints": {
+                "token_endpoint": "https://kaos.local/t",
+                "authorize_endpoint": "https://kaos.local/a",
+            },
+            "scopes": [{"scope_value": CALL_SCOPE, "description": "Invoke the MCP server"}],
+        }
+
+
+@dataclass(frozen=True)
+class DesiredPermissionSet:
+    """An AIB permission set granting ``call`` on one synthetic service."""
+
+    namespace: str
+    mcp: str
+
+    @property
+    def name(self) -> str:
+        return permission_set_name(self.namespace, self.mcp)
+
+    @property
+    def service_client_id(self) -> str:
+        return service_client_id(self.namespace, self.mcp)
+
+    def admin_body(self, service_id: str) -> dict:
+        return {
+            "name": self.name,
+            "description": f"call {self.namespace}/{self.mcp}",
+            "service_scopes": [
+                {
+                    "service_id": service_id,
+                    "scopes": [CALL_SCOPE],
+                    "requirement_type": "mandatory",
+                }
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class DesiredAgent:
+    """An AIB local agent projected from a KAOS Agent and its requested edges."""
+
+    namespace: str
+    name: str
+    permission_set_names: tuple[str, ...]
+    granted_resources: tuple[str, ...]
+
+    @property
+    def external_id(self) -> str:
+        return agent_external_id(self.namespace, self.name)
+
+    def admin_body(self, permission_set_ids: list[str]) -> dict:
+        return {
+            "display_name": self.external_id,
+            "description": f"KAOS agent {self.namespace}/{self.name}",
+            "permission_sets": [
+                {"permission_set_id": pid, "requirement_type": "mandatory"}
+                for pid in permission_set_ids
+            ],
+        }
+
+
+@dataclass
+class DesiredState:
+    """The full desired AIB state projected from a set of KAOS resources."""
+
+    services: list[DesiredService] = field(default_factory=list)
+    permission_sets: list[DesiredPermissionSet] = field(default_factory=list)
+    agents: list[DesiredAgent] = field(default_factory=list)
+
+
+def _meta(resource: dict) -> tuple[str, str]:
+    md = resource.get("metadata", {})
+    return md.get("namespace", "default"), md.get("name", "")
+
+
+def project(resources: list[dict]) -> DesiredState:
+    """Project a list of KAOS resources into the desired AIB state.
+
+    Only agents with at least one requested MCPServer edge are projected; an agent with
+    no edges has nothing to authorize and is skipped. Services and permission sets are
+    derived from the union of declared MCPServers and the edges agents request, so an
+    edge to an MCPServer that has no standalone resource still yields a service.
+    """
+    state = DesiredState()
+
+    services: dict[tuple[str, str], DesiredService] = {}
+    permission_sets: dict[tuple[str, str], DesiredPermissionSet] = {}
+
+    def ensure_service(ns: str, name: str) -> None:
+        key = (ns, name)
+        if key not in services:
+            services[key] = DesiredService(namespace=ns, name=name)
+
+    for resource in resources:
+        if resource.get("kind") == MCPSERVER_KIND:
+            ns, name = _meta(resource)
+            if name:
+                ensure_service(ns, name)
+
+    for resource in resources:
+        if resource.get("kind") != AGENT_KIND:
+            continue
+        ns, name = _meta(resource)
+        if not name:
+            continue
+        spec = resource.get("spec") or {}
+        ps_names: list[str] = []
+        granted: list[str] = []
+        for mcp in spec.get("mcpServers") or []:
+            ensure_service(ns, mcp)
+            key = (ns, mcp)
+            if key not in permission_sets:
+                permission_sets[key] = DesiredPermissionSet(namespace=ns, mcp=mcp)
+            ps_names.append(permission_sets[key].name)
+            granted.append(mcpserver_resource_uri(ns, mcp))
+        if not ps_names:
+            continue
+        state.agents.append(
+            DesiredAgent(
+                namespace=ns,
+                name=name,
+                permission_set_names=tuple(ps_names),
+                granted_resources=tuple(granted),
+            )
+        )
+
+    state.services = list(services.values())
+    state.permission_sets = list(permission_sets.values())
+    return state

--- a/sync-service/kaos_sync/reconcile.py
+++ b/sync-service/kaos_sync/reconcile.py
@@ -1,0 +1,125 @@
+"""Reconciliation of desired AIB state and per-agent credential Secrets.
+
+This module is I/O-free in itself: it orchestrates an :class:`AIBAdminClient` and a
+:class:`SecretStore` (both protocols) so it can be unit tested with fakes. Concrete
+implementations live in :mod:`kaos_sync.aib_client` and :mod:`kaos_sync.secrets`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from kaos_sync.projection import DesiredAgent, DesiredState
+
+
+def credential_secret_name(prefix: str, agent_name: str) -> str:
+    """Per-agent credential Secret name, derivable by both the sync service and operator."""
+    return f"{prefix}-{agent_name}"
+
+
+class AIBAdminClient(Protocol):
+    def create_or_get(
+        self, collection: str, match_field: str, match_value: str, body: dict
+    ) -> str: ...
+
+    def mint_credentials(self, agent_id: str) -> dict: ...
+
+
+class SecretStore(Protocol):
+    def get(self, namespace: str, name: str) -> dict[str, str] | None: ...
+
+    def upsert(self, namespace: str, name: str, string_data: dict[str, str]) -> None: ...
+
+
+@dataclass
+class AgentSync:
+    """Outcome of reconciling a single agent."""
+
+    external_id: str
+    agent_id: str
+    secret_namespace: str
+    secret_name: str
+    credentials_minted: bool
+
+
+@dataclass
+class ReconcileSummary:
+    services: int = 0
+    permission_sets: int = 0
+    agents: list[AgentSync] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.agents is None:
+            self.agents = []
+
+
+def reconcile(
+    desired: DesiredState,
+    aib: AIBAdminClient,
+    secrets: SecretStore,
+    secret_prefix: str = "kaos-aib",
+) -> ReconcileSummary:
+    """Apply the desired AIB state and provision per-agent credential Secrets.
+
+    Services and permission sets are created (or matched) first so their ids can be
+    referenced; each agent is then created as a local AIB agent bound to its permission
+    sets. Credentials are minted only when a Secret does not already carry them, keeping
+    the pass idempotent and avoiding credential churn on every reconcile.
+    """
+    summary = ReconcileSummary()
+
+    service_ids: dict[str, str] = {}
+    for service in desired.services:
+        service_ids[service.client_id] = aib.create_or_get(
+            "services", "client_id", service.client_id, service.admin_body()
+        )
+    summary.services = len(service_ids)
+
+    permission_set_ids: dict[str, str] = {}
+    for permission_set in desired.permission_sets:
+        service_id = service_ids[permission_set.service_client_id]
+        permission_set_ids[permission_set.name] = aib.create_or_get(
+            "permission-sets", "name", permission_set.name, permission_set.admin_body(service_id)
+        )
+    summary.permission_sets = len(permission_set_ids)
+
+    for agent in desired.agents:
+        summary.agents.append(
+            _reconcile_agent(agent, aib, secrets, secret_prefix, permission_set_ids)
+        )
+
+    return summary
+
+
+def _reconcile_agent(
+    agent: DesiredAgent,
+    aib: AIBAdminClient,
+    secrets: SecretStore,
+    secret_prefix: str,
+    permission_set_ids: dict[str, str],
+) -> AgentSync:
+    bound = [permission_set_ids[name] for name in agent.permission_set_names]
+    agent_id = aib.create_or_get(
+        "agents", "display_name", agent.external_id, agent.admin_body(bound)
+    )
+
+    secret_name = credential_secret_name(secret_prefix, agent.name)
+    existing = secrets.get(agent.namespace, secret_name)
+    minted = False
+    if not existing or not existing.get("client_id"):
+        cred = aib.mint_credentials(agent_id)
+        secrets.upsert(
+            agent.namespace,
+            secret_name,
+            {"client_id": cred["client_id"], "client_secret": cred["client_secret"]},
+        )
+        minted = True
+
+    return AgentSync(
+        external_id=agent.external_id,
+        agent_id=agent_id,
+        secret_namespace=agent.namespace,
+        secret_name=secret_name,
+        credentials_minted=minted,
+    )

--- a/sync-service/pyproject.toml
+++ b/sync-service/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kaos-sync"
+version = "0.4.8.dev0"
+description = "KAOS -> Agentic Identity Broker synchronization service"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "httpx>=0.27.0",
+    "kubernetes>=29.0.0",
+]
+
+[project.scripts]
+kaos-sync = "kaos_sync.main:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "black>=24.0.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["kaos_sync*"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/sync-service/tests/test_projection.py
+++ b/sync-service/tests/test_projection.py
@@ -1,0 +1,119 @@
+"""Tests for the pure KAOS -> AIB projection."""
+
+from __future__ import annotations
+
+from kaos_sync.projection import (
+    DesiredState,
+    agent_external_id,
+    mcpserver_resource_uri,
+    permission_set_name,
+    project,
+    service_client_id,
+)
+
+
+def _mcpserver(name: str, namespace: str = "demo") -> dict:
+    return {
+        "kind": "MCPServer",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {"runtime": "python-string"},
+    }
+
+
+def _agent(name: str, mcp_servers: list[str], namespace: str = "demo") -> dict:
+    return {
+        "kind": "Agent",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {"modelAPI": "gpt", "model": "gpt-4", "mcpServers": mcp_servers},
+    }
+
+
+def test_encoding_conventions():
+    assert service_client_id("demo", "github") == "kaos-mcpserver-demo-github"
+    assert permission_set_name("demo", "github") == "kaos:mcpserver:demo:github:call"
+    assert agent_external_id("demo", "researcher") == "kaos://agent/demo/researcher"
+    assert mcpserver_resource_uri("demo", "github") == "kaos://mcpserver/demo/github"
+
+
+def test_project_full_graph():
+    state = project(
+        [
+            _mcpserver("github"),
+            _mcpserver("slack"),
+            _agent("researcher", ["github"]),
+        ]
+    )
+
+    # Both declared MCPServers become services even if only one is granted.
+    assert {s.client_id for s in state.services} == {
+        "kaos-mcpserver-demo-github",
+        "kaos-mcpserver-demo-slack",
+    }
+    # Only the requested edge yields a permission set.
+    assert [ps.name for ps in state.permission_sets] == ["kaos:mcpserver:demo:github:call"]
+
+    assert len(state.agents) == 1
+    agent = state.agents[0]
+    assert agent.external_id == "kaos://agent/demo/researcher"
+    assert agent.permission_set_names == ("kaos:mcpserver:demo:github:call",)
+    assert agent.granted_resources == ("kaos://mcpserver/demo/github",)
+
+
+def test_agent_without_edges_is_skipped():
+    state = project([_mcpserver("github"), _agent("idle", [])])
+    assert state.agents == []
+    # The standalone MCPServer is still projected as a service.
+    assert [s.client_id for s in state.services] == ["kaos-mcpserver-demo-github"]
+
+
+def test_edge_to_undeclared_mcpserver_still_yields_service():
+    # Agent references an MCPServer that has no standalone resource in the input.
+    state = project([_agent("researcher", ["ghost"])])
+    assert [s.client_id for s in state.services] == ["kaos-mcpserver-demo-ghost"]
+    assert [ps.name for ps in state.permission_sets] == ["kaos:mcpserver:demo:ghost:call"]
+    assert state.agents[0].granted_resources == ("kaos://mcpserver/demo/ghost",)
+
+
+def test_projection_is_idempotent_and_deduplicates():
+    resources = [
+        _mcpserver("github"),
+        _agent("a", ["github"]),
+        _agent("b", ["github"]),
+    ]
+    first = project(resources)
+    second = project(resources)
+
+    # Shared service/permission set are not duplicated across two agents.
+    assert len(first.services) == 1
+    assert len(first.permission_sets) == 1
+    assert len(first.agents) == 2
+
+    # Deterministic output: re-projecting the same input yields equal state.
+    assert _as_tuple(first) == _as_tuple(second)
+
+
+def test_admin_bodies_shape():
+    state = project([_mcpserver("github"), _agent("researcher", ["github"])])
+
+    svc_body = state.services[0].admin_body()
+    assert svc_body["client_id"] == "kaos-mcpserver-demo-github"
+    assert svc_body["scopes"] == [{"scope_value": "call", "description": "Invoke the MCP server"}]
+
+    ps_body = state.permission_sets[0].admin_body(service_id="svc-123")
+    assert ps_body["service_scopes"][0]["service_id"] == "svc-123"
+    assert ps_body["service_scopes"][0]["scopes"] == ["call"]
+
+    # Local agent body carries no client_id so AIB mints the actor token locally.
+    agent_body = state.agents[0].admin_body(permission_set_ids=["ps-1"])
+    assert "client_id" not in agent_body
+    assert agent_body["permission_sets"] == [
+        {"permission_set_id": "ps-1", "requirement_type": "mandatory"}
+    ]
+
+
+def _as_tuple(state: DesiredState):
+    return (
+        tuple(sorted(s.client_id for s in state.services)),
+        tuple(sorted(ps.name for ps in state.permission_sets)),
+        tuple(sorted(a.external_id for a in state.agents)),
+    )

--- a/sync-service/tests/test_reconcile.py
+++ b/sync-service/tests/test_reconcile.py
@@ -1,0 +1,139 @@
+"""Tests for the reconcile orchestration and credential Secret provisioning."""
+
+from __future__ import annotations
+
+import pytest
+
+from kaos_sync.config import Settings
+from kaos_sync.main import run_once
+from kaos_sync.projection import project
+from kaos_sync.reconcile import credential_secret_name, reconcile
+
+
+class FakeAIB:
+    """In-memory AIB admin double with create-or-get idempotency and credential minting."""
+
+    def __init__(self):
+        self.collections: dict[str, dict[str, dict]] = {}
+        self.mint_calls: list[str] = []
+        self._next = 0
+
+    def create_or_get(self, collection, match_field, match_value, body):
+        store = self.collections.setdefault(collection, {})
+        if match_value in store:
+            return store[match_value]["id"]
+        self._next += 1
+        item_id = f"{collection}-{self._next}"
+        store[match_value] = {"id": item_id, "body": body}
+        return item_id
+
+    def mint_credentials(self, agent_id):
+        self.mint_calls.append(agent_id)
+        return {"client_id": f"cid-{agent_id}", "client_secret": f"secret-{agent_id}"}
+
+
+class FakeSecrets:
+    def __init__(self):
+        self.store: dict[tuple[str, str], dict[str, str]] = {}
+
+    def get(self, namespace, name):
+        return self.store.get((namespace, name))
+
+    def upsert(self, namespace, name, string_data):
+        self.store[(namespace, name)] = dict(string_data)
+
+
+class FakeLister:
+    def __init__(self, resources):
+        self._resources = resources
+
+    def list_resources(self, namespaces):
+        return self._resources
+
+
+def _mcpserver(name, namespace="demo"):
+    return {"kind": "MCPServer", "metadata": {"name": name, "namespace": namespace}}
+
+
+def _agent(name, mcp_servers, namespace="demo"):
+    return {
+        "kind": "Agent",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {"mcpServers": mcp_servers},
+    }
+
+
+def test_credential_secret_name():
+    assert credential_secret_name("kaos-aib", "researcher") == "kaos-aib-researcher"
+
+
+def test_reconcile_creates_records_and_secret():
+    desired = project([_mcpserver("github"), _agent("researcher", ["github"])])
+    aib, secrets = FakeAIB(), FakeSecrets()
+
+    summary = reconcile(desired, aib, secrets, "kaos-aib")
+
+    assert summary.services == 1
+    assert summary.permission_sets == 1
+    assert len(summary.agents) == 1
+
+    agent = summary.agents[0]
+    assert agent.external_id == "kaos://agent/demo/researcher"
+    assert agent.secret_namespace == "demo"
+    assert agent.secret_name == "kaos-aib-researcher"
+    assert agent.credentials_minted is True
+
+    stored = secrets.get("demo", "kaos-aib-researcher")
+    assert stored == {
+        "client_id": f"cid-{agent.agent_id}",
+        "client_secret": f"secret-{agent.agent_id}",
+    }
+
+
+def test_reconcile_binds_agent_to_permission_sets():
+    desired = project([_agent("researcher", ["github"])])
+    aib, secrets = FakeAIB(), FakeSecrets()
+    reconcile(desired, aib, secrets)
+
+    agent_body = aib.collections["agents"]["kaos://agent/demo/researcher"]["body"]
+    bound_ids = [p["permission_set_id"] for p in agent_body["permission_sets"]]
+    ps_id = aib.collections["permission-sets"]["kaos:mcpserver:demo:github:call"]["id"]
+    assert bound_ids == [ps_id]
+    assert "client_id" not in agent_body
+
+
+def test_reconcile_is_idempotent_and_does_not_remint():
+    desired = project([_mcpserver("github"), _agent("researcher", ["github"])])
+    aib, secrets = FakeAIB(), FakeSecrets()
+
+    first = reconcile(desired, aib, secrets)
+    assert first.agents[0].credentials_minted is True
+    assert aib.mint_calls  # minted once
+
+    second = reconcile(desired, aib, secrets)
+    assert second.services == 1
+    assert second.permission_sets == 1
+    assert second.agents[0].credentials_minted is False
+    assert len(aib.mint_calls) == 1  # not minted again
+
+
+def test_reconcile_remints_when_secret_missing_credentials():
+    desired = project([_agent("researcher", ["github"])])
+    aib, secrets = FakeAIB(), FakeSecrets()
+    # Secret exists but is empty/incomplete -> credentials must be (re)minted.
+    secrets.upsert("demo", "kaos-aib-researcher", {})
+
+    summary = reconcile(desired, aib, secrets)
+    assert summary.agents[0].credentials_minted is True
+    assert secrets.get("demo", "kaos-aib-researcher")["client_id"]
+
+
+def test_run_once_projects_and_reconciles():
+    resources = [_mcpserver("github"), _mcpserver("slack"), _agent("researcher", ["github"])]
+    aib, secrets = FakeAIB(), FakeSecrets()
+    summary = run_once(Settings(), FakeLister(resources), aib, secrets)
+
+    # github + slack become services; only the github edge is granted.
+    assert summary.services == 2
+    assert summary.permission_sets == 1
+    assert summary.agents[0].secret_name == "kaos-aib-researcher"


### PR DESCRIPTION
Wires the agent-authentication components into an installable, end-to-end path:

- **Sync service** (`sync-service/`): a Python package that projects KAOS agents, MCP servers, and model APIs into the identity broker (synthetic services, permission sets, local-client agents) and provisions per-agent credential Secrets via a periodic reconcile loop. Includes a tested pure projection library, a reconcile runtime with a mocked-broker/fake-k8s test suite, a Dockerfile, and a Helm chart (Deployment + ServiceAccount + cluster RBAC).
- **Operator credential mounting**: new `security.agentAuth.issuer` and `security.agentAuth.credentialSecretPrefix` settings. When configured alongside the access-check URL, the agent reconciler injects the agent's broker identity and credentials (optional secret references so pods start before the Secret exists) plus the token endpoint. Gated and default-off.
- **CLI `kaos system install --auth-enabled`**: wires the operator to the broker (access-check URL, issuer, credential prefix) and can install the broker (local chart) and deploy the sync service, with sensible namespace-derived defaults and overrides.

Credential mounting and auth wiring are default-off, so existing installs are unchanged. Unit, operator, and CLI tests cover both enabled and disabled modes.