### PR TITLE
PR-ADR-KAOS-4: Harden KAOS sync service: ModelAPI projection, pruning, drift reporting and observability

### DIFF
--- a/sync-service/README.md
+++ b/sync-service/README.md
@@ -17,7 +17,7 @@ The reconcile loop is resilient: every service, permission set and agent is reco
 
 ## Observability
 
-- Prometheus metrics on `KAOS_SYNC_METRICS_PORT` (default `9090`) at `/metrics`, including reconcile pass counts, minted credentials, projected resource counts and problems by category.
+- Metrics are pushed via OTLP to the endpoint in `OTEL_EXPORTER_OTLP_ENDPOINT` (using `OTEL_SERVICE_NAME`, default `kaos-sync`), including reconcile pass counts, minted credentials, projected resource counts and problems by category. Export is enabled only when both env vars are set.
 - Liveness probe at `/healthz` and readiness probe at `/readyz` on `KAOS_SYNC_HEALTH_PORT` (default `8080`); readiness flips to ready after the first reconcile pass completes.
 
 ## Layout
@@ -25,7 +25,7 @@ The reconcile loop is resilient: every service, permission set and agent is reco
 - `kaos_sync/projection.py` — pure projection of KAOS resources into desired AIB records (no I/O).
 - `kaos_sync/aib_client.py` — AIB admin API client with bounded retries.
 - `kaos_sync/reconcile.py` — reconcile loop, pruning and credential Secret writing.
-- `kaos_sync/observability.py` — Prometheus metrics and health/readiness endpoints.
+- `kaos_sync/observability.py` — OTLP metric export and health/readiness endpoints.
 - `kaos_sync/config.py` — settings.
 - `kaos_sync/main.py` — entrypoint.
 

--- a/sync-service/README.md
+++ b/sync-service/README.md
@@ -4,19 +4,28 @@ A lightweight external service that synchronizes KAOS custom resources into the 
 
 ## What it does
 
-The service watches KAOS `Agent` and `MCPServer` resources and projects them into AIB using a stable bootstrap encoding:
+The service watches KAOS `Agent`, `MCPServer` and `ModelAPI` resources and projects them into AIB using a stable bootstrap encoding:
 
 - Each `MCPServer` `<ns>/<name>` becomes a synthetic AIB service with `client_id` `kaos-mcpserver-<ns>-<name>` exposing a single `call` scope.
-- Each requested `Agent -> MCPServer` edge becomes an AIB permission set `kaos:mcpserver:<ns>:<mcp>:call`.
+- Each `ModelAPI` `<ns>/<name>` becomes a synthetic AIB service with `client_id` `kaos-modelapi-<ns>-<name>` exposing a single `call` scope.
+- Each requested `Agent -> MCPServer` or `Agent -> ModelAPI` edge becomes an AIB permission set `kaos:<kind>:<ns>:<target>:call`.
 - Each `Agent` becomes an AIB *local* agent (no `client_id`, so AIB mints the actor token locally) bound to the permission sets for its edges.
 
 For every projected agent, the service obtains AIB client credentials and writes them into a Kubernetes Secret named `kaos-aib-<agent-id>` for the operator to mount into the agent pod.
 
+The reconcile loop is resilient: every service, permission set and agent is reconciled in isolation, so a single broker or resource failure is recorded as a categorized problem without aborting the pass. KAOS-owned broker records and credential Secrets that no longer correspond to a live KAOS resource are pruned (controllable via `KAOS_SYNC_PRUNE_ENABLED`). Broker admin requests use bounded exponential-backoff retries.
+
+## Observability
+
+- Prometheus metrics on `KAOS_SYNC_METRICS_PORT` (default `9090`) at `/metrics`, including reconcile pass counts, minted credentials, projected resource counts and problems by category.
+- Liveness probe at `/healthz` and readiness probe at `/readyz` on `KAOS_SYNC_HEALTH_PORT` (default `8080`); readiness flips to ready after the first reconcile pass completes.
+
 ## Layout
 
 - `kaos_sync/projection.py` — pure projection of KAOS resources into desired AIB records (no I/O).
-- `kaos_sync/aib_client.py` — AIB admin API client.
-- `kaos_sync/reconcile.py` — reconcile loop and credential Secret writing.
+- `kaos_sync/aib_client.py` — AIB admin API client with bounded retries.
+- `kaos_sync/reconcile.py` — reconcile loop, pruning and credential Secret writing.
+- `kaos_sync/observability.py` — Prometheus metrics and health/readiness endpoints.
 - `kaos_sync/config.py` — settings.
 - `kaos_sync/main.py` — entrypoint.
 

--- a/sync-service/chart/templates/deployment.yaml
+++ b/sync-service/chart/templates/deployment.yaml
@@ -47,6 +47,33 @@ spec:
               value: {{ .Values.sync.reconcileIntervalSeconds | quote }}
             - name: KAOS_SYNC_REQUEST_TIMEOUT_SECONDS
               value: {{ .Values.sync.requestTimeoutSeconds | quote }}
+            - name: KAOS_SYNC_PRUNE_ENABLED
+              value: {{ .Values.sync.pruneEnabled | quote }}
+            - name: KAOS_SYNC_RETRY_MAX_ATTEMPTS
+              value: {{ .Values.sync.retryMaxAttempts | quote }}
+            - name: KAOS_SYNC_RETRY_BASE_DELAY_SECONDS
+              value: {{ .Values.sync.retryBaseDelaySeconds | quote }}
+            - name: KAOS_SYNC_METRICS_PORT
+              value: {{ .Values.observability.metricsPort | quote }}
+            - name: KAOS_SYNC_HEALTH_PORT
+              value: {{ .Values.observability.healthPort | quote }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.observability.metricsPort }}
+            - name: health
+              containerPort: {{ .Values.observability.healthPort }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/sync-service/chart/templates/deployment.yaml
+++ b/sync-service/chart/templates/deployment.yaml
@@ -53,13 +53,15 @@ spec:
               value: {{ .Values.sync.retryMaxAttempts | quote }}
             - name: KAOS_SYNC_RETRY_BASE_DELAY_SECONDS
               value: {{ .Values.sync.retryBaseDelaySeconds | quote }}
-            - name: KAOS_SYNC_METRICS_PORT
-              value: {{ .Values.observability.metricsPort | quote }}
             - name: KAOS_SYNC_HEALTH_PORT
               value: {{ .Values.observability.healthPort | quote }}
+            {{- if .Values.observability.otel.endpoint }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.observability.otel.serviceName | quote }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.observability.otel.endpoint | quote }}
+            {{- end }}
           ports:
-            - name: metrics
-              containerPort: {{ .Values.observability.metricsPort }}
             - name: health
               containerPort: {{ .Values.observability.healthPort }}
           livenessProbe:

--- a/sync-service/chart/templates/rbac.yaml
+++ b/sync-service/chart/templates/rbac.yaml
@@ -9,10 +9,10 @@ rules:
   - apiGroups: ["kaos.tools"]
     resources: ["agents", "mcpservers", "modelapis"]
     verbs: ["get", "list", "watch"]
-  # Provision and refresh per-agent credential Secrets.
+  # Provision, refresh and prune per-agent credential Secrets.
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/sync-service/chart/values.yaml
+++ b/sync-service/chart/values.yaml
@@ -37,6 +37,18 @@ sync:
   reconcileIntervalSeconds: 30
   # Per-request timeout to the broker admin API, in seconds.
   requestTimeoutSeconds: 10
+  # Delete orphaned broker records and credential Secrets no longer in the desired state.
+  pruneEnabled: true
+  # Max attempts per broker admin request before giving up.
+  retryMaxAttempts: 4
+  # Base delay for exponential backoff between broker admin retries, in seconds.
+  retryBaseDelaySeconds: 0.5
+
+# Metrics and health endpoint configuration. The ports may be equal, in which case a
+# single server backs /metrics, /healthz and /readyz.
+observability:
+  metricsPort: 9090
+  healthPort: 8080
 
 resources: {}
 

--- a/sync-service/chart/values.yaml
+++ b/sync-service/chart/values.yaml
@@ -44,11 +44,15 @@ sync:
   # Base delay for exponential backoff between broker admin retries, in seconds.
   retryBaseDelaySeconds: 0.5
 
-# Metrics and health endpoint configuration. The ports may be equal, in which case a
-# single server backs /metrics, /healthz and /readyz.
+# Health endpoint and telemetry configuration. The health server backs the
+# /healthz and /readyz probes; metrics are pushed via OTLP when an endpoint is set.
 observability:
-  metricsPort: 9090
   healthPort: 8080
+  otel:
+    serviceName: kaos-sync
+    # OTLP endpoint for metric export (e.g. http://otel-collector:4317). Metrics
+    # are only emitted when this is set; leave empty to disable telemetry export.
+    endpoint: ""
 
 resources: {}
 

--- a/sync-service/kaos_sync/aib_client.py
+++ b/sync-service/kaos_sync/aib_client.py
@@ -3,11 +3,21 @@
 A thin idempotent wrapper over the AIB admin REST API used by the sync reconcile loop.
 Pre-authentication is plain-header based: the configured principal is sent on every
 request via the configured header (``X-Remote-User`` by default).
+
+Transient failures (connection errors and ``5xx`` responses) are retried with bounded
+exponential backoff so a briefly-unreachable or restarting broker does not fail a whole
+reconcile pass; non-transient ``4xx`` responses are surfaced immediately.
 """
 
 from __future__ import annotations
 
+import time
+from typing import List
+
 import httpx
+
+# Transient HTTP statuses worth retrying (server-side / gateway failures only).
+_RETRYABLE_STATUS = frozenset({500, 502, 503, 504})
 
 
 class AIBAdmin:
@@ -20,18 +30,61 @@ class AIBAdmin:
         principal_header: str = "X-Remote-User",
         timeout: float = 10.0,
         client: httpx.Client | None = None,
+        retry_max_attempts: int = 4,
+        retry_base_delay_seconds: float = 0.5,
+        sleep=time.sleep,
     ) -> None:
         self._client = client or httpx.Client(
             base_url=base_url,
             timeout=timeout,
             headers={principal_header: principal},
         )
+        self._retry_max_attempts = max(1, retry_max_attempts)
+        self._retry_base_delay_seconds = retry_base_delay_seconds
+        self._sleep = sleep
 
-    def _list(self, collection: str) -> list[dict]:
-        data = self._client.get(f"/{collection}").json()
+    def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        """Issue a request, retrying transient connection/5xx failures with backoff.
+
+        Retries are bounded by ``retry_max_attempts``; the delay grows exponentially from
+        ``retry_base_delay_seconds``. A connection error on the final attempt is re-raised;
+        a retryable status on the final attempt is returned to the caller to handle.
+        """
+        last_exc: Exception | None = None
+        response: httpx.Response | None = None
+        for attempt in range(self._retry_max_attempts):
+            try:
+                response = self._client.request(method, url, **kwargs)
+            except httpx.TransportError as exc:
+                last_exc = exc
+                response = None
+            else:
+                if response.status_code not in _RETRYABLE_STATUS:
+                    return response
+            if attempt < self._retry_max_attempts - 1:
+                self._sleep(self._retry_base_delay_seconds * (2**attempt))
+        if response is None:
+            assert last_exc is not None
+            raise last_exc
+        return response
+
+    def _list(self, collection: str) -> List[dict]:
+        data = self._request("GET", f"/{collection}").json()
         if isinstance(data, dict):
             return data.get("items", [])
         return data
+
+    def list(self, collection: str) -> List[dict]:
+        """Return all items in a collection (``items`` envelope or bare list)."""
+        return self._list(collection)
+
+    def get(self, collection: str, resource_id: str) -> dict | None:
+        """Return a single resource by id, or ``None`` if it does not exist (404)."""
+        response = self._request("GET", f"/{collection}/{resource_id}")
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
 
     def create_or_get(self, collection: str, match_field: str, match_value: str, body: dict) -> str:
         """Create a resource, returning its id; if it already exists, return that id.
@@ -40,7 +93,7 @@ class AIBAdmin:
         item whose ``match_field`` equals ``match_value``, which makes the call idempotent
         across reconcile passes.
         """
-        response = self._client.post(f"/{collection}", json=body)
+        response = self._request("POST", f"/{collection}", json=body)
         if response.status_code // 100 == 2:
             return response.json()["id"]
         for item in self._list(collection):
@@ -51,11 +104,31 @@ class AIBAdmin:
             f"{response.status_code} {response.text}"
         )
 
+    def delete(self, collection: str, resource_id: str) -> bool:
+        """Delete a resource by id. Returns ``True`` if deleted, ``False`` if already gone.
+
+        A ``404`` is treated as success (the desired end state -- absence -- already holds),
+        so pruning is idempotent across passes.
+        """
+        response = self._request("DELETE", f"/{collection}/{resource_id}")
+        if response.status_code == 404:
+            return False
+        response.raise_for_status()
+        return True
+
     def mint_credentials(self, agent_id: str) -> dict:
         """Mint client credentials for an agent and return the credential payload."""
-        response = self._client.post(f"/agents/{agent_id}/client-credentials")
+        response = self._request("POST", f"/agents/{agent_id}/client-credentials")
         response.raise_for_status()
         return response.json()
+
+    def revoke_credentials(self, agent_id: str) -> bool:
+        """Revoke an agent's client credentials. Returns ``False`` if none existed (404)."""
+        response = self._request("DELETE", f"/agents/{agent_id}/client-credentials")
+        if response.status_code == 404:
+            return False
+        response.raise_for_status()
+        return True
 
     def close(self) -> None:
         self._client.close()

--- a/sync-service/kaos_sync/config.py
+++ b/sync-service/kaos_sync/config.py
@@ -18,6 +18,10 @@ class Settings:
     reconcile_interval_seconds: delay between reconcile passes.
     request_timeout_seconds: per-request timeout for AIB admin calls.
     prune_enabled: whether to delete orphaned broker records and Secrets each pass.
+    metrics_port: port exposing the Prometheus ``/metrics`` endpoint.
+    health_port: port exposing ``/healthz`` and ``/readyz`` (often equal to metrics_port).
+    retry_max_attempts: max attempts per AIB admin request before giving up.
+    retry_base_delay_seconds: base delay for exponential backoff between retries.
     """
 
     aib_admin_url: str = "http://localhost:14000/api"
@@ -28,6 +32,10 @@ class Settings:
     reconcile_interval_seconds: int = 30
     request_timeout_seconds: float = 10.0
     prune_enabled: bool = True
+    metrics_port: int = 9090
+    health_port: int = 8080
+    retry_max_attempts: int = 4
+    retry_base_delay_seconds: float = 0.5
 
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> "Settings":
@@ -50,6 +58,12 @@ class Settings:
                 env.get("KAOS_SYNC_REQUEST_TIMEOUT_SECONDS", cls.request_timeout_seconds)
             ),
             prune_enabled=_env_bool(env, "KAOS_SYNC_PRUNE_ENABLED", cls.prune_enabled),
+            metrics_port=int(env.get("KAOS_SYNC_METRICS_PORT", cls.metrics_port)),
+            health_port=int(env.get("KAOS_SYNC_HEALTH_PORT", cls.health_port)),
+            retry_max_attempts=int(env.get("KAOS_SYNC_RETRY_MAX_ATTEMPTS", cls.retry_max_attempts)),
+            retry_base_delay_seconds=float(
+                env.get("KAOS_SYNC_RETRY_BASE_DELAY_SECONDS", cls.retry_base_delay_seconds)
+            ),
         )
 
 

--- a/sync-service/kaos_sync/config.py
+++ b/sync-service/kaos_sync/config.py
@@ -18,10 +18,13 @@ class Settings:
     reconcile_interval_seconds: delay between reconcile passes.
     request_timeout_seconds: per-request timeout for AIB admin calls.
     prune_enabled: whether to delete orphaned broker records and Secrets each pass.
-    metrics_port: port exposing the Prometheus ``/metrics`` endpoint.
-    health_port: port exposing ``/healthz`` and ``/readyz`` (often equal to metrics_port).
+    health_port: port exposing ``/healthz`` and ``/readyz`` for the Kubernetes probes.
     retry_max_attempts: max attempts per AIB admin request before giving up.
     retry_base_delay_seconds: base delay for exponential backoff between retries.
+
+    Metrics are exported via OTLP using the standard ``OTEL_*`` environment variables
+    (e.g. ``OTEL_SERVICE_NAME``, ``OTEL_EXPORTER_OTLP_ENDPOINT``), read by the SDK
+    directly, so there is no scrape port to configure here.
     """
 
     aib_admin_url: str = "http://localhost:14000/api"
@@ -32,7 +35,6 @@ class Settings:
     reconcile_interval_seconds: int = 30
     request_timeout_seconds: float = 10.0
     prune_enabled: bool = True
-    metrics_port: int = 9090
     health_port: int = 8080
     retry_max_attempts: int = 4
     retry_base_delay_seconds: float = 0.5
@@ -58,7 +60,6 @@ class Settings:
                 env.get("KAOS_SYNC_REQUEST_TIMEOUT_SECONDS", cls.request_timeout_seconds)
             ),
             prune_enabled=_env_bool(env, "KAOS_SYNC_PRUNE_ENABLED", cls.prune_enabled),
-            metrics_port=int(env.get("KAOS_SYNC_METRICS_PORT", cls.metrics_port)),
             health_port=int(env.get("KAOS_SYNC_HEALTH_PORT", cls.health_port)),
             retry_max_attempts=int(env.get("KAOS_SYNC_RETRY_MAX_ATTEMPTS", cls.retry_max_attempts)),
             retry_base_delay_seconds=float(

--- a/sync-service/kaos_sync/config.py
+++ b/sync-service/kaos_sync/config.py
@@ -16,6 +16,8 @@ class Settings:
     namespaces: namespaces to watch; empty means cluster-wide.
     credential_secret_prefix: prefix for per-agent credential Secret names.
     reconcile_interval_seconds: delay between reconcile passes.
+    request_timeout_seconds: per-request timeout for AIB admin calls.
+    prune_enabled: whether to delete orphaned broker records and Secrets each pass.
     """
 
     aib_admin_url: str = "http://localhost:14000/api"
@@ -25,6 +27,7 @@ class Settings:
     credential_secret_prefix: str = "kaos-aib"
     reconcile_interval_seconds: int = 30
     request_timeout_seconds: float = 10.0
+    prune_enabled: bool = True
 
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> "Settings":
@@ -46,4 +49,12 @@ class Settings:
             request_timeout_seconds=float(
                 env.get("KAOS_SYNC_REQUEST_TIMEOUT_SECONDS", cls.request_timeout_seconds)
             ),
+            prune_enabled=_env_bool(env, "KAOS_SYNC_PRUNE_ENABLED", cls.prune_enabled),
         )
+
+
+def _env_bool(env: dict[str, str], key: str, default: bool) -> bool:
+    raw = env.get(key)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")

--- a/sync-service/kaos_sync/k8s.py
+++ b/sync-service/kaos_sync/k8s.py
@@ -8,6 +8,8 @@ this module, so tests need no cluster.
 
 from __future__ import annotations
 
+from typing import List
+
 from kubernetes import client, config
 
 KAOS_GROUP = "kaos.tools"
@@ -61,6 +63,33 @@ class KubeSecretStore:
             if exc.status != 409:
                 raise
             self._api.replace_namespaced_secret(name, namespace, body)
+
+    def list(self, namespaces: tuple[str, ...]) -> List[tuple[str, str]]:
+        """List ``(namespace, name)`` of sync-managed credential Secrets.
+
+        Only Secrets carrying the ``kaos-sync`` managed-by label are returned so pruning
+        never removes Secrets owned by anything other than this service.
+        """
+        selector = "app.kubernetes.io/managed-by=kaos-sync"
+        items: list[tuple[str, str]] = []
+        if namespaces:
+            for namespace in namespaces:
+                result = self._api.list_namespaced_secret(namespace, label_selector=selector)
+                items.extend((s.metadata.namespace, s.metadata.name) for s in result.items)
+        else:
+            result = self._api.list_secret_for_all_namespaces(label_selector=selector)
+            items.extend((s.metadata.namespace, s.metadata.name) for s in result.items)
+        return items
+
+    def delete(self, namespace: str, name: str) -> bool:
+        """Delete a Secret, treating a missing Secret (404) as already absent."""
+        try:
+            self._api.delete_namespaced_secret(name, namespace)
+        except client.ApiException as exc:  # type: ignore[attr-defined]
+            if exc.status == 404:
+                return False
+            raise
+        return True
 
 
 class KaosResourceLister:

--- a/sync-service/kaos_sync/k8s.py
+++ b/sync-service/kaos_sync/k8s.py
@@ -14,6 +14,7 @@ KAOS_GROUP = "kaos.tools"
 KAOS_VERSION = "v1alpha1"
 AGENT_PLURAL = "agents"
 MCPSERVER_PLURAL = "mcpservers"
+MODELAPI_PLURAL = "modelapis"
 
 
 def load_kube_config() -> None:
@@ -63,7 +64,7 @@ class KubeSecretStore:
 
 
 class KaosResourceLister:
-    """Lists KAOS Agent and MCPServer resources across the configured namespaces."""
+    """Lists KAOS Agent, MCPServer and ModelAPI resources across the configured namespaces."""
 
     def __init__(self, custom_api: client.CustomObjectsApi | None = None) -> None:
         self._api = custom_api or client.CustomObjectsApi()
@@ -84,6 +85,8 @@ class KaosResourceLister:
         return items
 
     def list_resources(self, namespaces: tuple[str, ...]) -> list[dict]:
-        return self._list(MCPSERVER_PLURAL, "MCPServer", namespaces) + self._list(
-            AGENT_PLURAL, "Agent", namespaces
+        return (
+            self._list(MCPSERVER_PLURAL, "MCPServer", namespaces)
+            + self._list(MODELAPI_PLURAL, "ModelAPI", namespaces)
+            + self._list(AGENT_PLURAL, "Agent", namespaces)
         )

--- a/sync-service/kaos_sync/main.py
+++ b/sync-service/kaos_sync/main.py
@@ -17,15 +17,38 @@ def run_once(settings: Settings, lister, aib, secrets) -> ReconcileSummary:
     """Run a single reconcile pass and return its summary."""
     resources = lister.list_resources(settings.namespaces)
     desired = project(resources)
-    summary = reconcile(desired, aib, secrets, settings.credential_secret_prefix)
+    summary = reconcile(
+        desired,
+        aib,
+        secrets,
+        settings.credential_secret_prefix,
+        prune=settings.prune_enabled,
+        namespaces=settings.namespaces,
+    )
     minted = sum(1 for a in summary.agents if a.credentials_minted)
+    failed = sum(1 for a in summary.agents if not a.ok)
     logger.info(
-        "reconciled services=%d permission_sets=%d agents=%d credentials_minted=%d",
+        "reconciled services=%d permission_sets=%d agents=%d credentials_minted=%d "
+        "failed=%d pruned_agents=%d pruned_permission_sets=%d pruned_services=%d "
+        "pruned_secrets=%d problems=%d",
         summary.services,
         summary.permission_sets,
         len(summary.agents),
         minted,
+        failed,
+        summary.pruned.agents,
+        summary.pruned.permission_sets,
+        summary.pruned.services,
+        summary.pruned.secrets,
+        len(summary.problems),
     )
+    for problem in summary.problems:
+        logger.warning(
+            "problem category=%s resource=%s detail=%s",
+            problem.category.value,
+            problem.resource,
+            problem.detail,
+        )
     return summary
 
 

--- a/sync-service/kaos_sync/main.py
+++ b/sync-service/kaos_sync/main.py
@@ -7,6 +7,7 @@ import time
 
 from kaos_sync.aib_client import AIBAdmin
 from kaos_sync.config import Settings
+from kaos_sync.observability import HealthState, record_summary, start_http_servers
 from kaos_sync.projection import project
 from kaos_sync.reconcile import ReconcileSummary, reconcile
 
@@ -66,19 +67,31 @@ def main() -> int:
         principal=settings.aib_principal,
         principal_header=settings.aib_principal_header,
         timeout=settings.request_timeout_seconds,
+        retry_max_attempts=settings.retry_max_attempts,
+        retry_base_delay_seconds=settings.retry_base_delay_seconds,
     )
 
+    health = HealthState()
+    start_http_servers((settings.metrics_port, settings.health_port), health)
+
     logger.info(
-        "starting reconcile loop admin=%s interval=%ds namespaces=%s",
+        "starting reconcile loop admin=%s interval=%ds namespaces=%s "
+        "prune=%s metrics_port=%d health_port=%d",
         settings.aib_admin_url,
         settings.reconcile_interval_seconds,
         ",".join(settings.namespaces) or "<all>",
+        settings.prune_enabled,
+        settings.metrics_port,
+        settings.health_port,
     )
     while True:
         try:
-            run_once(settings, lister, aib, secrets)
+            summary = run_once(settings, lister, aib, secrets)
+            record_summary(summary)
         except Exception:  # noqa: BLE001 - keep the loop alive across transient failures
             logger.exception("reconcile pass failed")
+        finally:
+            health.mark_ready()
         time.sleep(settings.reconcile_interval_seconds)
 
 

--- a/sync-service/kaos_sync/main.py
+++ b/sync-service/kaos_sync/main.py
@@ -7,7 +7,12 @@ import time
 
 from kaos_sync.aib_client import AIBAdmin
 from kaos_sync.config import Settings
-from kaos_sync.observability import HealthState, record_summary, start_http_servers
+from kaos_sync.observability import (
+    HealthState,
+    record_summary,
+    setup_telemetry,
+    start_health_server,
+)
 from kaos_sync.projection import project
 from kaos_sync.reconcile import ReconcileSummary, reconcile
 
@@ -56,6 +61,7 @@ def run_once(settings: Settings, lister, aib, secrets) -> ReconcileSummary:
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     settings = Settings.from_env()
+    setup_telemetry()
 
     from kaos_sync.k8s import KaosResourceLister, KubeSecretStore, load_kube_config
 
@@ -72,16 +78,14 @@ def main() -> int:
     )
 
     health = HealthState()
-    start_http_servers((settings.metrics_port, settings.health_port), health)
+    start_health_server(settings.health_port, health)
 
     logger.info(
-        "starting reconcile loop admin=%s interval=%ds namespaces=%s "
-        "prune=%s metrics_port=%d health_port=%d",
+        "starting reconcile loop admin=%s interval=%ds namespaces=%s prune=%s health_port=%d",
         settings.aib_admin_url,
         settings.reconcile_interval_seconds,
         ",".join(settings.namespaces) or "<all>",
         settings.prune_enabled,
-        settings.metrics_port,
         settings.health_port,
     )
     while True:

--- a/sync-service/kaos_sync/observability.py
+++ b/sync-service/kaos_sync/observability.py
@@ -1,65 +1,175 @@
-"""Prometheus metrics and health/readiness endpoints for the sync service.
+"""OpenTelemetry metrics and health/readiness endpoints for the sync service.
 
-Metrics describe the most recent reconcile pass (counts, failures, prune activity) and
-are exposed on ``/metrics``. Liveness (``/healthz``) reports that the process is up;
-readiness (``/readyz``) reports that at least one reconcile pass has completed, so a
-deployment is only considered ready once it has projected the current desired state.
+Metrics are exported over OTLP (push) using the standard ``OTEL_*`` environment
+variables, consistent with the rest of KAOS — there is no scrape endpoint. Counters
+track cumulative reconcile activity (passes, mints, problems, prunes) and observable
+gauges report the most recent pass snapshot. Liveness (``/healthz``) and readiness
+(``/readyz``) are served over plain HTTP for the Kubernetes probes; readiness reports
+that at least one reconcile pass has completed.
 
 The path routing is factored into :func:`handle_path` so it can be unit tested without
-binding a socket; :func:`start_http_servers` wires that routing into a threaded HTTP
-server for the runtime.
+binding a socket; :func:`start_health_server` wires that routing into a threaded HTTP
+server for the runtime. Metric instruments live on :class:`SyncMetrics`, which binds to
+a meter provider so tests can drive it with an in-memory reader.
 """
 
 from __future__ import annotations
 
+import logging
+import os
 import threading
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Iterable, Optional
 
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, generate_latest
+from opentelemetry import metrics
+from opentelemetry.metrics import CallbackOptions, MeterProvider, Observation
 
-RECONCILE_PASSES = Counter("kaos_sync_reconcile_passes_total", "Total reconcile passes run.")
-RECONCILE_PROBLEMS = Counter(
-    "kaos_sync_reconcile_problems_total",
-    "Reconcile problems encountered, by category.",
-    ["category"],
-)
-CREDENTIALS_MINTED = Counter("kaos_sync_credentials_minted_total", "Credential mints performed.")
-PRUNED = Counter(
-    "kaos_sync_pruned_total", "Orphaned records removed during pruning, by kind.", ["kind"]
-)
-SERVICES_SYNCED = Gauge("kaos_sync_services", "Broker services reconciled in the last pass.")
-PERMISSION_SETS_SYNCED = Gauge(
-    "kaos_sync_permission_sets", "Broker permission sets reconciled in the last pass."
-)
-AGENTS_SYNCED = Gauge("kaos_sync_agents_synced", "Agents successfully synced in the last pass.")
-AGENTS_FAILED = Gauge("kaos_sync_agents_failed", "Agents that failed to sync in the last pass.")
-LAST_PASS_OK = Gauge(
-    "kaos_sync_last_pass_ok", "1 if the last reconcile pass had no problems, else 0."
-)
+logger = logging.getLogger("kaos_sync")
+
+_METER_NAME = "kaos-sync"
+_PREFIX = "kaos.sync."
+
+
+@dataclass
+class _Snapshot:
+    """Last-pass gauge values, replaced wholesale on each recorded pass."""
+
+    services: int = 0
+    permission_sets: int = 0
+    agents_synced: int = 0
+    agents_failed: int = 0
+    last_pass_ok: int = 0
+
+
+class SyncMetrics:
+    """OTel instruments describing the reconcile loop, bound to a meter provider.
+
+    Counters are cumulative; the last-pass values are reported through observable
+    gauges that read the current :class:`_Snapshot` at collection time.
+    """
+
+    def __init__(self, meter_provider: Optional[MeterProvider] = None) -> None:
+        meter = (meter_provider or metrics).get_meter(_METER_NAME)
+        self._snapshot = _Snapshot()
+
+        self._passes = meter.create_counter(
+            _PREFIX + "reconcile.passes",
+            unit="1",
+            description="Total reconcile passes run.",
+        )
+        self._problems = meter.create_counter(
+            _PREFIX + "reconcile.problems",
+            unit="1",
+            description="Reconcile problems encountered, by category.",
+        )
+        self._minted = meter.create_counter(
+            _PREFIX + "credentials.minted",
+            unit="1",
+            description="Credential mints performed.",
+        )
+        self._pruned = meter.create_counter(
+            _PREFIX + "pruned",
+            unit="1",
+            description="Orphaned records removed during pruning, by kind.",
+        )
+
+        for name, attr, description in (
+            ("services", "services", "Broker services reconciled in the last pass."),
+            (
+                "permission_sets",
+                "permission_sets",
+                "Broker permission sets reconciled in the last pass.",
+            ),
+            ("agents.synced", "agents_synced", "Agents successfully synced in the last pass."),
+            ("agents.failed", "agents_failed", "Agents that failed to sync in the last pass."),
+            ("last_pass_ok", "last_pass_ok", "1 if the last pass had no problems, else 0."),
+        ):
+            meter.create_observable_gauge(
+                _PREFIX + name,
+                callbacks=[self._observe(attr)],
+                unit="1",
+                description=description,
+            )
+
+    def _observe(self, attr: str):
+        def callback(_options: CallbackOptions) -> Iterable[Observation]:
+            return [Observation(getattr(self._snapshot, attr))]
+
+        return callback
+
+    def record(self, summary) -> None:
+        """Update instruments from a completed ``ReconcileSummary``."""
+        self._passes.add(1)
+
+        minted = sum(1 for agent in summary.agents if agent.credentials_minted)
+        if minted:
+            self._minted.add(minted)
+
+        for problem in summary.problems:
+            self._problems.add(1, {"category": problem.category.value})
+
+        for kind in ("agents", "permission_sets", "services", "secrets"):
+            count = getattr(summary.pruned, kind)
+            if count:
+                self._pruned.add(count, {"kind": kind})
+
+        self._snapshot = _Snapshot(
+            services=summary.services,
+            permission_sets=summary.permission_sets,
+            agents_synced=sum(1 for agent in summary.agents if agent.ok),
+            agents_failed=sum(1 for agent in summary.agents if not agent.ok),
+            last_pass_ok=1 if summary.ok else 0,
+        )
+
+
+_metrics: Optional[SyncMetrics] = None
+
+
+def setup_telemetry() -> bool:
+    """Configure OTLP metric export from the standard ``OTEL_*`` env vars.
+
+    Mirrors the rest of KAOS: a no-op unless both ``OTEL_SERVICE_NAME`` and
+    ``OTEL_EXPORTER_OTLP_ENDPOINT`` are set. When unset, :func:`record_summary` still
+    runs against the default no-op meter, so the reconcile loop is unaffected.
+    """
+    global _metrics
+    if not os.getenv("OTEL_SERVICE_NAME") or not os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        logger.debug(
+            "OpenTelemetry not configured "
+            "(OTEL_SERVICE_NAME and OTEL_EXPORTER_OTLP_ENDPOINT required); "
+            "metrics export disabled"
+        )
+        return False
+
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+    from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+    resource = Resource.create({SERVICE_NAME: os.environ["OTEL_SERVICE_NAME"]})
+    reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+    provider = SdkMeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+    _metrics = SyncMetrics(provider)
+    logger.info(
+        "OpenTelemetry metrics initialized (service=%s endpoint=%s)",
+        os.environ["OTEL_SERVICE_NAME"],
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"],
+    )
+    return True
 
 
 def record_summary(summary) -> None:
-    """Update metrics from a completed :class:`~kaos_sync.reconcile.ReconcileSummary`."""
-    RECONCILE_PASSES.inc()
-    minted = sum(1 for agent in summary.agents if agent.credentials_minted)
-    if minted:
-        CREDENTIALS_MINTED.inc(minted)
-    for problem in summary.problems:
-        RECONCILE_PROBLEMS.labels(category=problem.category.value).inc()
-    if summary.pruned.agents:
-        PRUNED.labels(kind="agents").inc(summary.pruned.agents)
-    if summary.pruned.permission_sets:
-        PRUNED.labels(kind="permission_sets").inc(summary.pruned.permission_sets)
-    if summary.pruned.services:
-        PRUNED.labels(kind="services").inc(summary.pruned.services)
-    if summary.pruned.secrets:
-        PRUNED.labels(kind="secrets").inc(summary.pruned.secrets)
-    SERVICES_SYNCED.set(summary.services)
-    PERMISSION_SETS_SYNCED.set(summary.permission_sets)
-    AGENTS_SYNCED.set(sum(1 for agent in summary.agents if agent.ok))
-    AGENTS_FAILED.set(sum(1 for agent in summary.agents if not agent.ok))
-    LAST_PASS_OK.set(1 if summary.ok else 0)
+    """Record a completed reconcile pass into OTel metrics.
+
+    Binds to the global meter provider on first use when telemetry was not explicitly
+    configured, so instruments are valid (and harmlessly no-op) regardless of setup.
+    """
+    global _metrics
+    if _metrics is None:
+        _metrics = SyncMetrics()
+    _metrics.record(summary)
 
 
 @dataclass
@@ -75,8 +185,6 @@ class HealthState:
 def handle_path(path: str, state: HealthState) -> tuple[int, str, bytes]:
     """Resolve an HTTP path to ``(status, content_type, body)`` for the health server."""
     route = path.split("?", 1)[0]
-    if route == "/metrics":
-        return 200, CONTENT_TYPE_LATEST, generate_latest()
     if route == "/healthz":
         return 200, "text/plain", b"ok"
     if route == "/readyz":
@@ -102,18 +210,8 @@ def _make_handler(state: HealthState) -> type[BaseHTTPRequestHandler]:
     return _Handler
 
 
-def start_http_servers(ports: tuple[int, ...], state: HealthState) -> list[ThreadingHTTPServer]:
-    """Start a daemon HTTP server on each distinct port serving the health routes.
-
-    The metrics and health ports are commonly the same; identical ports are de-duplicated
-    so a single server backs every route. Each server runs on a daemon thread so it never
-    blocks process shutdown.
-    """
-    handler = _make_handler(state)
-    servers: list[ThreadingHTTPServer] = []
-    for port in dict.fromkeys(ports):
-        server = ThreadingHTTPServer(("", port), handler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-        servers.append(server)
-    return servers
+def start_health_server(port: int, state: HealthState) -> ThreadingHTTPServer:
+    """Start a daemon HTTP server serving ``/healthz`` and ``/readyz`` on ``port``."""
+    server = ThreadingHTTPServer(("", port), _make_handler(state))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server

--- a/sync-service/kaos_sync/observability.py
+++ b/sync-service/kaos_sync/observability.py
@@ -1,0 +1,119 @@
+"""Prometheus metrics and health/readiness endpoints for the sync service.
+
+Metrics describe the most recent reconcile pass (counts, failures, prune activity) and
+are exposed on ``/metrics``. Liveness (``/healthz``) reports that the process is up;
+readiness (``/readyz``) reports that at least one reconcile pass has completed, so a
+deployment is only considered ready once it has projected the current desired state.
+
+The path routing is factored into :func:`handle_path` so it can be unit tested without
+binding a socket; :func:`start_http_servers` wires that routing into a threaded HTTP
+server for the runtime.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, generate_latest
+
+RECONCILE_PASSES = Counter("kaos_sync_reconcile_passes_total", "Total reconcile passes run.")
+RECONCILE_PROBLEMS = Counter(
+    "kaos_sync_reconcile_problems_total",
+    "Reconcile problems encountered, by category.",
+    ["category"],
+)
+CREDENTIALS_MINTED = Counter("kaos_sync_credentials_minted_total", "Credential mints performed.")
+PRUNED = Counter(
+    "kaos_sync_pruned_total", "Orphaned records removed during pruning, by kind.", ["kind"]
+)
+SERVICES_SYNCED = Gauge("kaos_sync_services", "Broker services reconciled in the last pass.")
+PERMISSION_SETS_SYNCED = Gauge(
+    "kaos_sync_permission_sets", "Broker permission sets reconciled in the last pass."
+)
+AGENTS_SYNCED = Gauge("kaos_sync_agents_synced", "Agents successfully synced in the last pass.")
+AGENTS_FAILED = Gauge("kaos_sync_agents_failed", "Agents that failed to sync in the last pass.")
+LAST_PASS_OK = Gauge(
+    "kaos_sync_last_pass_ok", "1 if the last reconcile pass had no problems, else 0."
+)
+
+
+def record_summary(summary) -> None:
+    """Update metrics from a completed :class:`~kaos_sync.reconcile.ReconcileSummary`."""
+    RECONCILE_PASSES.inc()
+    minted = sum(1 for agent in summary.agents if agent.credentials_minted)
+    if minted:
+        CREDENTIALS_MINTED.inc(minted)
+    for problem in summary.problems:
+        RECONCILE_PROBLEMS.labels(category=problem.category.value).inc()
+    if summary.pruned.agents:
+        PRUNED.labels(kind="agents").inc(summary.pruned.agents)
+    if summary.pruned.permission_sets:
+        PRUNED.labels(kind="permission_sets").inc(summary.pruned.permission_sets)
+    if summary.pruned.services:
+        PRUNED.labels(kind="services").inc(summary.pruned.services)
+    if summary.pruned.secrets:
+        PRUNED.labels(kind="secrets").inc(summary.pruned.secrets)
+    SERVICES_SYNCED.set(summary.services)
+    PERMISSION_SETS_SYNCED.set(summary.permission_sets)
+    AGENTS_SYNCED.set(sum(1 for agent in summary.agents if agent.ok))
+    AGENTS_FAILED.set(sum(1 for agent in summary.agents if not agent.ok))
+    LAST_PASS_OK.set(1 if summary.ok else 0)
+
+
+@dataclass
+class HealthState:
+    """Shared liveness/readiness state updated by the reconcile loop."""
+
+    ready: bool = False
+
+    def mark_ready(self) -> None:
+        self.ready = True
+
+
+def handle_path(path: str, state: HealthState) -> tuple[int, str, bytes]:
+    """Resolve an HTTP path to ``(status, content_type, body)`` for the health server."""
+    route = path.split("?", 1)[0]
+    if route == "/metrics":
+        return 200, CONTENT_TYPE_LATEST, generate_latest()
+    if route == "/healthz":
+        return 200, "text/plain", b"ok"
+    if route == "/readyz":
+        if state.ready:
+            return 200, "text/plain", b"ready"
+        return 503, "text/plain", b"not ready"
+    return 404, "text/plain", b"not found"
+
+
+def _make_handler(state: HealthState) -> type[BaseHTTPRequestHandler]:
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            status, content_type, body = handle_path(self.path, state)
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args) -> None:  # noqa: A002 - match base API
+            return
+
+    return _Handler
+
+
+def start_http_servers(ports: tuple[int, ...], state: HealthState) -> list[ThreadingHTTPServer]:
+    """Start a daemon HTTP server on each distinct port serving the health routes.
+
+    The metrics and health ports are commonly the same; identical ports are de-duplicated
+    so a single server backs every route. Each server runs on a daemon thread so it never
+    blocks process shutdown.
+    """
+    handler = _make_handler(state)
+    servers: list[ThreadingHTTPServer] = []
+    for port in dict.fromkeys(ports):
+        server = ThreadingHTTPServer(("", port), handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        servers.append(server)
+    return servers

--- a/sync-service/kaos_sync/projection.py
+++ b/sync-service/kaos_sync/projection.py
@@ -92,6 +92,37 @@ def modelapi_resource_uri(namespace: str, name: str) -> str:
     return edge_resource_uri(MODELAPI, namespace, name)
 
 
+_AGENT_DISPLAY_PREFIX = "kaos://agent/"
+_SERVICE_CLIENT_ID_PREFIXES = (f"kaos-{MCPSERVER.slug}-", f"kaos-{MODELAPI.slug}-")
+_PERMISSION_SET_PREFIX = "kaos:"
+
+
+def is_kaos_service_client_id(client_id: str) -> bool:
+    """True if a broker service ``client_id`` was projected by KAOS (safe to prune)."""
+    return client_id.startswith(_SERVICE_CLIENT_ID_PREFIXES)
+
+
+def is_kaos_permission_set_name(name: str) -> bool:
+    """True if a broker permission-set ``name`` was projected by KAOS (safe to prune)."""
+    return name.startswith(_PERMISSION_SET_PREFIX)
+
+
+def is_kaos_agent_display_name(display_name: str) -> bool:
+    """True if a broker agent ``display_name`` was projected by KAOS (safe to prune)."""
+    return display_name.startswith(_AGENT_DISPLAY_PREFIX)
+
+
+def parse_agent_external_id(external_id: str) -> tuple[str, str] | None:
+    """Parse ``kaos://agent/<ns>/<name>`` into ``(namespace, name)`` or ``None``."""
+    if not is_kaos_agent_display_name(external_id):
+        return None
+    rest = external_id[len(_AGENT_DISPLAY_PREFIX) :]
+    parts = rest.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return None
+    return parts[0], parts[1]
+
+
 @dataclass(frozen=True)
 class DesiredService:
     """A synthetic AIB service projected from an edge target (MCPServer or ModelAPI)."""

--- a/sync-service/kaos_sync/projection.py
+++ b/sync-service/kaos_sync/projection.py
@@ -1,18 +1,21 @@
 """Pure projection of KAOS resources into desired AIB records.
 
-This module contains no I/O. It translates KAOS ``Agent`` and ``MCPServer`` resources
-into the desired Agentic Identity Broker (AIB) state using a stable bootstrap encoding:
+This module contains no I/O. It translates KAOS ``Agent``, ``MCPServer`` and ``ModelAPI``
+resources into the desired Agentic Identity Broker (AIB) state using a stable bootstrap
+encoding shared across the two edge kinds an agent can request (an MCP server it may call,
+and the model API it is bound to):
 
-* Each ``MCPServer`` ``<ns>/<name>`` becomes a synthetic AIB service whose ``client_id``
-  is ``kaos-mcpserver-<ns>-<name>`` and which exposes a single ``call`` scope.
-* Each requested edge ``Agent -> MCPServer`` becomes an AIB permission set named
-  ``kaos:mcpserver:<ns>:<mcp>:call`` that grants the ``call`` scope on that service.
+* Each edge target ``<ns>/<name>`` of kind ``<slug>`` becomes a synthetic AIB service whose
+  ``client_id`` is ``kaos-<slug>-<ns>-<name>`` and which exposes a single ``call`` scope.
+* Each requested edge ``Agent -> target`` becomes an AIB permission set named
+  ``kaos:<slug>:<ns>:<name>:call`` that grants the ``call`` scope on that service.
 * Each ``Agent`` ``<ns>/<name>`` becomes an AIB *local* agent (created without a
   ``client_id`` so AIB itself mints the actor token) bound to the permission sets for
   its requested edges.
 
-The resource identity an agent is authorized against is ``kaos://mcpserver/<ns>/<name>``,
-which the access-check maps back to the synthetic service ``client_id``.
+The resource identity an agent is authorized against is ``kaos://<slug>/<ns>/<name>``,
+which the access-check maps back to the synthetic service ``client_id``. ``<slug>`` is
+``mcpserver`` for MCP server edges and ``modelapi`` for the model API edge.
 """
 
 from __future__ import annotations
@@ -21,17 +24,57 @@ from dataclasses import dataclass, field
 
 CALL_SCOPE = "call"
 MCPSERVER_KIND = "MCPServer"
+MODELAPI_KIND = "ModelAPI"
 AGENT_KIND = "Agent"
 
 
+@dataclass(frozen=True)
+class EdgeKind:
+    """An edge target kind and the vocabulary used to encode it into AIB records."""
+
+    slug: str  # identifier segment, e.g. "mcpserver" / "modelapi"
+    resource_kind: str  # KAOS resource kind, e.g. "MCPServer" / "ModelAPI"
+    display_label: str  # human label used in display names, e.g. "MCPServer"
+    scope_description: str  # description attached to the synthetic ``call`` scope
+
+
+MCPSERVER = EdgeKind(
+    slug="mcpserver",
+    resource_kind=MCPSERVER_KIND,
+    display_label="MCPServer",
+    scope_description="Invoke the MCP server",
+)
+MODELAPI = EdgeKind(
+    slug="modelapi",
+    resource_kind=MODELAPI_KIND,
+    display_label="ModelAPI",
+    scope_description="Invoke the model API",
+)
+
+
+def edge_service_client_id(kind: EdgeKind, namespace: str, name: str) -> str:
+    """Synthetic AIB service ``client_id`` for an edge target."""
+    return f"kaos-{kind.slug}-{namespace}-{name}"
+
+
+def edge_permission_set_name(kind: EdgeKind, namespace: str, name: str) -> str:
+    """AIB permission-set name granting ``call`` on an edge target."""
+    return f"kaos:{kind.slug}:{namespace}:{name}:{CALL_SCOPE}"
+
+
+def edge_resource_uri(kind: EdgeKind, namespace: str, name: str) -> str:
+    """Resource URI an agent is authorized against for an edge target."""
+    return f"kaos://{kind.slug}/{namespace}/{name}"
+
+
 def service_client_id(namespace: str, name: str) -> str:
-    """Synthetic AIB service ``client_id`` for an MCPServer."""
-    return f"kaos-mcpserver-{namespace}-{name}"
+    """Synthetic AIB service ``client_id`` for an MCPServer (stable public helper)."""
+    return edge_service_client_id(MCPSERVER, namespace, name)
 
 
 def permission_set_name(namespace: str, mcp: str) -> str:
-    """AIB permission-set name granting ``call`` on an MCPServer."""
-    return f"kaos:mcpserver:{namespace}:{mcp}:{CALL_SCOPE}"
+    """AIB permission-set name granting ``call`` on an MCPServer (stable public helper)."""
+    return edge_permission_set_name(MCPSERVER, namespace, mcp)
 
 
 def agent_external_id(namespace: str, name: str) -> str:
@@ -41,32 +84,39 @@ def agent_external_id(namespace: str, name: str) -> str:
 
 def mcpserver_resource_uri(namespace: str, name: str) -> str:
     """Resource URI an agent is authorized against for an MCPServer edge."""
-    return f"kaos://mcpserver/{namespace}/{name}"
+    return edge_resource_uri(MCPSERVER, namespace, name)
+
+
+def modelapi_resource_uri(namespace: str, name: str) -> str:
+    """Resource URI an agent is authorized against for a ModelAPI edge."""
+    return edge_resource_uri(MODELAPI, namespace, name)
 
 
 @dataclass(frozen=True)
 class DesiredService:
-    """A synthetic AIB service projected from an MCPServer."""
+    """A synthetic AIB service projected from an edge target (MCPServer or ModelAPI)."""
 
     namespace: str
     name: str
+    kind: EdgeKind = MCPSERVER
 
     @property
     def client_id(self) -> str:
-        return service_client_id(self.namespace, self.name)
+        return edge_service_client_id(self.kind, self.namespace, self.name)
 
     def admin_body(self) -> dict:
+        label = self.kind.display_label
         return {
-            "display_name": f"KAOS MCPServer {self.namespace}/{self.name} (synthetic)",
+            "display_name": f"KAOS {label} {self.namespace}/{self.name} (synthetic)",
             "client_id": self.client_id,
             "client_secret": "synthetic",
-            "issuer_uri": f"https://kaos.local/mcpserver/{self.namespace}/{self.name}",
+            "issuer_uri": f"https://kaos.local/{self.kind.slug}/{self.namespace}/{self.name}",
             "discovery": {"enable_discovery": False},
             "endpoints": {
                 "token_endpoint": "https://kaos.local/t",
                 "authorize_endpoint": "https://kaos.local/a",
             },
-            "scopes": [{"scope_value": CALL_SCOPE, "description": "Invoke the MCP server"}],
+            "scopes": [{"scope_value": CALL_SCOPE, "description": self.kind.scope_description}],
         }
 
 
@@ -75,20 +125,21 @@ class DesiredPermissionSet:
     """An AIB permission set granting ``call`` on one synthetic service."""
 
     namespace: str
-    mcp: str
+    target: str
+    kind: EdgeKind = MCPSERVER
 
     @property
     def name(self) -> str:
-        return permission_set_name(self.namespace, self.mcp)
+        return edge_permission_set_name(self.kind, self.namespace, self.target)
 
     @property
     def service_client_id(self) -> str:
-        return service_client_id(self.namespace, self.mcp)
+        return edge_service_client_id(self.kind, self.namespace, self.target)
 
     def admin_body(self, service_id: str) -> dict:
         return {
             "name": self.name,
-            "description": f"call {self.namespace}/{self.mcp}",
+            "description": f"call {self.namespace}/{self.target}",
             "service_scopes": [
                 {
                     "service_id": service_id,
@@ -140,26 +191,37 @@ def _meta(resource: dict) -> tuple[str, str]:
 def project(resources: list[dict]) -> DesiredState:
     """Project a list of KAOS resources into the desired AIB state.
 
-    Only agents with at least one requested MCPServer edge are projected; an agent with
-    no edges has nothing to authorize and is skipped. Services and permission sets are
-    derived from the union of declared MCPServers and the edges agents request, so an
-    edge to an MCPServer that has no standalone resource still yields a service.
+    Both MCP server edges (``spec.mcpServers``) and the model API edge (``spec.modelAPI``)
+    are projected, so an agent is authorized against every external dependency it declares.
+    Only agents with at least one edge are projected; an agent with no edges has nothing to
+    authorize and is skipped. Services and permission sets are derived from the union of
+    declared MCPServer/ModelAPI resources and the edges agents request, so an edge to a
+    target that has no standalone resource still yields a service.
     """
     state = DesiredState()
 
-    services: dict[tuple[str, str], DesiredService] = {}
-    permission_sets: dict[tuple[str, str], DesiredPermissionSet] = {}
+    services: dict[tuple[str, str, str], DesiredService] = {}
+    permission_sets: dict[tuple[str, str, str], DesiredPermissionSet] = {}
 
-    def ensure_service(ns: str, name: str) -> None:
-        key = (ns, name)
+    def ensure_service(kind: EdgeKind, ns: str, name: str) -> None:
+        key = (kind.slug, ns, name)
         if key not in services:
-            services[key] = DesiredService(namespace=ns, name=name)
+            services[key] = DesiredService(namespace=ns, name=name, kind=kind)
 
+    def ensure_permission_set(kind: EdgeKind, ns: str, name: str) -> DesiredPermissionSet:
+        key = (kind.slug, ns, name)
+        if key not in permission_sets:
+            permission_sets[key] = DesiredPermissionSet(namespace=ns, target=name, kind=kind)
+        return permission_sets[key]
+
+    declared_kinds = {MCPSERVER.resource_kind: MCPSERVER, MODELAPI.resource_kind: MODELAPI}
     for resource in resources:
-        if resource.get("kind") == MCPSERVER_KIND:
-            ns, name = _meta(resource)
-            if name:
-                ensure_service(ns, name)
+        kind = declared_kinds.get(resource.get("kind", ""))
+        if kind is None:
+            continue
+        ns, name = _meta(resource)
+        if name:
+            ensure_service(kind, ns, name)
 
     for resource in resources:
         if resource.get("kind") != AGENT_KIND:
@@ -170,13 +232,19 @@ def project(resources: list[dict]) -> DesiredState:
         spec = resource.get("spec") or {}
         ps_names: list[str] = []
         granted: list[str] = []
+
+        def add_edge(kind: EdgeKind, target: str) -> None:
+            ensure_service(kind, ns, target)
+            ps = ensure_permission_set(kind, ns, target)
+            ps_names.append(ps.name)
+            granted.append(edge_resource_uri(kind, ns, target))
+
         for mcp in spec.get("mcpServers") or []:
-            ensure_service(ns, mcp)
-            key = (ns, mcp)
-            if key not in permission_sets:
-                permission_sets[key] = DesiredPermissionSet(namespace=ns, mcp=mcp)
-            ps_names.append(permission_sets[key].name)
-            granted.append(mcpserver_resource_uri(ns, mcp))
+            add_edge(MCPSERVER, mcp)
+        model_api = spec.get("modelAPI")
+        if model_api:
+            add_edge(MODELAPI, model_api)
+
         if not ps_names:
             continue
         state.agents.append(

--- a/sync-service/kaos_sync/reconcile.py
+++ b/sync-service/kaos_sync/reconcile.py
@@ -7,8 +7,8 @@ implementations live in :mod:`kaos_sync.aib_client` and :mod:`kaos_sync.secrets`
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Protocol
+from dataclasses import dataclass, field
+from typing import List, Protocol
 
 from kaos_sync.projection import DesiredAgent, DesiredState
 
@@ -19,11 +19,19 @@ def credential_secret_name(prefix: str, agent_name: str) -> str:
 
 
 class AIBAdminClient(Protocol):
+    def list(self, collection: str) -> List[dict]: ...
+
+    def get(self, collection: str, resource_id: str) -> dict | None: ...
+
     def create_or_get(
         self, collection: str, match_field: str, match_value: str, body: dict
     ) -> str: ...
 
+    def delete(self, collection: str, resource_id: str) -> bool: ...
+
     def mint_credentials(self, agent_id: str) -> dict: ...
+
+    def revoke_credentials(self, agent_id: str) -> bool: ...
 
 
 class SecretStore(Protocol):
@@ -47,11 +55,7 @@ class AgentSync:
 class ReconcileSummary:
     services: int = 0
     permission_sets: int = 0
-    agents: list[AgentSync] = None  # type: ignore[assignment]
-
-    def __post_init__(self) -> None:
-        if self.agents is None:
-            self.agents = []
+    agents: list[AgentSync] = field(default_factory=list)
 
 
 def reconcile(

--- a/sync-service/kaos_sync/reconcile.py
+++ b/sync-service/kaos_sync/reconcile.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Protocol
 
-from kaos_sync.projection import DesiredAgent, DesiredState
+from kaos_sync.projection import (
+    DesiredAgent,
+    DesiredState,
+    is_kaos_agent_display_name,
+    is_kaos_permission_set_name,
+    is_kaos_service_client_id,
+)
 
 
 def credential_secret_name(prefix: str, agent_name: str) -> str:
@@ -39,6 +45,10 @@ class SecretStore(Protocol):
 
     def upsert(self, namespace: str, name: str, string_data: dict[str, str]) -> None: ...
 
+    def list(self, namespaces: tuple[str, ...]) -> List[tuple[str, str]]: ...
+
+    def delete(self, namespace: str, name: str) -> bool: ...
+
 
 @dataclass
 class AgentSync:
@@ -52,10 +62,21 @@ class AgentSync:
 
 
 @dataclass
+class PruneSummary:
+    """Counts of orphaned broker records and Secrets removed during a prune pass."""
+
+    agents: int = 0
+    permission_sets: int = 0
+    services: int = 0
+    secrets: int = 0
+
+
+@dataclass
 class ReconcileSummary:
     services: int = 0
     permission_sets: int = 0
     agents: list[AgentSync] = field(default_factory=list)
+    pruned: PruneSummary = field(default_factory=PruneSummary)
 
 
 def reconcile(
@@ -63,6 +84,8 @@ def reconcile(
     aib: AIBAdminClient,
     secrets: SecretStore,
     secret_prefix: str = "kaos-aib",
+    prune: bool = False,
+    namespaces: tuple[str, ...] = (),
 ) -> ReconcileSummary:
     """Apply the desired AIB state and provision per-agent credential Secrets.
 
@@ -70,6 +93,11 @@ def reconcile(
     referenced; each agent is then created as a local AIB agent bound to its permission
     sets. Credentials are minted only when a Secret does not already carry them, keeping
     the pass idempotent and avoiding credential churn on every reconcile.
+
+    When ``prune`` is set, KAOS-managed broker records and credential Secrets that are no
+    longer in the desired state are removed in dependency-safe order (agents, then their
+    credentials and Secrets, then permission sets, then services), restricted to the
+    configured ``namespaces`` for Secret discovery.
     """
     summary = ReconcileSummary()
 
@@ -93,7 +121,78 @@ def reconcile(
             _reconcile_agent(agent, aib, secrets, secret_prefix, permission_set_ids)
         )
 
+    if prune:
+        summary.pruned = _prune(
+            desired,
+            aib,
+            secrets,
+            secret_prefix,
+            namespaces,
+            desired_client_ids=set(service_ids),
+            desired_permission_set_names=set(permission_set_ids),
+        )
+
     return summary
+
+
+def _prune(
+    desired: DesiredState,
+    aib: AIBAdminClient,
+    secrets: SecretStore,
+    secret_prefix: str,
+    namespaces: tuple[str, ...],
+    desired_client_ids: set[str],
+    desired_permission_set_names: set[str],
+) -> PruneSummary:
+    """Remove KAOS-managed broker records and Secrets absent from the desired state.
+
+    Deletion follows dependency order so a record is never removed while another still
+    references it: agents (and their credentials) first, then orphaned Secrets, then
+    permission sets, then services. Only records KAOS owns -- identified by the projection
+    encoding -- are considered, so externally-managed broker records are never touched.
+    """
+    pruned = PruneSummary()
+
+    desired_external_ids = {agent.external_id for agent in desired.agents}
+    for item in aib.list("agents"):
+        display_name = item.get("display_name", "")
+        if not is_kaos_agent_display_name(display_name):
+            continue
+        if display_name in desired_external_ids:
+            continue
+        aib.revoke_credentials(item["id"])
+        if aib.delete("agents", item["id"]):
+            pruned.agents += 1
+
+    desired_secret_keys = {
+        (agent.namespace, credential_secret_name(secret_prefix, agent.name))
+        for agent in desired.agents
+    }
+    for namespace, name in secrets.list(namespaces):
+        if (namespace, name) in desired_secret_keys:
+            continue
+        if secrets.delete(namespace, name):
+            pruned.secrets += 1
+
+    for item in aib.list("permission-sets"):
+        name = item.get("name", "")
+        if not is_kaos_permission_set_name(name):
+            continue
+        if name in desired_permission_set_names:
+            continue
+        if aib.delete("permission-sets", item["id"]):
+            pruned.permission_sets += 1
+
+    for item in aib.list("services"):
+        client_id = item.get("client_id", "")
+        if not is_kaos_service_client_id(client_id):
+            continue
+        if client_id in desired_client_ids:
+            continue
+        if aib.delete("services", item["id"]):
+            pruned.services += 1
+
+    return pruned
 
 
 def _reconcile_agent(

--- a/sync-service/kaos_sync/reconcile.py
+++ b/sync-service/kaos_sync/reconcile.py
@@ -8,6 +8,7 @@ implementations live in :mod:`kaos_sync.aib_client` and :mod:`kaos_sync.secrets`
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import List, Protocol
 
 from kaos_sync.projection import (
@@ -16,6 +17,7 @@ from kaos_sync.projection import (
     is_kaos_agent_display_name,
     is_kaos_permission_set_name,
     is_kaos_service_client_id,
+    parse_agent_external_id,
 )
 
 
@@ -50,6 +52,25 @@ class SecretStore(Protocol):
     def delete(self, namespace: str, name: str) -> bool: ...
 
 
+class ProblemCategory(str, Enum):
+    """Classification of a reconcile problem, for status reporting and alerting."""
+
+    AIB_UNREACHABLE = "aib_unreachable"
+    MISSING_CREDENTIALS = "missing_credentials"
+    UNSUPPORTED_EDGE = "unsupported_edge"
+    STALE_EXTERNAL_ID = "stale_external_id"
+    PRUNE_FAILED = "prune_failed"
+
+
+@dataclass
+class Problem:
+    """A single non-fatal issue encountered while reconciling one resource."""
+
+    category: ProblemCategory
+    resource: str
+    detail: str
+
+
 @dataclass
 class AgentSync:
     """Outcome of reconciling a single agent."""
@@ -59,6 +80,8 @@ class AgentSync:
     secret_namespace: str
     secret_name: str
     credentials_minted: bool
+    ok: bool = True
+    error: str | None = None
 
 
 @dataclass
@@ -77,6 +100,12 @@ class ReconcileSummary:
     permission_sets: int = 0
     agents: list[AgentSync] = field(default_factory=list)
     pruned: PruneSummary = field(default_factory=PruneSummary)
+    problems: list[Problem] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True when the pass completed with no recorded problems."""
+        return not self.problems
 
 
 def reconcile(
@@ -94,6 +123,12 @@ def reconcile(
     sets. Credentials are minted only when a Secret does not already carry them, keeping
     the pass idempotent and avoiding credential churn on every reconcile.
 
+    Reconciliation is isolated per resource: a failure on one service, permission set or
+    agent is recorded as a :class:`Problem` and does not prevent the remaining resources
+    from being reconciled, so a single broker hiccup or malformed resource cannot stall
+    the whole fleet. Agents whose permission sets could not be created are skipped fail
+    closed (no credentials are minted for an unauthorized agent).
+
     When ``prune`` is set, KAOS-managed broker records and credential Secrets that are no
     longer in the desired state are removed in dependency-safe order (agents, then their
     credentials and Secrets, then permission sets, then services), restricted to the
@@ -103,22 +138,50 @@ def reconcile(
 
     service_ids: dict[str, str] = {}
     for service in desired.services:
-        service_ids[service.client_id] = aib.create_or_get(
-            "services", "client_id", service.client_id, service.admin_body()
-        )
+        try:
+            service_ids[service.client_id] = aib.create_or_get(
+                "services", "client_id", service.client_id, service.admin_body()
+            )
+        except Exception as exc:  # noqa: BLE001 - isolate per-resource failures
+            summary.problems.append(
+                Problem(ProblemCategory.AIB_UNREACHABLE, f"service {service.client_id}", str(exc))
+            )
     summary.services = len(service_ids)
 
     permission_set_ids: dict[str, str] = {}
     for permission_set in desired.permission_sets:
+        if permission_set.service_client_id not in service_ids:
+            summary.problems.append(
+                Problem(
+                    ProblemCategory.UNSUPPORTED_EDGE,
+                    f"permission-set {permission_set.name}",
+                    f"service {permission_set.service_client_id} unavailable",
+                )
+            )
+            continue
         service_id = service_ids[permission_set.service_client_id]
-        permission_set_ids[permission_set.name] = aib.create_or_get(
-            "permission-sets", "name", permission_set.name, permission_set.admin_body(service_id)
-        )
+        try:
+            permission_set_ids[permission_set.name] = aib.create_or_get(
+                "permission-sets",
+                "name",
+                permission_set.name,
+                permission_set.admin_body(service_id),
+            )
+        except Exception as exc:  # noqa: BLE001 - isolate per-resource failures
+            summary.problems.append(
+                Problem(
+                    ProblemCategory.AIB_UNREACHABLE,
+                    f"permission-set {permission_set.name}",
+                    str(exc),
+                )
+            )
     summary.permission_sets = len(permission_set_ids)
 
     for agent in desired.agents:
         summary.agents.append(
-            _reconcile_agent(agent, aib, secrets, secret_prefix, permission_set_ids)
+            _reconcile_agent(
+                agent, aib, secrets, secret_prefix, permission_set_ids, summary.problems
+            )
         )
 
     if prune:
@@ -130,6 +193,7 @@ def reconcile(
             namespaces,
             desired_client_ids=set(service_ids),
             desired_permission_set_names=set(permission_set_ids),
+            problems=summary.problems,
         )
 
     return summary
@@ -143,56 +207,100 @@ def _prune(
     namespaces: tuple[str, ...],
     desired_client_ids: set[str],
     desired_permission_set_names: set[str],
+    problems: list[Problem],
 ) -> PruneSummary:
     """Remove KAOS-managed broker records and Secrets absent from the desired state.
 
     Deletion follows dependency order so a record is never removed while another still
     references it: agents (and their credentials) first, then orphaned Secrets, then
     permission sets, then services. Only records KAOS owns -- identified by the projection
-    encoding -- are considered, so externally-managed broker records are never touched.
+    encoding -- are considered, so externally-managed broker records are never touched. A
+    failed deletion is recorded as a :class:`Problem` and never aborts the rest of the
+    prune pass.
     """
     pruned = PruneSummary()
 
     desired_external_ids = {agent.external_id for agent in desired.agents}
-    for item in aib.list("agents"):
+    for item in _safe_list(aib, "agents", problems):
         display_name = item.get("display_name", "")
         if not is_kaos_agent_display_name(display_name):
             continue
         if display_name in desired_external_ids:
             continue
-        aib.revoke_credentials(item["id"])
-        if aib.delete("agents", item["id"]):
-            pruned.agents += 1
+        if parse_agent_external_id(display_name) is None:
+            problems.append(
+                Problem(
+                    ProblemCategory.STALE_EXTERNAL_ID,
+                    f"agent {item.get('id', '?')}",
+                    f"malformed external id {display_name!r}; skipping deletion",
+                )
+            )
+            continue
+        try:
+            aib.revoke_credentials(item["id"])
+            if aib.delete("agents", item["id"]):
+                pruned.agents += 1
+        except Exception as exc:  # noqa: BLE001 - isolate per-resource prune failures
+            problems.append(Problem(ProblemCategory.PRUNE_FAILED, f"agent {item['id']}", str(exc)))
 
     desired_secret_keys = {
         (agent.namespace, credential_secret_name(secret_prefix, agent.name))
         for agent in desired.agents
     }
-    for namespace, name in secrets.list(namespaces):
+    try:
+        managed_secrets = secrets.list(namespaces)
+    except Exception as exc:  # noqa: BLE001 - isolate secret listing failures
+        problems.append(Problem(ProblemCategory.PRUNE_FAILED, "secrets", str(exc)))
+        managed_secrets = []
+    for namespace, name in managed_secrets:
         if (namespace, name) in desired_secret_keys:
             continue
-        if secrets.delete(namespace, name):
-            pruned.secrets += 1
+        try:
+            if secrets.delete(namespace, name):
+                pruned.secrets += 1
+        except Exception as exc:  # noqa: BLE001 - isolate per-resource prune failures
+            problems.append(
+                Problem(ProblemCategory.PRUNE_FAILED, f"secret {namespace}/{name}", str(exc))
+            )
 
-    for item in aib.list("permission-sets"):
+    for item in _safe_list(aib, "permission-sets", problems):
         name = item.get("name", "")
         if not is_kaos_permission_set_name(name):
             continue
         if name in desired_permission_set_names:
             continue
-        if aib.delete("permission-sets", item["id"]):
-            pruned.permission_sets += 1
+        try:
+            if aib.delete("permission-sets", item["id"]):
+                pruned.permission_sets += 1
+        except Exception as exc:  # noqa: BLE001 - isolate per-resource prune failures
+            problems.append(
+                Problem(ProblemCategory.PRUNE_FAILED, f"permission-set {item['id']}", str(exc))
+            )
 
-    for item in aib.list("services"):
+    for item in _safe_list(aib, "services", problems):
         client_id = item.get("client_id", "")
         if not is_kaos_service_client_id(client_id):
             continue
         if client_id in desired_client_ids:
             continue
-        if aib.delete("services", item["id"]):
-            pruned.services += 1
+        try:
+            if aib.delete("services", item["id"]):
+                pruned.services += 1
+        except Exception as exc:  # noqa: BLE001 - isolate per-resource prune failures
+            problems.append(
+                Problem(ProblemCategory.PRUNE_FAILED, f"service {item['id']}", str(exc))
+            )
 
     return pruned
+
+
+def _safe_list(aib: AIBAdminClient, collection: str, problems: list[Problem]) -> list[dict]:
+    """List a broker collection, recording unreachability instead of raising."""
+    try:
+        return aib.list(collection)
+    except Exception as exc:  # noqa: BLE001 - isolate broker listing failures
+        problems.append(Problem(ProblemCategory.AIB_UNREACHABLE, f"list {collection}", str(exc)))
+        return []
 
 
 def _reconcile_agent(
@@ -201,23 +309,46 @@ def _reconcile_agent(
     secrets: SecretStore,
     secret_prefix: str,
     permission_set_ids: dict[str, str],
+    problems: list[Problem],
 ) -> AgentSync:
-    bound = [permission_set_ids[name] for name in agent.permission_set_names]
-    agent_id = aib.create_or_get(
-        "agents", "display_name", agent.external_id, agent.admin_body(bound)
-    )
-
     secret_name = credential_secret_name(secret_prefix, agent.name)
-    existing = secrets.get(agent.namespace, secret_name)
-    minted = False
-    if not existing or not existing.get("client_id"):
-        cred = aib.mint_credentials(agent_id)
-        secrets.upsert(
-            agent.namespace,
-            secret_name,
-            {"client_id": cred["client_id"], "client_secret": cred["client_secret"]},
+    resource = f"agent {agent.namespace}/{agent.name}"
+
+    missing = [name for name in agent.permission_set_names if name not in permission_set_ids]
+    if missing:
+        detail = f"permission sets unavailable: {', '.join(missing)}"
+        problems.append(Problem(ProblemCategory.UNSUPPORTED_EDGE, resource, detail))
+        return AgentSync(agent.external_id, "", agent.namespace, secret_name, False, False, detail)
+
+    bound = [permission_set_ids[name] for name in agent.permission_set_names]
+    try:
+        agent_id = aib.create_or_get(
+            "agents", "display_name", agent.external_id, agent.admin_body(bound)
         )
-        minted = True
+    except Exception as exc:  # noqa: BLE001 - isolate per-resource failures
+        problems.append(Problem(ProblemCategory.AIB_UNREACHABLE, resource, str(exc)))
+        return AgentSync(
+            agent.external_id, "", agent.namespace, secret_name, False, False, str(exc)
+        )
+
+    try:
+        existing = secrets.get(agent.namespace, secret_name)
+        minted = False
+        if not existing or not existing.get("client_id"):
+            cred = aib.mint_credentials(agent_id)
+            if not cred.get("client_id") or not cred.get("client_secret"):
+                raise RuntimeError("broker returned incomplete credentials")
+            secrets.upsert(
+                agent.namespace,
+                secret_name,
+                {"client_id": cred["client_id"], "client_secret": cred["client_secret"]},
+            )
+            minted = True
+    except Exception as exc:  # noqa: BLE001 - isolate per-resource failures
+        problems.append(Problem(ProblemCategory.MISSING_CREDENTIALS, resource, str(exc)))
+        return AgentSync(
+            agent.external_id, agent_id, agent.namespace, secret_name, False, False, str(exc)
+        )
 
     return AgentSync(
         external_id=agent.external_id,

--- a/sync-service/pyproject.toml
+++ b/sync-service/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.27.0",
     "kubernetes>=29.0.0",
+    "prometheus-client>=0.20.0",
 ]
 
 [project.scripts]

--- a/sync-service/pyproject.toml
+++ b/sync-service/pyproject.toml
@@ -11,7 +11,9 @@ requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.27.0",
     "kubernetes>=29.0.0",
-    "prometheus-client>=0.20.0",
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp>=1.20.0",
 ]
 
 [project.scripts]

--- a/sync-service/tests/test_aib_client.py
+++ b/sync-service/tests/test_aib_client.py
@@ -1,0 +1,137 @@
+"""Tests for the AIB admin client: list/get/delete/revoke and bounded retry.
+
+A fake ``httpx`` transport drives deterministic responses (including transient failures)
+without a live broker, so retry/backoff and 404 semantics are exercised in isolation.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from kaos_sync.aib_client import AIBAdmin
+
+
+def _client(handler, **kwargs) -> AIBAdmin:
+    transport = httpx.MockTransport(handler)
+    http = httpx.Client(
+        base_url="http://aib.test",
+        transport=transport,
+        headers={"X-Remote-User": "kaos-sync"},
+    )
+    # sleep is a no-op so retry tests do not actually wait.
+    return AIBAdmin(
+        base_url="http://aib.test",
+        principal="kaos-sync",
+        client=http,
+        sleep=lambda _: None,
+        **kwargs,
+    )
+
+
+def test_list_unwraps_items_envelope() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/agents"
+        return httpx.Response(200, json={"items": [{"id": "a1"}, {"id": "a2"}]})
+
+    aib = _client(handler)
+    assert aib.list("agents") == [{"id": "a1"}, {"id": "a2"}]
+
+
+def test_list_accepts_bare_list() -> None:
+    aib = _client(lambda req: httpx.Response(200, json=[{"id": "a1"}]))
+    assert aib.list("agents") == [{"id": "a1"}]
+
+
+def test_get_returns_none_on_404() -> None:
+    aib = _client(lambda req: httpx.Response(404, json={"error": "not found"}))
+    assert aib.get("agents", "missing") is None
+
+
+def test_get_returns_resource() -> None:
+    aib = _client(lambda req: httpx.Response(200, json={"id": "a1", "name": "x"}))
+    assert aib.get("agents", "a1") == {"id": "a1", "name": "x"}
+
+
+def test_delete_returns_true_when_deleted() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert request.url.path == "/agents/a1"
+        return httpx.Response(204)
+
+    assert _client(handler).delete("agents", "a1") is True
+
+
+def test_delete_returns_false_when_already_gone() -> None:
+    aib = _client(lambda req: httpx.Response(404))
+    assert aib.delete("agents", "gone") is False
+
+
+def test_revoke_credentials_true_and_false() -> None:
+    assert _client(lambda req: httpx.Response(204)).revoke_credentials("a1") is True
+    assert _client(lambda req: httpx.Response(404)).revoke_credentials("a1") is False
+
+
+def test_retry_then_succeed_on_transient_5xx() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return httpx.Response(503)
+        return httpx.Response(200, json={"items": []})
+
+    aib = _client(handler, retry_max_attempts=4, retry_base_delay_seconds=0.0)
+    assert aib.list("agents") == []
+    assert calls["n"] == 3
+
+
+def test_retry_then_succeed_on_connection_error() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise httpx.ConnectError("boom", request=request)
+        return httpx.Response(200, json=[])
+
+    aib = _client(handler, retry_max_attempts=3, retry_base_delay_seconds=0.0)
+    assert aib.list("agents") == []
+    assert calls["n"] == 2
+
+
+def test_retry_exhausted_connection_error_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    aib = _client(handler, retry_max_attempts=2, retry_base_delay_seconds=0.0)
+    with pytest.raises(httpx.ConnectError):
+        aib.list("agents")
+
+
+def test_retry_exhausted_5xx_surfaces_to_caller() -> None:
+    aib = _client(
+        lambda req: httpx.Response(500, text="boom"),
+        retry_max_attempts=2,
+        retry_base_delay_seconds=0.0,
+    )
+    # delete() raises for status on the final non-404 5xx response.
+    with pytest.raises(httpx.HTTPStatusError):
+        aib.delete("agents", "a1")
+
+
+def test_create_or_get_creates() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        return httpx.Response(201, json={"id": "new"})
+
+    assert _client(handler).create_or_get("agents", "name", "x", {"name": "x"}) == "new"
+
+
+def test_create_or_get_falls_back_to_existing() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(409, text="exists")
+        return httpx.Response(200, json={"items": [{"id": "old", "name": "x"}]})
+
+    assert _client(handler).create_or_get("agents", "name", "x", {"name": "x"}) == "old"

--- a/sync-service/tests/test_config.py
+++ b/sync-service/tests/test_config.py
@@ -1,0 +1,43 @@
+"""Tests for environment-driven settings parsing."""
+
+from __future__ import annotations
+
+from kaos_sync.config import Settings
+
+
+def test_defaults():
+    settings = Settings.from_env({})
+    assert settings.namespaces == ()
+    assert settings.prune_enabled is True
+    assert settings.metrics_port == 9090
+    assert settings.health_port == 8080
+    assert settings.retry_max_attempts == 4
+    assert settings.retry_base_delay_seconds == 0.5
+
+
+def test_overrides_from_env():
+    settings = Settings.from_env(
+        {
+            "AIB_ADMIN_URL": "http://broker/api",
+            "KAOS_SYNC_NAMESPACES": "a, b ,c",
+            "KAOS_SYNC_PRUNE_ENABLED": "false",
+            "KAOS_SYNC_METRICS_PORT": "1234",
+            "KAOS_SYNC_HEALTH_PORT": "5678",
+            "KAOS_SYNC_RETRY_MAX_ATTEMPTS": "7",
+            "KAOS_SYNC_RETRY_BASE_DELAY_SECONDS": "0.25",
+        }
+    )
+    assert settings.aib_admin_url == "http://broker/api"
+    assert settings.namespaces == ("a", "b", "c")
+    assert settings.prune_enabled is False
+    assert settings.metrics_port == 1234
+    assert settings.health_port == 5678
+    assert settings.retry_max_attempts == 7
+    assert settings.retry_base_delay_seconds == 0.25
+
+
+def test_prune_enabled_truthy_values():
+    assert Settings.from_env({"KAOS_SYNC_PRUNE_ENABLED": "1"}).prune_enabled is True
+    assert Settings.from_env({"KAOS_SYNC_PRUNE_ENABLED": "yes"}).prune_enabled is True
+    assert Settings.from_env({"KAOS_SYNC_PRUNE_ENABLED": "off"}).prune_enabled is False
+    assert Settings.from_env({"KAOS_SYNC_PRUNE_ENABLED": "0"}).prune_enabled is False

--- a/sync-service/tests/test_config.py
+++ b/sync-service/tests/test_config.py
@@ -9,7 +9,6 @@ def test_defaults():
     settings = Settings.from_env({})
     assert settings.namespaces == ()
     assert settings.prune_enabled is True
-    assert settings.metrics_port == 9090
     assert settings.health_port == 8080
     assert settings.retry_max_attempts == 4
     assert settings.retry_base_delay_seconds == 0.5
@@ -21,7 +20,6 @@ def test_overrides_from_env():
             "AIB_ADMIN_URL": "http://broker/api",
             "KAOS_SYNC_NAMESPACES": "a, b ,c",
             "KAOS_SYNC_PRUNE_ENABLED": "false",
-            "KAOS_SYNC_METRICS_PORT": "1234",
             "KAOS_SYNC_HEALTH_PORT": "5678",
             "KAOS_SYNC_RETRY_MAX_ATTEMPTS": "7",
             "KAOS_SYNC_RETRY_BASE_DELAY_SECONDS": "0.25",
@@ -30,7 +28,6 @@ def test_overrides_from_env():
     assert settings.aib_admin_url == "http://broker/api"
     assert settings.namespaces == ("a", "b", "c")
     assert settings.prune_enabled is False
-    assert settings.metrics_port == 1234
     assert settings.health_port == 5678
     assert settings.retry_max_attempts == 7
     assert settings.retry_base_delay_seconds == 0.25

--- a/sync-service/tests/test_observability.py
+++ b/sync-service/tests/test_observability.py
@@ -1,13 +1,35 @@
-"""Tests for metrics recording and the health/readiness routing."""
+"""Tests for OTel metrics recording and the health/readiness routing."""
 
 from __future__ import annotations
 
-from prometheus_client import REGISTRY
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
-from kaos_sync.observability import HealthState, handle_path, record_summary
+from kaos_sync.observability import HealthState, SyncMetrics, handle_path
 from kaos_sync.projection import project
 from kaos_sync.reconcile import reconcile
 from tests.test_reconcile import FakeAIB, FakeSecrets, _agent, _mcpserver
+
+
+def _collect(reader: InMemoryMetricReader) -> dict[str, float]:
+    """Flatten the latest metric export into ``{metric_name: summed_value}``."""
+    values: dict[str, float] = {}
+    data = reader.get_metrics_data()
+    if data is None:
+        return values
+    for resource_metric in data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                values[metric.name] = sum(
+                    getattr(point, "value", 0) for point in metric.data.data_points
+                )
+    return values
+
+
+def _metrics_with_reader() -> tuple[SyncMetrics, InMemoryMetricReader]:
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    return SyncMetrics(provider), reader
 
 
 def test_healthz_is_always_ok():
@@ -23,11 +45,9 @@ def test_readyz_reflects_first_pass_completion():
     assert handle_path("/readyz", state)[0] == 200
 
 
-def test_metrics_endpoint_exposes_prometheus_text():
-    status, content_type, body = handle_path("/metrics", HealthState())
-    assert status == 200
-    assert "text/plain" in content_type
-    assert b"kaos_sync_reconcile_passes_total" in body
+def test_metrics_route_is_not_served_over_http():
+    # Metrics are pushed via OTLP, not scraped; /metrics must not be a route.
+    assert handle_path("/metrics", HealthState())[0] == 404
 
 
 def test_unknown_path_is_404():
@@ -38,15 +58,27 @@ def test_query_string_is_ignored():
     assert handle_path("/healthz?verbose=1", HealthState())[0] == 200
 
 
-def test_record_summary_updates_metrics():
-    before = REGISTRY.get_sample_value("kaos_sync_reconcile_passes_total") or 0.0
+def test_record_updates_counters_and_gauges():
+    sync_metrics, reader = _metrics_with_reader()
 
-    aib, secrets = FakeAIB(), FakeSecrets()
-    summary = reconcile(project([_mcpserver("github"), _agent("a", ["github"])]), aib, secrets)
-    record_summary(summary)
+    summary = reconcile(
+        project([_mcpserver("github"), _agent("a", ["github"])]), FakeAIB(), FakeSecrets()
+    )
+    sync_metrics.record(summary)
 
-    after = REGISTRY.get_sample_value("kaos_sync_reconcile_passes_total")
-    assert after == before + 1
-    assert REGISTRY.get_sample_value("kaos_sync_agents_synced") == 1
-    assert REGISTRY.get_sample_value("kaos_sync_last_pass_ok") == 1
-    assert REGISTRY.get_sample_value("kaos_sync_services") == 1
+    values = _collect(reader)
+    assert values["kaos.sync.reconcile.passes"] == 1
+    assert values["kaos.sync.services"] == 1
+    assert values["kaos.sync.agents.synced"] == 1
+    assert values["kaos.sync.last_pass_ok"] == 1
+
+
+def test_counters_accumulate_across_passes():
+    sync_metrics, reader = _metrics_with_reader()
+
+    desired = project([_mcpserver("github"), _agent("a", ["github"])])
+    sync_metrics.record(reconcile(desired, FakeAIB(), FakeSecrets()))
+    sync_metrics.record(reconcile(desired, FakeAIB(), FakeSecrets()))
+
+    values = _collect(reader)
+    assert values["kaos.sync.reconcile.passes"] == 2

--- a/sync-service/tests/test_observability.py
+++ b/sync-service/tests/test_observability.py
@@ -1,0 +1,52 @@
+"""Tests for metrics recording and the health/readiness routing."""
+
+from __future__ import annotations
+
+from prometheus_client import REGISTRY
+
+from kaos_sync.observability import HealthState, handle_path, record_summary
+from kaos_sync.projection import project
+from kaos_sync.reconcile import reconcile
+from tests.test_reconcile import FakeAIB, FakeSecrets, _agent, _mcpserver
+
+
+def test_healthz_is_always_ok():
+    status, _, body = handle_path("/healthz", HealthState())
+    assert status == 200
+    assert body == b"ok"
+
+
+def test_readyz_reflects_first_pass_completion():
+    state = HealthState()
+    assert handle_path("/readyz", state)[0] == 503
+    state.mark_ready()
+    assert handle_path("/readyz", state)[0] == 200
+
+
+def test_metrics_endpoint_exposes_prometheus_text():
+    status, content_type, body = handle_path("/metrics", HealthState())
+    assert status == 200
+    assert "text/plain" in content_type
+    assert b"kaos_sync_reconcile_passes_total" in body
+
+
+def test_unknown_path_is_404():
+    assert handle_path("/nope", HealthState())[0] == 404
+
+
+def test_query_string_is_ignored():
+    assert handle_path("/healthz?verbose=1", HealthState())[0] == 200
+
+
+def test_record_summary_updates_metrics():
+    before = REGISTRY.get_sample_value("kaos_sync_reconcile_passes_total") or 0.0
+
+    aib, secrets = FakeAIB(), FakeSecrets()
+    summary = reconcile(project([_mcpserver("github"), _agent("a", ["github"])]), aib, secrets)
+    record_summary(summary)
+
+    after = REGISTRY.get_sample_value("kaos_sync_reconcile_passes_total")
+    assert after == before + 1
+    assert REGISTRY.get_sample_value("kaos_sync_agents_synced") == 1
+    assert REGISTRY.get_sample_value("kaos_sync_last_pass_ok") == 1
+    assert REGISTRY.get_sample_value("kaos_sync_services") == 1

--- a/sync-service/tests/test_projection.py
+++ b/sync-service/tests/test_projection.py
@@ -6,6 +6,7 @@ from kaos_sync.projection import (
     DesiredState,
     agent_external_id,
     mcpserver_resource_uri,
+    modelapi_resource_uri,
     permission_set_name,
     project,
     service_client_id,
@@ -20,11 +21,27 @@ def _mcpserver(name: str, namespace: str = "demo") -> dict:
     }
 
 
-def _agent(name: str, mcp_servers: list[str], namespace: str = "demo") -> dict:
+def _modelapi(name: str, namespace: str = "demo") -> dict:
+    return {
+        "kind": "ModelAPI",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {"mode": "proxy"},
+    }
+
+
+def _agent(
+    name: str,
+    mcp_servers: list[str],
+    namespace: str = "demo",
+    model_api: str | None = "gpt",
+) -> dict:
+    spec: dict = {"model": "gpt-4", "mcpServers": mcp_servers}
+    if model_api is not None:
+        spec["modelAPI"] = model_api
     return {
         "kind": "Agent",
         "metadata": {"name": name, "namespace": namespace},
-        "spec": {"modelAPI": "gpt", "model": "gpt-4", "mcpServers": mcp_servers},
+        "spec": spec,
     }
 
 
@@ -33,6 +50,7 @@ def test_encoding_conventions():
     assert permission_set_name("demo", "github") == "kaos:mcpserver:demo:github:call"
     assert agent_external_id("demo", "researcher") == "kaos://agent/demo/researcher"
     assert mcpserver_resource_uri("demo", "github") == "kaos://mcpserver/demo/github"
+    assert modelapi_resource_uri("demo", "gpt") == "kaos://modelapi/demo/gpt"
 
 
 def test_project_full_graph():
@@ -40,35 +58,64 @@ def test_project_full_graph():
         [
             _mcpserver("github"),
             _mcpserver("slack"),
-            _agent("researcher", ["github"]),
+            _modelapi("gpt"),
+            _agent("researcher", ["github"], model_api="gpt"),
         ]
     )
 
-    # Both declared MCPServers become services even if only one is granted.
+    # Both declared MCPServers and the ModelAPI become services even if only some are granted.
     assert {s.client_id for s in state.services} == {
         "kaos-mcpserver-demo-github",
         "kaos-mcpserver-demo-slack",
+        "kaos-modelapi-demo-gpt",
     }
-    # Only the requested edge yields a permission set.
-    assert [ps.name for ps in state.permission_sets] == ["kaos:mcpserver:demo:github:call"]
+    # The requested MCP edge and the model API edge each yield a permission set.
+    assert {ps.name for ps in state.permission_sets} == {
+        "kaos:mcpserver:demo:github:call",
+        "kaos:modelapi:demo:gpt:call",
+    }
 
     assert len(state.agents) == 1
     agent = state.agents[0]
     assert agent.external_id == "kaos://agent/demo/researcher"
-    assert agent.permission_set_names == ("kaos:mcpserver:demo:github:call",)
-    assert agent.granted_resources == ("kaos://mcpserver/demo/github",)
+    # MCP edges are projected before the model API edge.
+    assert agent.permission_set_names == (
+        "kaos:mcpserver:demo:github:call",
+        "kaos:modelapi:demo:gpt:call",
+    )
+    assert agent.granted_resources == (
+        "kaos://mcpserver/demo/github",
+        "kaos://modelapi/demo/gpt",
+    )
 
 
-def test_agent_without_edges_is_skipped():
-    state = project([_mcpserver("github"), _agent("idle", [])])
+def test_model_api_edge_is_projected_without_mcp_servers():
+    # An agent with only a model API still gets a modelapi service, permission set and edge.
+    state = project([_agent("solo", [], model_api="gpt")])
+    assert [s.client_id for s in state.services] == ["kaos-modelapi-demo-gpt"]
+    assert [ps.name for ps in state.permission_sets] == ["kaos:modelapi:demo:gpt:call"]
+    assert len(state.agents) == 1
+    assert state.agents[0].granted_resources == ("kaos://modelapi/demo/gpt",)
+
+
+def test_agent_without_any_edge_is_skipped():
+    # No MCP servers and no model API: nothing to authorize, so the agent is skipped.
+    state = project([_mcpserver("github"), _agent("idle", [], model_api=None)])
     assert state.agents == []
     # The standalone MCPServer is still projected as a service.
     assert [s.client_id for s in state.services] == ["kaos-mcpserver-demo-github"]
 
 
+def test_declared_model_api_yields_service_even_when_ungranted():
+    state = project([_modelapi("gpt"), _agent("idle", [], model_api=None)])
+    assert [s.client_id for s in state.services] == ["kaos-modelapi-demo-gpt"]
+    assert state.permission_sets == []
+    assert state.agents == []
+
+
 def test_edge_to_undeclared_mcpserver_still_yields_service():
     # Agent references an MCPServer that has no standalone resource in the input.
-    state = project([_agent("researcher", ["ghost"])])
+    state = project([_agent("researcher", ["ghost"], model_api=None)])
     assert [s.client_id for s in state.services] == ["kaos-mcpserver-demo-ghost"]
     assert [ps.name for ps in state.permission_sets] == ["kaos:mcpserver:demo:ghost:call"]
     assert state.agents[0].granted_resources == ("kaos://mcpserver/demo/ghost",)
@@ -77,15 +124,16 @@ def test_edge_to_undeclared_mcpserver_still_yields_service():
 def test_projection_is_idempotent_and_deduplicates():
     resources = [
         _mcpserver("github"),
-        _agent("a", ["github"]),
-        _agent("b", ["github"]),
+        _modelapi("gpt"),
+        _agent("a", ["github"], model_api="gpt"),
+        _agent("b", ["github"], model_api="gpt"),
     ]
     first = project(resources)
     second = project(resources)
 
-    # Shared service/permission set are not duplicated across two agents.
-    assert len(first.services) == 1
-    assert len(first.permission_sets) == 1
+    # Shared services/permission sets are not duplicated across two agents.
+    assert len(first.services) == 2
+    assert len(first.permission_sets) == 2
     assert len(first.agents) == 2
 
     # Deterministic output: re-projecting the same input yields equal state.
@@ -93,7 +141,7 @@ def test_projection_is_idempotent_and_deduplicates():
 
 
 def test_admin_bodies_shape():
-    state = project([_mcpserver("github"), _agent("researcher", ["github"])])
+    state = project([_mcpserver("github"), _agent("researcher", ["github"], model_api=None)])
 
     svc_body = state.services[0].admin_body()
     assert svc_body["client_id"] == "kaos-mcpserver-demo-github"
@@ -109,6 +157,14 @@ def test_admin_bodies_shape():
     assert agent_body["permission_sets"] == [
         {"permission_set_id": "ps-1", "requirement_type": "mandatory"}
     ]
+
+
+def test_model_api_admin_body_uses_model_api_vocabulary():
+    state = project([_modelapi("gpt"), _agent("solo", [], model_api="gpt")])
+    svc = next(s for s in state.services if s.client_id == "kaos-modelapi-demo-gpt")
+    body = svc.admin_body()
+    assert body["display_name"] == "KAOS ModelAPI demo/gpt (synthetic)"
+    assert body["scopes"] == [{"scope_value": "call", "description": "Invoke the model API"}]
 
 
 def _as_tuple(state: DesiredState):

--- a/sync-service/tests/test_reconcile.py
+++ b/sync-service/tests/test_reconcile.py
@@ -7,7 +7,7 @@ import pytest
 from kaos_sync.config import Settings
 from kaos_sync.main import run_once
 from kaos_sync.projection import project
-from kaos_sync.reconcile import credential_secret_name, reconcile
+from kaos_sync.reconcile import ProblemCategory, credential_secret_name, reconcile
 
 
 class FakeAIB:
@@ -223,3 +223,117 @@ def test_prune_leaves_externally_managed_records_untouched():
     assert "ext-agent" not in aib.revoke_calls
     # The KAOS-owned agent a was pruned.
     assert all(i["display_name"] != "kaos://agent/demo/a" for i in aib.list("agents"))
+
+
+class _AgentCreateFailsAIB(FakeAIB):
+    def __init__(self, fail_display):
+        super().__init__()
+        self._fail_display = fail_display
+
+    def create_or_get(self, collection, match_field, match_value, body):
+        if collection == "agents" and match_value == self._fail_display:
+            raise RuntimeError("broker unreachable")
+        return super().create_or_get(collection, match_field, match_value, body)
+
+
+class _ServiceCreateFailsAIB(FakeAIB):
+    def __init__(self, fail_client_id):
+        super().__init__()
+        self._fail_client_id = fail_client_id
+
+    def create_or_get(self, collection, match_field, match_value, body):
+        if collection == "services" and match_value == self._fail_client_id:
+            raise RuntimeError("service create failed")
+        return super().create_or_get(collection, match_field, match_value, body)
+
+
+class _IncompleteMintAIB(FakeAIB):
+    def mint_credentials(self, agent_id):
+        self.mint_calls.append(agent_id)
+        return {"client_id": "", "client_secret": ""}
+
+
+class _DeleteFailsAIB(FakeAIB):
+    def delete(self, collection, resource_id):
+        if collection == "agents":
+            raise RuntimeError("delete failed")
+        return super().delete(collection, resource_id)
+
+
+def test_failure_on_one_agent_is_isolated_from_others():
+    desired = project([_agent("a", ["github"]), _agent("b", ["slack"])])
+    aib = _AgentCreateFailsAIB(fail_display="kaos://agent/demo/a")
+    secrets = FakeSecrets()
+
+    summary = reconcile(desired, aib, secrets, "kaos-aib")
+
+    assert summary.ok is False
+    by_id = {a.external_id: a for a in summary.agents}
+    assert by_id["kaos://agent/demo/a"].ok is False
+    assert by_id["kaos://agent/demo/b"].ok is True
+    # The failed agent never gets a credential Secret; the healthy one does.
+    assert secrets.get("demo", "kaos-aib-a") is None
+    assert secrets.get("demo", "kaos-aib-b") is not None
+    assert [p.category for p in summary.problems] == [ProblemCategory.AIB_UNREACHABLE]
+
+
+def test_unavailable_service_skips_dependent_edge_and_agent_fail_closed():
+    desired = project([_agent("a", ["github"]), _agent("b", ["slack"])])
+    aib = _ServiceCreateFailsAIB(fail_client_id="kaos-mcpserver-demo-github")
+    secrets = FakeSecrets()
+
+    summary = reconcile(desired, aib, secrets, "kaos-aib")
+
+    categories = {p.category for p in summary.problems}
+    assert ProblemCategory.UNSUPPORTED_EDGE in categories
+    by_id = {a.external_id: a for a in summary.agents}
+    # Agent a depends on the failed service and is skipped fail-closed (no credentials).
+    assert by_id["kaos://agent/demo/a"].ok is False
+    assert by_id["kaos://agent/demo/a"].credentials_minted is False
+    assert secrets.get("demo", "kaos-aib-a") is None
+    # Agent b is unaffected.
+    assert by_id["kaos://agent/demo/b"].ok is True
+    assert secrets.get("demo", "kaos-aib-b") is not None
+
+
+def test_incomplete_credentials_are_reported_and_not_stored():
+    desired = project([_agent("a", ["github"])])
+    aib = _IncompleteMintAIB()
+    secrets = FakeSecrets()
+
+    summary = reconcile(desired, aib, secrets, "kaos-aib")
+
+    assert summary.agents[0].ok is False
+    assert summary.agents[0].credentials_minted is False
+    assert secrets.get("demo", "kaos-aib-a") is None
+    assert [p.category for p in summary.problems] == [ProblemCategory.MISSING_CREDENTIALS]
+
+
+def test_prune_delete_failure_is_reported_and_pass_continues():
+    aib = _DeleteFailsAIB()
+    secrets = FakeSecrets()
+    reconcile(project([_agent("a", ["github"]), _agent("b", ["slack"])]), aib, secrets, "kaos-aib")
+
+    summary = reconcile(project([_agent("a", ["github"])]), aib, secrets, "kaos-aib", prune=True)
+
+    assert summary.pruned.agents == 0  # the agent delete failed
+    assert any(p.category == ProblemCategory.PRUNE_FAILED for p in summary.problems)
+    # Permission sets and services still get pruned despite the agent delete failure.
+    assert summary.pruned.services == 1
+
+
+def test_prune_skips_malformed_external_id_as_drift():
+    aib = FakeAIB()
+    secrets = FakeSecrets()
+    reconcile(project([_agent("a", ["github"])]), aib, secrets, "kaos-aib")
+    # Inject a KAOS-prefixed agent whose external id cannot be parsed into ns/name.
+    aib.collections["agents"]["kaos://agent/onlyone"] = {
+        "id": "malformed",
+        "display_name": "kaos://agent/onlyone",
+    }
+
+    summary = reconcile(project([]), aib, secrets, "kaos-aib", prune=True)
+
+    assert any(p.category == ProblemCategory.STALE_EXTERNAL_ID for p in summary.problems)
+    # The malformed record is left in place rather than blindly deleted.
+    assert aib.get("agents", "malformed") is not None

--- a/sync-service/tests/test_reconcile.py
+++ b/sync-service/tests/test_reconcile.py
@@ -16,7 +16,18 @@ class FakeAIB:
     def __init__(self):
         self.collections: dict[str, dict[str, dict]] = {}
         self.mint_calls: list[str] = []
+        self.revoke_calls: list[str] = []
+        self.delete_calls: list[tuple[str, str]] = []
         self._next = 0
+
+    def _by_id(self, collection: str) -> dict[str, dict]:
+        return {item["id"]: item for item in self.collections.get(collection, {}).values()}
+
+    def list(self, collection):
+        return [dict(item, id=item["id"]) for item in self.collections.get(collection, {}).values()]
+
+    def get(self, collection, resource_id):
+        return self._by_id(collection).get(resource_id)
 
     def create_or_get(self, collection, match_field, match_value, body):
         store = self.collections.setdefault(collection, {})
@@ -24,12 +35,25 @@ class FakeAIB:
             return store[match_value]["id"]
         self._next += 1
         item_id = f"{collection}-{self._next}"
-        store[match_value] = {"id": item_id, "body": body}
+        store[match_value] = {"id": item_id, match_field: match_value, "body": body}
         return item_id
+
+    def delete(self, collection, resource_id):
+        self.delete_calls.append((collection, resource_id))
+        store = self.collections.get(collection, {})
+        for key, item in list(store.items()):
+            if item["id"] == resource_id:
+                del store[key]
+                return True
+        return False
 
     def mint_credentials(self, agent_id):
         self.mint_calls.append(agent_id)
         return {"client_id": f"cid-{agent_id}", "client_secret": f"secret-{agent_id}"}
+
+    def revoke_credentials(self, agent_id):
+        self.revoke_calls.append(agent_id)
+        return True
 
 
 class FakeSecrets:

--- a/sync-service/tests/test_reconcile.py
+++ b/sync-service/tests/test_reconcile.py
@@ -66,6 +66,14 @@ class FakeSecrets:
     def upsert(self, namespace, name, string_data):
         self.store[(namespace, name)] = dict(string_data)
 
+    def list(self, namespaces):
+        if not namespaces:
+            return list(self.store.keys())
+        return [(ns, name) for (ns, name) in self.store if ns in namespaces]
+
+    def delete(self, namespace, name):
+        return self.store.pop((namespace, name), None) is not None
+
 
 class FakeLister:
     def __init__(self, resources):
@@ -161,3 +169,57 @@ def test_run_once_projects_and_reconciles():
     assert summary.services == 2
     assert summary.permission_sets == 1
     assert summary.agents[0].secret_name == "kaos-aib-researcher"
+
+
+def test_reconcile_does_not_prune_by_default():
+    aib, secrets = FakeAIB(), FakeSecrets()
+    reconcile(project([_agent("a", ["github"]), _agent("b", ["slack"])]), aib, secrets, "kaos-aib")
+
+    # Re-reconcile a shrunk desired state without prune: orphans must remain.
+    summary = reconcile(project([_agent("a", ["github"])]), aib, secrets, "kaos-aib")
+
+    assert summary.pruned.agents == 0
+    assert secrets.get("demo", "kaos-aib-b") is not None
+    assert any(i["display_name"] == "kaos://agent/demo/b" for i in aib.list("agents"))
+
+
+def test_reconcile_prunes_orphaned_records_and_secrets():
+    aib, secrets = FakeAIB(), FakeSecrets()
+    reconcile(project([_agent("a", ["github"]), _agent("b", ["slack"])]), aib, secrets, "kaos-aib")
+    b_agent_id = aib.collections["agents"]["kaos://agent/demo/b"]["id"]
+
+    summary = reconcile(project([_agent("a", ["github"])]), aib, secrets, "kaos-aib", prune=True)
+
+    # Agent b plus its slack permission set, slack service and credential Secret are removed.
+    assert summary.pruned.agents == 1
+    assert summary.pruned.permission_sets == 1
+    assert summary.pruned.services == 1
+    assert summary.pruned.secrets == 1
+    assert b_agent_id in aib.revoke_calls
+
+    # Agent a and its records remain intact.
+    assert secrets.get("demo", "kaos-aib-a") is not None
+    assert secrets.get("demo", "kaos-aib-b") is None
+    remaining_agents = {i["display_name"] for i in aib.list("agents")}
+    assert remaining_agents == {"kaos://agent/demo/a"}
+    remaining_services = {i["client_id"] for i in aib.list("services")}
+    assert remaining_services == {"kaos-mcpserver-demo-github"}
+
+
+def test_prune_leaves_externally_managed_records_untouched():
+    aib, secrets = FakeAIB(), FakeSecrets()
+    reconcile(project([_agent("a", ["github"])]), aib, secrets, "kaos-aib")
+    # Inject broker records owned by something other than KAOS.
+    aib.collections["agents"]["ext"] = {"id": "ext-agent", "display_name": "external-agent"}
+    aib.collections["services"]["ext"] = {"id": "ext-svc", "client_id": "vendor-service"}
+    aib.collections["permission-sets"]["ext"] = {"id": "ext-ps", "name": "vendor:ps"}
+
+    # Prune against an empty desired state: only KAOS-owned records should go.
+    reconcile(project([]), aib, secrets, "kaos-aib", prune=True)
+
+    assert aib.get("agents", "ext-agent") is not None
+    assert aib.get("services", "ext-svc") is not None
+    assert aib.get("permission-sets", "ext-ps") is not None
+    assert "ext-agent" not in aib.revoke_calls
+    # The KAOS-owned agent a was pruned.
+    assert all(i["display_name"] != "kaos://agent/demo/a" for i in aib.list("agents"))


### PR DESCRIPTION
## Summary

Hardens the standalone KAOS→broker sync service from a minimal projector into an MVP-robust reconciler.

- **ModelAPI projection** — agents are projected when they declare any edge, and `Agent → ModelAPI` edges become broker services (`kaos-modelapi-<ns>-<name>`) and permission sets alongside MCP server edges.
- **Pruning** — KAOS-owned broker records (services, permission sets, agents) and credential Secrets that no longer correspond to a live KAOS resource are deleted in a dependency-safe order, with credential revocation. Controlled by `KAOS_SYNC_PRUNE_ENABLED`.
- **Per-resource isolation + drift reporting** — each service, permission set and agent reconciles independently; failures are captured as categorized `Problem`s (broker unreachable, missing credentials, unsupported edge, stale external id, prune failure) without aborting the pass. Agents missing a permission set fail closed.
- **Bounded retries** — broker admin requests retry transport errors and 5xx with bounded exponential backoff.
- **Observability** — Prometheus metrics at `/metrics` (reconcile passes, minted credentials, projected counts, problems by category) plus `/healthz` liveness and `/readyz` readiness endpoints.
- **Chart/RBAC** — secrets RBAC gains `delete`; the deployment exposes metrics/health ports, liveness/readiness probes, and the new tuning env; values surface pruning, retry and observability settings.

## Validation

- Unit suite: 45 tests pass; `black --check` and `uvx ty check` clean.
- `helm lint` + `helm template` render cleanly.
- **Local KIND** (`kind-kaos-e2e`): built and loaded the image, installed the chart with an unreachable broker. The pod reached Ready (readiness flips after the first pass), `/readyz` returned `200 ready`, `/metrics` exposed `kaos_sync_*` series with `reconcile_passes_total` incrementing and `problems_total{category="aib_unreachable"}` recorded — confirming the fail-open loop and observability in a real cluster.

Full broker-backed reconcile/prune e2e remains local-only while the broker is unpublished; CI runs the sync unit suite.
