### PR TITLE
PR-ADR-KAOS-5: Gateway user authentication with Keycloak and dual JWT providers

### DIFF
--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -31,6 +31,22 @@ AUTH_EXT_AUTHZ_PORT = 9191
 AUTH_ENDUSER_PORT = 8000
 AUTH_ADMIN_PORT = 14000
 DEFAULT_SYNC_RELEASE = "kaos-sync"
+
+# User-auth (human identity provider, Keycloak by default) defaults
+DEFAULT_KEYCLOAK_NAMESPACE = "keycloak"
+DEFAULT_KEYCLOAK_RELEASE = "keycloak"
+DEFAULT_KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.0"
+KEYCLOAK_HTTP_PORT = 8080
+DEFAULT_USER_AUTH_REALM = "kaos"
+DEFAULT_USER_AUTH_AUDIENCE = "kaos"
+DEFAULT_USER_AUTH_CLIENT_ID = "kaos"
+# Dev-only fixtures used to bootstrap a non-interactive test identity. These are
+# intended exclusively for local/e2e validation, never for production installs.
+DEFAULT_USER_AUTH_CLIENT_SECRET = "kaos-dev-secret"
+DEFAULT_USER_AUTH_TEST_USER = "kaos-user"
+DEFAULT_USER_AUTH_TEST_PASSWORD = "kaos-password"
+DEFAULT_KEYCLOAK_ADMIN_USER = "admin"
+DEFAULT_KEYCLOAK_ADMIN_PASSWORD = "admin"
 # KAOS CRD names (for explicit install/uninstall)
 KAOS_CRDS = [
     "agents.kaos.tools",
@@ -536,15 +552,26 @@ def _default_auth_admin_url(auth_namespace: str, auth_release: str) -> str:
     return f"http://{host}:{AUTH_ADMIN_PORT}/api"
 
 
+def _default_user_auth_issuer(keycloak_namespace: str, keycloak_release: str) -> str:
+    """Default user-auth OIDC issuer (Keycloak realm URL) for the gateway provider."""
+    host = f"{keycloak_release}.{keycloak_namespace}.svc.cluster.local"
+    return f"http://{host}:{KEYCLOAK_HTTP_PORT}/realms/{DEFAULT_USER_AUTH_REALM}"
+
+
 def _build_auth_operator_args(
     ext_authz_url: str,
     issuer: str,
     credential_secret_prefix: str,
+    user_issuer: str = "",
+    user_audience: str = "",
+    user_jwks_uri: str = "",
 ) -> list[str]:
     """Build the operator Helm --set arguments that enable agent-auth wiring.
 
     Returns the flat ``--set key=value`` argument list so it can be unit-tested
-    independently of running Helm.
+    independently of running Helm. User-auth (``security.userAuth.*``) arguments
+    are appended only when a user issuer is supplied, keeping agent-only and
+    autonomous-only installs unchanged.
     """
     args: list[str] = []
     args.extend(["--set", f"security.agentAuth.extAuthzUrl={ext_authz_url}"])
@@ -555,6 +582,12 @@ def _build_auth_operator_args(
             f"security.agentAuth.credentialSecretPrefix={credential_secret_prefix}",
         ]
     )
+    if user_issuer:
+        args.extend(["--set", f"security.userAuth.issuer={user_issuer}"])
+    if user_audience:
+        args.extend(["--set", f"security.userAuth.audience={user_audience}"])
+    if user_jwks_uri:
+        args.extend(["--set", f"security.userAuth.jwksUri={user_jwks_uri}"])
     return args
 
 
@@ -628,6 +661,241 @@ def _install_aib(
     return True
 
 
+def _keycloak_realm_json(
+    realm: str,
+    client_id: str,
+    client_secret: str,
+    audience: str,
+    username: str,
+    password: str,
+) -> dict:
+    """Build a minimal Keycloak realm definition for non-interactive validation.
+
+    The realm exposes a confidential client with the direct-access-grant flow so a
+    user access token can be minted programmatically (password grant), and an
+    audience mapper so the issued token carries the audience the gateway verifies.
+    """
+    return {
+        "realm": realm,
+        "enabled": True,
+        "clients": [
+            {
+                "clientId": client_id,
+                "enabled": True,
+                "publicClient": False,
+                "secret": client_secret,
+                "directAccessGrantsEnabled": True,
+                "standardFlowEnabled": True,
+                "serviceAccountsEnabled": True,
+                "redirectUris": ["*"],
+                "protocolMappers": [
+                    {
+                        "name": "kaos-audience",
+                        "protocol": "openid-connect",
+                        "protocolMapper": "oidc-audience-mapper",
+                        "config": {
+                            "included.client.audience": audience,
+                            "id.token.claim": "false",
+                            "access.token.claim": "true",
+                        },
+                    }
+                ],
+            }
+        ],
+        "users": [
+            {
+                "username": username,
+                "enabled": True,
+                "credentials": [
+                    {"type": "password", "value": password, "temporary": False}
+                ],
+            }
+        ],
+    }
+
+
+def _keycloak_realm_configmap_name(release: str) -> str:
+    """Name of the ConfigMap holding the imported realm definition."""
+    return f"{release}-realm-import"
+
+
+def _bootstrap_keycloak_realm(
+    namespace: str,
+    release: str,
+    realm: str,
+    audience: str,
+) -> bool:
+    """Create the realm-import ConfigMap consumed by Keycloak's --import-realm.
+
+    This is the non-interactive realm bootstrap: it provisions the realm, a
+    confidential client and a test user so a user token can be obtained without a
+    browser login. Applied via kubectl so it is independent of the Keycloak chart.
+    """
+    realm_json = json.dumps(
+        _keycloak_realm_json(
+            realm,
+            DEFAULT_USER_AUTH_CLIENT_ID,
+            DEFAULT_USER_AUTH_CLIENT_SECRET,
+            audience,
+            DEFAULT_USER_AUTH_TEST_USER,
+            DEFAULT_USER_AUTH_TEST_PASSWORD,
+        ),
+        indent=2,
+    )
+    configmap = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": _keycloak_realm_configmap_name(release),
+            "namespace": namespace,
+        },
+        "data": {f"{realm}-realm.json": realm_json},
+    }
+
+    apply_ns = _run_kubectl(
+        ["create", "namespace", namespace],
+        check=False,
+    )
+    if (
+        apply_ns.returncode != 0
+        and "already exists" not in (apply_ns.stderr or "").lower()
+    ):
+        typer.echo(
+            f"Warning: could not create namespace '{namespace}': {apply_ns.stderr}",
+            err=True,
+        )
+
+    result = _run_kubectl(
+        ["apply", "-f", "-"], check=False, input=json.dumps(configmap)
+    )
+    if result.returncode != 0:
+        typer.echo(f"Error bootstrapping Keycloak realm: {result.stderr}", err=True)
+        return False
+    typer.echo(f"✅ Keycloak realm '{realm}' bootstrap manifest applied")
+    return True
+
+
+def _keycloak_dev_manifests(namespace: str, release: str) -> list[dict]:
+    """Self-contained Keycloak dev deployment (start-dev, H2 in-memory, no DB).
+
+    Mounts the realm-import ConfigMap and runs with --import-realm so the
+    bootstrapped realm/client/user are available on startup. Intended for local
+    and e2e validation only.
+    """
+    labels = {"app": release}
+    configmap_name = _keycloak_realm_configmap_name(release)
+    deployment = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": release, "namespace": namespace, "labels": labels},
+        "spec": {
+            "replicas": 1,
+            "selector": {"matchLabels": labels},
+            "template": {
+                "metadata": {"labels": labels},
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "keycloak",
+                            "image": DEFAULT_KEYCLOAK_IMAGE,
+                            "args": ["start-dev", "--import-realm"],
+                            "env": [
+                                {
+                                    "name": "KEYCLOAK_ADMIN",
+                                    "value": DEFAULT_KEYCLOAK_ADMIN_USER,
+                                },
+                                {
+                                    "name": "KEYCLOAK_ADMIN_PASSWORD",
+                                    "value": DEFAULT_KEYCLOAK_ADMIN_PASSWORD,
+                                },
+                            ],
+                            "ports": [{"containerPort": KEYCLOAK_HTTP_PORT}],
+                            "volumeMounts": [
+                                {
+                                    "name": "realm-import",
+                                    "mountPath": "/opt/keycloak/data/import",
+                                    "readOnly": True,
+                                }
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "name": "realm-import",
+                            "configMap": {"name": configmap_name},
+                        }
+                    ],
+                },
+            },
+        },
+    }
+    service = {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": release, "namespace": namespace, "labels": labels},
+        "spec": {
+            "selector": labels,
+            "ports": [
+                {
+                    "port": KEYCLOAK_HTTP_PORT,
+                    "targetPort": KEYCLOAK_HTTP_PORT,
+                    "name": "http",
+                }
+            ],
+        },
+    }
+    return [deployment, service]
+
+
+def _install_keycloak(
+    namespace: str,
+    release: str,
+    realm: str,
+    audience: str,
+    chart_path: str | None,
+    wait: bool,
+) -> bool:
+    """Install Keycloak as the human user identity provider.
+
+    The realm/client/test-user are bootstrapped first (non-interactive). When a
+    chart path is supplied Keycloak is installed via Helm (mirrors the broker
+    dev path); otherwise a self-contained dev deployment is applied via kubectl.
+    """
+    typer.echo("Installing user identity provider (Keycloak)...")
+    if not _bootstrap_keycloak_realm(namespace, release, realm, audience):
+        return False
+
+    if chart_path:
+        helm_args = [
+            "upgrade",
+            "--install",
+            release,
+            chart_path,
+            "--namespace",
+            namespace,
+            "--create-namespace",
+            "--set",
+            f"realmImport.configMapName={_keycloak_realm_configmap_name(release)}",
+        ]
+        if wait:
+            helm_args.append("--wait")
+        result = run_helm_command(helm_args, check=False)
+        if result.returncode != 0:
+            typer.echo(f"Error installing Keycloak: {result.stderr}", err=True)
+            return False
+    else:
+        for manifest in _keycloak_dev_manifests(namespace, release):
+            result = _run_kubectl(
+                ["apply", "-f", "-"], check=False, input=json.dumps(manifest)
+            )
+            if result.returncode != 0:
+                typer.echo(f"Error installing Keycloak: {result.stderr}", err=True)
+                return False
+
+    typer.echo(f"✅ Keycloak installed in '{namespace}' namespace")
+    return True
+
+
 def _uninstall_monitoring(backend: str, namespace: str) -> bool:
     """Uninstall monitoring stack for the given backend."""
     release = "jaeger" if backend == "jaeger" else "signoz"
@@ -695,6 +963,12 @@ def install_command(
     sync_chart_path: str | None = None,
     sync_image_repository: str | None = None,
     sync_image_tag: str | None = None,
+    user_auth: bool = True,
+    keycloak_namespace: str = DEFAULT_KEYCLOAK_NAMESPACE,
+    keycloak_release: str = DEFAULT_KEYCLOAK_RELEASE,
+    keycloak_chart_path: str | None = None,
+    user_auth_issuer: str | None = None,
+    user_auth_audience: str = DEFAULT_USER_AUTH_AUDIENCE,
 ) -> None:
     """Install the KAOS operator using Helm."""
     if not check_helm_installed():
@@ -728,6 +1002,10 @@ def install_command(
         ext_authz_url = ext_authz_url or _default_ext_authz_url(auth_namespace)
         auth_issuer = auth_issuer or _default_auth_issuer(auth_namespace, auth_release)
         auth_admin_url = _default_auth_admin_url(auth_namespace, auth_release)
+        if user_auth:
+            user_auth_issuer = user_auth_issuer or _default_user_auth_issuer(
+                keycloak_namespace, keycloak_release
+            )
 
         # Install the identity broker from a local chart when provided (it is
         # unpublished, so a chart path is required to install it here).
@@ -763,6 +1041,22 @@ def install_command(
             typer.echo(
                 "Note: --sync-chart-path not provided; skipping sync service deployment.",
             )
+
+        # Install Keycloak as the human user identity provider and bootstrap its
+        # realm so the gateway can verify user subject tokens alongside agent
+        # actor tokens. Skipped when user-auth is disabled.
+        if user_auth:
+            if not _install_keycloak(
+                keycloak_namespace,
+                keycloak_release,
+                DEFAULT_USER_AUTH_REALM,
+                user_auth_audience,
+                keycloak_chart_path,
+                wait,
+            ):
+                typer.echo(
+                    "Warning: Keycloak installation failed, continuing...", err=True
+                )
 
     # Phase 2: Wait for infra that the operator depends on
     if gateway_enabled:
@@ -867,11 +1161,19 @@ def install_command(
         helm_args.extend(["--set", f"agentDefaults.memory.redisUrl={redis_url}"])
 
     if auth_enabled:
+        resolved_user_issuer = (
+            user_auth_issuer
+            or _default_user_auth_issuer(keycloak_namespace, keycloak_release)
+            if user_auth
+            else ""
+        )
         helm_args.extend(
             _build_auth_operator_args(
                 ext_authz_url or _default_ext_authz_url(auth_namespace),
                 auth_issuer or _default_auth_issuer(auth_namespace, auth_release),
                 credential_secret_prefix,
+                user_issuer=resolved_user_issuer,
+                user_audience=user_auth_audience if user_auth else "",
             )
         )
 

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -706,6 +706,11 @@ def _keycloak_realm_json(
             {
                 "username": username,
                 "enabled": True,
+                "emailVerified": True,
+                "email": f"{username}@example.com",
+                "firstName": "KAOS",
+                "lastName": "User",
+                "requiredActions": [],
                 "credentials": [
                     {"type": "password", "value": password, "temporary": False}
                 ],

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -140,6 +140,34 @@ def install(
         "--sync-image-tag",
         help="Override the sync service image tag (for local/dev images).",
     ),
+    user_auth: bool = typer.Option(
+        True,
+        "--user-auth/--no-user-auth",
+        help="Install the human user identity provider (Keycloak) and wire user "
+        "subject-token validation at the gateway. Effective only with --auth-enabled.",
+    ),
+    keycloak_namespace: str = typer.Option(
+        "keycloak",
+        "--keycloak-namespace",
+        help="Namespace for the user identity provider (Keycloak).",
+    ),
+    keycloak_chart_path: str | None = typer.Option(
+        None,
+        "--keycloak-chart-path",
+        help="Path to a local Keycloak Helm chart to install. When omitted, a "
+        "self-contained dev deployment is applied instead.",
+    ),
+    user_auth_issuer: str | None = typer.Option(
+        None,
+        "--user-auth-issuer",
+        help="Override the user-auth OIDC issuer URL. Defaults to the bootstrapped "
+        "Keycloak realm in the keycloak namespace.",
+    ),
+    user_auth_audience: str = typer.Option(
+        "kaos",
+        "--user-auth-audience",
+        help="Expected audience claim for user subject tokens.",
+    ),
 ) -> None:
     """Install the KAOS operator using Helm."""
     # Default to signoz if flag provided without value
@@ -169,6 +197,12 @@ def install(
         sync_chart_path=sync_chart_path,
         sync_image_repository=sync_image_repository,
         sync_image_tag=sync_image_tag,
+        user_auth=user_auth,
+        keycloak_namespace=keycloak_namespace,
+        keycloak_release="keycloak",
+        keycloak_chart_path=keycloak_chart_path,
+        user_auth_issuer=user_auth_issuer,
+        user_auth_audience=user_auth_audience,
     )
 
 

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -884,6 +884,8 @@ class TestSystemInstallFlags:
         assert "--auth-enabled" in output
         assert "--auth-namespace" in output
         assert "--sync-chart-path" in output
+        assert "--user-auth" in output
+        assert "--keycloak-namespace" in output
 
 
 class TestAuthWiring:
@@ -961,6 +963,190 @@ class TestAuthWiring:
         joined = " ".join(captured.get("args", []))
         assert "security.agentAuth.extAuthzUrl=" in joined
         assert "security.agentAuth.credentialSecretPrefix=kaos-aib" in joined
+
+    def test_build_auth_operator_args_includes_user_auth(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            user_issuer="http://keycloak.keycloak:8080/realms/kaos",
+            user_audience="kaos",
+            user_jwks_uri="http://keycloak.keycloak:8080/custom/certs",
+        )
+        joined = " ".join(args)
+        assert (
+            "security.userAuth.issuer=http://keycloak.keycloak:8080/realms/kaos"
+            in joined
+        )
+        assert "security.userAuth.audience=kaos" in joined
+        assert (
+            "security.userAuth.jwksUri=http://keycloak.keycloak:8080/custom/certs"
+            in joined
+        )
+
+    def test_build_auth_operator_args_omits_user_auth_when_unset(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+        )
+        joined = " ".join(args)
+        assert "security.userAuth" not in joined
+
+    def test_default_user_auth_issuer(self):
+        from kaos_cli.install import _default_user_auth_issuer
+
+        issuer = _default_user_auth_issuer("kc-ns", "keycloak")
+        assert issuer == "http://keycloak.kc-ns.svc.cluster.local:8080/realms/kaos"
+
+    def test_auth_enabled_wires_user_auth_values(self):
+        """--auth-enabled (user-auth on by default) adds security.userAuth.* args."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+
+        captured = {}
+
+        def fake_helm(args, check=True, **kwargs):
+            if "upgrade" in args and any(
+                "kaos-operator" in a or a.endswith("/chart") for a in args
+            ):
+                captured["args"] = args
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("kaos_cli.install.check_helm_installed", return_value=True), patch(
+            "kaos_cli.install.run_helm_command", side_effect=fake_helm
+        ), patch("kaos_cli.install._run_kubectl") as mock_kubectl:
+            mock_kubectl.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            result = runner.invoke(
+                app,
+                [
+                    "system",
+                    "install",
+                    "--auth-enabled",
+                    "--chart-path",
+                    "operator/chart",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        joined = " ".join(captured.get("args", []))
+        assert "security.userAuth.issuer=" in joined
+        assert "security.userAuth.audience=kaos" in joined
+
+    def test_no_user_auth_omits_user_auth_values(self):
+        """--no-user-auth installs neither Keycloak nor the userAuth wiring."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+
+        captured = {}
+
+        def fake_helm(args, check=True, **kwargs):
+            if "upgrade" in args and any(
+                "kaos-operator" in a or a.endswith("/chart") for a in args
+            ):
+                captured["args"] = args
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("kaos_cli.install.check_helm_installed", return_value=True), patch(
+            "kaos_cli.install.run_helm_command", side_effect=fake_helm
+        ), patch("kaos_cli.install._install_keycloak") as mock_kc, patch(
+            "kaos_cli.install._run_kubectl"
+        ) as mock_kubectl:
+            mock_kubectl.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            result = runner.invoke(
+                app,
+                [
+                    "system",
+                    "install",
+                    "--auth-enabled",
+                    "--no-user-auth",
+                    "--chart-path",
+                    "operator/chart",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_kc.assert_not_called()
+        joined = " ".join(captured.get("args", []))
+        assert "security.userAuth" not in joined
+        # Agent-auth wiring is unaffected.
+        assert "security.agentAuth.extAuthzUrl=" in joined
+
+    def test_keycloak_install_applies_realm_and_deployment(self):
+        """--auth-enabled applies the realm ConfigMap and Keycloak dev deployment."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+
+        kubectl_inputs = []
+
+        def fake_kubectl(args, check=True, **kwargs):
+            if "input" in kwargs and kwargs["input"]:
+                kubectl_inputs.append(kwargs["input"])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("kaos_cli.install.check_helm_installed", return_value=True), patch(
+            "kaos_cli.install.run_helm_command",
+            return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
+        ), patch("kaos_cli.install._run_kubectl", side_effect=fake_kubectl):
+            result = runner.invoke(
+                app,
+                [
+                    "system",
+                    "install",
+                    "--auth-enabled",
+                    "--chart-path",
+                    "operator/chart",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        blob = "\n".join(kubectl_inputs)
+        assert "ConfigMap" in blob
+        assert "kaos-realm.json" in blob
+        assert "quay.io/keycloak/keycloak" in blob
+
+    def test_keycloak_chart_path_uses_helm(self):
+        """--keycloak-chart-path installs Keycloak via Helm with the realm ConfigMap."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+
+        helm_calls = []
+
+        def fake_helm(args, check=True, **kwargs):
+            helm_calls.append(args)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("kaos_cli.install.check_helm_installed", return_value=True), patch(
+            "kaos_cli.install.run_helm_command", side_effect=fake_helm
+        ), patch("kaos_cli.install._run_kubectl") as mock_kubectl:
+            mock_kubectl.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            result = runner.invoke(
+                app,
+                [
+                    "system",
+                    "install",
+                    "--auth-enabled",
+                    "--keycloak-chart-path",
+                    "charts/keycloak",
+                    "--chart-path",
+                    "operator/chart",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        joined = " ".join(" ".join(c) for c in helm_calls)
+        assert "charts/keycloak" in joined
+        assert "realmImport.configMapName=keycloak-realm-import" in joined
 
     def test_install_monitoring_enabled_without_value(self):
         """--monitoring-enabled without value defaults to signoz (not an invalid backend error)."""

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -41,6 +41,17 @@ data:
   SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX: {{ .credentialSecretPrefix | quote }}
   {{- end }}
   {{- end }}
+  {{- with .userAuth }}
+  {{- if .issuer }}
+  SECURITY_USER_AUTH_ISSUER: {{ .issuer | quote }}
+  {{- end }}
+  {{- if .audience }}
+  SECURITY_USER_AUTH_AUDIENCE: {{ .audience | quote }}
+  {{- end }}
+  {{- if .jwksUri }}
+  SECURITY_USER_AUTH_JWKS_URI: {{ .jwksUri | quote }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   # Global telemetry configuration (defaults for all components)
   {{- if .Values.telemetry.enabled }}

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -91,7 +91,21 @@ security:
     # AGENT_AUTH_CLIENT_ID/AGENT_AUTH_CLIENT_SECRET environment variables. Empty disables
     # credential mounting. Example: kaos-aib
     credentialSecretPrefix: ""
-
+  # userAuth configures the human user identity provider (e.g. Keycloak) whose
+  # subject tokens are verified at the gateway alongside agent actor tokens. When
+  # issuer is unset, no user jwt provider is generated (agent-only/autonomous
+  # installs); the block is independent of agentAuth.
+  userAuth:
+    # issuer is the user-auth OIDC issuer URL. Example:
+    # http://keycloak.kaos-system.svc.cluster.local:8080/realms/kaos
+    issuer: ""
+    # audience is the expected audience claim for user subject tokens.
+    # Example: kaos
+    audience: ""
+    # jwksUri optionally overrides the user provider's JWKS endpoint. When empty
+    # it is derived from the issuer using the standard OIDC realm path
+    # (<issuer>/protocol/openid-connect/certs).
+    jwksUri: ""
 serviceAccount:
   annotations: {}
   automount: true

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -31,12 +31,30 @@ type Config struct {
 	// Secret provisioned by the sync service (agentAuth.credentialSecretPrefix).
 	// An empty value disables credential mounting into agent pods.
 	CredentialSecretPrefix string
+
+	// UserIssuer is the user-auth OIDC issuer URL (userAuth.issuer): the identity
+	// provider (e.g. Keycloak) that issues human user subject tokens. When set, a
+	// user jwt_authn provider is emitted on protected routes. Empty means no user
+	// provider is generated (agent-only / autonomous installs).
+	UserIssuer string
+
+	// UserAudience is the expected audience claim for user subject tokens
+	// (userAuth.audience). Validated by the user jwt_authn provider when set.
+	UserAudience string
+
+	// UserJWKSURIOverride optionally overrides the user provider's JWKS endpoint
+	// (userAuth.jwksUri). When empty it is derived from UserIssuer using the
+	// standard OIDC realm path.
+	UserJWKSURIOverride string
 }
 
 const (
 	envExtAuthzURL            = "SECURITY_AGENT_AUTH_EXT_AUTHZ_URL"
 	envIssuer                 = "SECURITY_AGENT_AUTH_ISSUER"
 	envCredentialSecretPrefix = "SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX"
+	envUserIssuer             = "SECURITY_USER_AUTH_ISSUER"
+	envUserAudience           = "SECURITY_USER_AUTH_AUDIENCE"
+	envUserJWKSURI            = "SECURITY_USER_AUTH_JWKS_URI"
 )
 
 // GetConfig reads security configuration from environment variables.
@@ -45,6 +63,9 @@ func GetConfig() Config {
 		ExtAuthzURL:            os.Getenv(envExtAuthzURL),
 		Issuer:                 os.Getenv(envIssuer),
 		CredentialSecretPrefix: os.Getenv(envCredentialSecretPrefix),
+		UserIssuer:             os.Getenv(envUserIssuer),
+		UserAudience:           os.Getenv(envUserAudience),
+		UserJWKSURIOverride:    os.Getenv(envUserJWKSURI),
 	}
 }
 
@@ -76,6 +97,41 @@ func (c Config) TokenEndpoint() string {
 		return ""
 	}
 	return issuer + "/oauth2/token"
+}
+
+// JWTEnabled reports whether the operator should emit jwt_authn providers on
+// protected routes. It is true when either the agent issuer or the user issuer
+// is configured. This is independent of IsOperational (which gates ext_authz):
+// the jwt block is only rendered when at least one issuer is known.
+func (c Config) JWTEnabled() bool {
+	return strings.TrimSpace(c.Issuer) != "" || strings.TrimSpace(c.UserIssuer) != ""
+}
+
+// AgentJWKSURI returns the JWKS endpoint for the agent (actor) provider, derived
+// from the agent-auth issuer. The broker publishes its signing keys at
+// "<issuer>/oauth2/jwks.json". It returns an empty string when no issuer is set.
+func (c Config) AgentJWKSURI() string {
+	issuer := strings.TrimRight(strings.TrimSpace(c.Issuer), "/")
+	if issuer == "" {
+		return ""
+	}
+	return issuer + "/oauth2/jwks.json"
+}
+
+// UserJWKSURI returns the JWKS endpoint for the user (subject) provider. An
+// explicit override (userAuth.jwksUri) takes precedence; otherwise it is derived
+// from the user issuer using the standard OIDC realm path
+// "<issuer>/protocol/openid-connect/certs" (Keycloak/OIDC). It returns an empty
+// string when neither an override nor a user issuer is configured.
+func (c Config) UserJWKSURI() string {
+	if override := strings.TrimSpace(c.UserJWKSURIOverride); override != "" {
+		return override
+	}
+	issuer := strings.TrimRight(strings.TrimSpace(c.UserIssuer), "/")
+	if issuer == "" {
+		return ""
+	}
+	return issuer + "/protocol/openid-connect/certs"
 }
 
 // ExtAuthzBackendRef parses the configured ext_authz host:port URL into the

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -97,6 +97,9 @@ func TestGetConfigReadsAllFields(t *testing.T) {
 	t.Setenv(envExtAuthzURL, "aib-ext-authz.aib-system:9002")
 	t.Setenv(envIssuer, "http://aib-enduser.aib-system.svc.cluster.local:8000")
 	t.Setenv(envCredentialSecretPrefix, "kaos-aib")
+	t.Setenv(envUserIssuer, "http://keycloak.kaos-system.svc.cluster.local:8080/realms/kaos")
+	t.Setenv(envUserAudience, "kaos")
+	t.Setenv(envUserJWKSURI, "")
 
 	cfg := GetConfig()
 
@@ -105,6 +108,77 @@ func TestGetConfigReadsAllFields(t *testing.T) {
 	}
 	if cfg.TokenEndpoint() != "http://aib-enduser.aib-system.svc.cluster.local:8000/oauth2/token" {
 		t.Errorf("unexpected token endpoint %q", cfg.TokenEndpoint())
+	}
+	if cfg.UserIssuer != "http://keycloak.kaos-system.svc.cluster.local:8080/realms/kaos" {
+		t.Errorf("unexpected user issuer %q", cfg.UserIssuer)
+	}
+	if cfg.UserAudience != "kaos" {
+		t.Errorf("unexpected user audience %q", cfg.UserAudience)
+	}
+}
+
+func TestJWTEnabled(t *testing.T) {
+	cases := []struct {
+		name       string
+		issuer     string
+		userIssuer string
+		want       bool
+	}{
+		{"neither", "", "", false},
+		{"agent only", "http://aib:8000", "", true},
+		{"user only", "", "http://kc/realms/kaos", true},
+		{"both", "http://aib:8000", "http://kc/realms/kaos", true},
+		{"whitespace only", "  ", "  ", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{Issuer: tc.issuer, UserIssuer: tc.userIssuer}
+			if cfg.JWTEnabled() != tc.want {
+				t.Errorf("JWTEnabled() = %v, want %v", cfg.JWTEnabled(), tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentJWKSURI(t *testing.T) {
+	cases := []struct {
+		name   string
+		issuer string
+		want   string
+	}{
+		{"empty issuer", "", ""},
+		{"issuer without slash", "http://aib:8000", "http://aib:8000/oauth2/jwks.json"},
+		{"issuer with trailing slash", "http://aib:8000/", "http://aib:8000/oauth2/jwks.json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (Config{Issuer: tc.issuer}).AgentJWKSURI(); got != tc.want {
+				t.Errorf("AgentJWKSURI() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUserJWKSURI(t *testing.T) {
+	cases := []struct {
+		name       string
+		userIssuer string
+		override   string
+		want       string
+	}{
+		{"empty", "", "", ""},
+		{"derived from realm issuer", "http://kc/realms/kaos", "", "http://kc/realms/kaos/protocol/openid-connect/certs"},
+		{"derived trims trailing slash", "http://kc/realms/kaos/", "", "http://kc/realms/kaos/protocol/openid-connect/certs"},
+		{"explicit override wins", "http://kc/realms/kaos", "http://kc/custom/jwks", "http://kc/custom/jwks"},
+		{"override without issuer", "", "http://kc/custom/jwks", "http://kc/custom/jwks"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{UserIssuer: tc.userIssuer, UserJWKSURIOverride: tc.override}
+			if got := cfg.UserJWKSURI(); got != tc.want {
+				t.Errorf("UserJWKSURI() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/operator/pkg/security/securitypolicy.go
+++ b/operator/pkg/security/securitypolicy.go
@@ -3,6 +3,7 @@ package security
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -91,7 +92,65 @@ func constructSecurityPolicy(params PolicyParams, cfg Config) (*unstructured.Uns
 		},
 	}, "spec", "extAuth")
 
+	if cfg.JWTEnabled() {
+		if providers := constructJWTProviders(cfg); len(providers) > 0 {
+			_ = unstructured.SetNestedSlice(policy.Object, providers, "spec", "jwt", "providers")
+		}
+	}
+
 	return policy, nil
+}
+
+// constructJWTProviders builds the Envoy Gateway SecurityPolicy spec.jwt.providers
+// list. The agent (actor) provider verifies the broker-issued token carried on the
+// x-agent-authorization header and is emitted whenever an agent issuer is set. The
+// user (subject) provider verifies the human token on the standard Authorization
+// header and is emitted only when a user issuer is configured; autonomous, actor-only
+// requests carry no user token, so the user provider must tolerate its absence. Each
+// provider maps identity claims to trusted headers for downstream ext_authz and audit.
+func constructJWTProviders(cfg Config) []interface{} {
+	providers := make([]interface{}, 0, 2)
+
+	if agentJWKS := cfg.AgentJWKSURI(); agentJWKS != "" {
+		providers = append(providers, map[string]interface{}{
+			"name":   "agent",
+			"issuer": strings.TrimSpace(cfg.Issuer),
+			"remoteJWKS": map[string]interface{}{
+				"uri": agentJWKS,
+			},
+			"extractFrom": map[string]interface{}{
+				"headers": []interface{}{
+					map[string]interface{}{
+						"name":        "x-agent-authorization",
+						"valuePrefix": "Bearer ",
+					},
+				},
+			},
+			"claimToHeaders": []interface{}{
+				map[string]interface{}{"claim": "sub", "header": "x-agent-claim-sub"},
+			},
+		})
+	}
+
+	if userJWKS := cfg.UserJWKSURI(); userJWKS != "" {
+		userProvider := map[string]interface{}{
+			"name":   "user",
+			"issuer": strings.TrimSpace(cfg.UserIssuer),
+			"remoteJWKS": map[string]interface{}{
+				"uri": userJWKS,
+			},
+			"claimToHeaders": []interface{}{
+				map[string]interface{}{"claim": "sub", "header": "x-user-claim-sub"},
+				map[string]interface{}{"claim": "preferred_username", "header": "x-user-claim-username"},
+			},
+		}
+		if audience := strings.TrimSpace(cfg.UserAudience); audience != "" {
+			userProvider["audiences"] = []interface{}{audience}
+		}
+		providers = append(providers, userProvider)
+	}
+
+	return providers
 }
 
 // ReconcileSecurityPolicy creates or updates the SecurityPolicy that guards a

--- a/operator/pkg/security/securitypolicy_test.go
+++ b/operator/pkg/security/securitypolicy_test.go
@@ -83,3 +83,133 @@ func TestConstructSecurityPolicyInvalidConfig(t *testing.T) {
 		t.Errorf("expected error for malformed ext_authz URL")
 	}
 }
+
+func bothIssuersConfig() Config {
+	cfg := operationalConfig()
+	cfg.Issuer = "http://aib-enduser.kaos-system.svc.cluster.local:8000"
+	cfg.UserIssuer = "http://keycloak.kaos-system.svc.cluster.local:8080/realms/kaos"
+	cfg.UserAudience = "kaos"
+	return cfg
+}
+
+func jwtProviders(t *testing.T, policy *unstructured.Unstructured) []interface{} {
+	t.Helper()
+	providers, found, err := unstructured.NestedSlice(policy.Object, "spec", "jwt", "providers")
+	if err != nil {
+		t.Fatalf("error reading jwt providers: %v", err)
+	}
+	if !found {
+		return nil
+	}
+	return providers
+}
+
+func providerByName(providers []interface{}, name string) map[string]interface{} {
+	for _, p := range providers {
+		m, ok := p.(map[string]interface{})
+		if ok && m["name"] == name {
+			return m
+		}
+	}
+	return nil
+}
+
+func TestConstructSecurityPolicyEmitsBothJWTProviders(t *testing.T) {
+	policy, err := constructSecurityPolicy(PolicyParams{Name: "a", Namespace: "ns", RouteName: "a"}, bothIssuersConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// extAuth must remain unchanged alongside the jwt block.
+	failOpen, found, _ := unstructured.NestedBool(policy.Object, "spec", "extAuth", "failOpen")
+	if !found || failOpen {
+		t.Errorf("expected extAuth.failOpen=false to be preserved")
+	}
+
+	providers := jwtProviders(t, policy)
+	if len(providers) != 2 {
+		t.Fatalf("expected 2 jwt providers, got %d", len(providers))
+	}
+
+	agent := providerByName(providers, "agent")
+	if agent == nil {
+		t.Fatalf("expected an agent provider")
+	}
+	if agent["issuer"] != "http://aib-enduser.kaos-system.svc.cluster.local:8000" {
+		t.Errorf("unexpected agent issuer %#v", agent["issuer"])
+	}
+	agentJWKS, _, _ := unstructured.NestedString(agent, "remoteJWKS", "uri")
+	if agentJWKS != "http://aib-enduser.kaos-system.svc.cluster.local:8000/oauth2/jwks.json" {
+		t.Errorf("unexpected agent jwks %q", agentJWKS)
+	}
+	agentHeaders, _, _ := unstructured.NestedSlice(agent, "extractFrom", "headers")
+	if len(agentHeaders) != 1 {
+		t.Fatalf("expected agent to extract from one header, got %d", len(agentHeaders))
+	}
+	h := agentHeaders[0].(map[string]interface{})
+	if h["name"] != "x-agent-authorization" || h["valuePrefix"] != "Bearer " {
+		t.Errorf("unexpected agent extractFrom header %#v", h)
+	}
+	if _, hasAud := agent["audiences"]; hasAud {
+		t.Errorf("agent provider should not set audiences")
+	}
+
+	user := providerByName(providers, "user")
+	if user == nil {
+		t.Fatalf("expected a user provider")
+	}
+	if user["issuer"] != "http://keycloak.kaos-system.svc.cluster.local:8080/realms/kaos" {
+		t.Errorf("unexpected user issuer %#v", user["issuer"])
+	}
+	userJWKS, _, _ := unstructured.NestedString(user, "remoteJWKS", "uri")
+	if userJWKS != "http://keycloak.kaos-system.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/certs" {
+		t.Errorf("unexpected user jwks %q", userJWKS)
+	}
+	userAud, _, _ := unstructured.NestedStringSlice(user, "audiences")
+	if len(userAud) != 1 || userAud[0] != "kaos" {
+		t.Errorf("unexpected user audiences %#v", userAud)
+	}
+	if _, hasExtract := user["extractFrom"]; hasExtract {
+		t.Errorf("user provider should use default Authorization extraction, got explicit extractFrom")
+	}
+	userClaims, _, _ := unstructured.NestedSlice(user, "claimToHeaders")
+	if len(userClaims) != 2 {
+		t.Errorf("expected two user claimToHeaders, got %d", len(userClaims))
+	}
+}
+
+func TestConstructSecurityPolicyAgentOnlyWhenNoUserIssuer(t *testing.T) {
+	cfg := operationalConfig()
+	cfg.Issuer = "http://aib:8000"
+
+	policy, err := constructSecurityPolicy(PolicyParams{Name: "a", Namespace: "ns", RouteName: "a"}, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	providers := jwtProviders(t, policy)
+	if len(providers) != 1 {
+		t.Fatalf("expected only the agent provider, got %d", len(providers))
+	}
+	if providerByName(providers, "agent") == nil {
+		t.Errorf("expected the agent provider to be present")
+	}
+	if providerByName(providers, "user") != nil {
+		t.Errorf("did not expect a user provider without a user issuer")
+	}
+}
+
+func TestConstructSecurityPolicyNoJWTBlockWhenDisabled(t *testing.T) {
+	// Operational (ext_authz) but no issuers configured: no jwt block at all.
+	policy, err := constructSecurityPolicy(PolicyParams{Name: "a", Namespace: "ns", RouteName: "a"}, operationalConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, found, _ := unstructured.NestedMap(policy.Object, "spec", "jwt"); found {
+		t.Errorf("expected no spec.jwt block when no issuers are configured")
+	}
+	// extAuth must still be present.
+	if _, found, _ := unstructured.NestedMap(policy.Object, "spec", "extAuth"); !found {
+		t.Errorf("expected extAuth to be present")
+	}
+}


### PR DESCRIPTION
Adds the human-identity half of the two-identity model. The operator now generates Envoy jwt_authn providers (agent required, user optional) on protected SecurityPolicies ahead of ext_authz, and the CLI installs a Keycloak user identity provider with a non-interactive realm bootstrap and wires security.userAuth into the operator.

## What changed
- **Operator config**: `SECURITY_USER_AUTH_ISSUER/_AUDIENCE/_JWKS_URI`, `JWTEnabled()`, agent/user JWKS resolution (explicit override else derived). `IsOperational()` unchanged.
- **SecurityPolicy**: emits `spec.jwt.providers` when JWT is enabled — agent provider (x-agent-authorization, Bearer), optional user provider (Authorization, audiences) — alongside the unchanged extAuth block.
- **Operator chart**: `security.userAuth` values + `SECURITY_USER_AUTH_*` configmap rendering (only-when-set).
- **CLI**: `--auth-enabled` now also installs Keycloak (self-contained dev deployment or Helm via `--keycloak-chart-path`), bootstraps a realm/client/test-user, and wires userAuth. New flags `--user-auth/--no-user-auth`, `--keycloak-namespace`, `--keycloak-chart-path`, `--user-auth-issuer`, `--user-auth-audience`.

## Validation
- Operator: `go test ./pkg/security/...`, vet/gofmt clean, no manifest drift.
- Chart: `helm template`/`helm lint`.
- CLI: 79 tests green.
- Live on KIND (Envoy Gateway v1.4.6): Keycloak installed + realm imported, real user token minted in-cluster, two-provider SecurityPolicy drove the optionality matrix and claim-header sanitization checks through the gateway.

Default-off contract holds: with no issuers configured no jwt block renders and installs are unchanged. Stacked on `feat/sync-service-reconciliation` (P5).