### PR TITLE
PR-ADR-KAOS-6: Gateway ext_proc token exchange

### DIFF
--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -30,6 +30,10 @@ DEFAULT_CREDENTIAL_SECRET_PREFIX = "kaos-aib"
 AUTH_EXT_AUTHZ_PORT = 9191
 AUTH_ENDUSER_PORT = 8000
 AUTH_ADMIN_PORT = 14000
+AUTH_EXT_PROC_PORT = 50051
+AUTH_EXT_PROC_CLIENT_ID = "extproc-gateway"
+AUTH_EXT_PROC_CLIENT_SECRET = "extproc-gateway-secret"
+DEFAULT_THIRD_PARTY_SERVICE_ID = "dummy-third-party"
 DEFAULT_SYNC_RELEASE = "kaos-sync"
 
 # User-auth (human identity provider, Keycloak by default) defaults
@@ -540,6 +544,16 @@ def _default_ext_authz_url(auth_namespace: str) -> str:
     return f"aib-access-check-grpc.{auth_namespace}.svc.cluster.local:{AUTH_EXT_AUTHZ_PORT}"
 
 
+def _default_ext_proc_url(auth_namespace: str, auth_release: str) -> str:
+    """Default host:port of the broker ExtProc token-exchange gRPC backend.
+
+    Matches the Service rendered by the broker chart's optional ExtProc
+    component (``<release>-agentic-identity-broker-extproc``).
+    """
+    host = f"{_auth_broker_fullname(auth_release)}-extproc.{auth_namespace}.svc.cluster.local"
+    return f"{host}:{AUTH_EXT_PROC_PORT}"
+
+
 def _default_auth_issuer(auth_namespace: str, auth_release: str) -> str:
     """Default issuer (broker enduser endpoint) propagated to agent pods."""
     host = f"{_auth_broker_fullname(auth_release)}.{auth_namespace}.svc.cluster.local"
@@ -565,13 +579,15 @@ def _build_auth_operator_args(
     user_issuer: str = "",
     user_audience: str = "",
     user_jwks_uri: str = "",
+    ext_proc_url: str = "",
 ) -> list[str]:
     """Build the operator Helm --set arguments that enable agent-auth wiring.
 
     Returns the flat ``--set key=value`` argument list so it can be unit-tested
     independently of running Helm. User-auth (``security.userAuth.*``) arguments
     are appended only when a user issuer is supplied, keeping agent-only and
-    autonomous-only installs unchanged.
+    autonomous-only installs unchanged. The token-exchange ext_proc backend
+    (``security.agentAuth.extProcUrl``) is appended only when supplied.
     """
     args: list[str] = []
     args.extend(["--set", f"security.agentAuth.extAuthzUrl={ext_authz_url}"])
@@ -582,6 +598,8 @@ def _build_auth_operator_args(
             f"security.agentAuth.credentialSecretPrefix={credential_secret_prefix}",
         ]
     )
+    if ext_proc_url:
+        args.extend(["--set", f"security.agentAuth.extProcUrl={ext_proc_url}"])
     if user_issuer:
         args.extend(["--set", f"security.userAuth.issuer={user_issuer}"])
     if user_audience:
@@ -635,6 +653,7 @@ def _install_aib(
     chart_path: str,
     values_path: str | None,
     wait: bool,
+    extra_set: list[str] | None = None,
 ) -> bool:
     """Install the identity broker from a local chart (unpublished/dev path)."""
     typer.echo("Installing identity broker...")
@@ -649,6 +668,8 @@ def _install_aib(
     ]
     if values_path:
         helm_args.extend(["--values", values_path])
+    if extra_set:
+        helm_args.extend(extra_set)
     if wait:
         helm_args.append("--wait")
 
@@ -659,6 +680,97 @@ def _install_aib(
 
     typer.echo(f"✅ Identity broker installed in '{namespace}' namespace")
     return True
+
+
+def _build_aib_extproc_args(
+    ext_proc_client_id: str,
+    ext_proc_client_secret: str,
+    client_assertion_type: str = "access_token",
+) -> list[str]:
+    """Build the broker-chart Helm --set args enabling the ExtProc component.
+
+    Returns the flat ``--set key=value`` list so it can be unit-tested without
+    running Helm. The OAuth2 token endpoint and issuer are left to the chart
+    defaults (the in-cluster broker enduser service).
+    """
+    return [
+        "--set",
+        "extProc.enabled=true",
+        "--set",
+        f"extProc.oauth2.clientId={ext_proc_client_id}",
+        "--set",
+        f"extProc.oauth2.clientSecret={ext_proc_client_secret}",
+        "--set",
+        f"extProc.oauth2.clientAssertionType={client_assertion_type}",
+    ]
+
+
+def _provision_token_exchange(
+    admin_url: str,
+    ext_proc_client_id: str,
+    third_party_service_id: str,
+    third_party_issuer: str,
+) -> bool:
+    """Register the ExtProc OAuth client and a dummy third-party service.
+
+    Best-effort, dev/validation-only provisioning against the broker admin API so
+    that the token-exchange path has an OAuth client to assert as and a
+    third-party service to exchange for. Failures are non-fatal: the install
+    continues and the validation surface can register the grant interactively.
+    """
+    import json
+    import urllib.error
+    import urllib.request
+
+    def _post(path: str, payload: dict) -> bool:
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            f"{admin_url.rstrip('/')}{path}",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            urllib.request.urlopen(req, timeout=10)  # noqa: S310 (in-cluster URL)
+            return True
+        except urllib.error.HTTPError as exc:
+            # 409/422 (already exists) is acceptable for idempotent provisioning.
+            if exc.code in (409, 422):
+                return True
+            typer.echo(
+                f"Warning: token-exchange provisioning {path} -> HTTP {exc.code}",
+                err=True,
+            )
+            return False
+        except urllib.error.URLError as exc:
+            typer.echo(
+                f"Warning: token-exchange provisioning {path} unreachable: {exc}",
+                err=True,
+            )
+            return False
+
+    ok = _post(
+        "/agents",
+        {
+            "client_id": ext_proc_client_id,
+            "display_name": "ExtProc Gateway",
+            "description": "Gateway token-exchange client (auto-provisioned)",
+        },
+    )
+    ok = (
+        _post(
+            "/services",
+            {
+                "display_name": "Dummy Third Party",
+                "client_id": "dummy-third-party",
+                "client_secret": "dummy-third-party-secret",
+                "issuer_uri": third_party_issuer,
+                "service_id": third_party_service_id,
+            },
+        )
+        and ok
+    )
+    return ok
 
 
 def _keycloak_realm_json(
@@ -963,6 +1075,8 @@ def install_command(
     ext_authz_url: str | None = None,
     auth_issuer: str | None = None,
     credential_secret_prefix: str = DEFAULT_CREDENTIAL_SECRET_PREFIX,
+    token_exchange: bool = True,
+    ext_proc_url: str | None = None,
     aib_chart_path: str | None = None,
     aib_values_path: str | None = None,
     sync_chart_path: str | None = None,
@@ -1007,20 +1121,44 @@ def install_command(
         ext_authz_url = ext_authz_url or _default_ext_authz_url(auth_namespace)
         auth_issuer = auth_issuer or _default_auth_issuer(auth_namespace, auth_release)
         auth_admin_url = _default_auth_admin_url(auth_namespace, auth_release)
+        if token_exchange:
+            ext_proc_url = ext_proc_url or _default_ext_proc_url(
+                auth_namespace, auth_release
+            )
         if user_auth:
             user_auth_issuer = user_auth_issuer or _default_user_auth_issuer(
                 keycloak_namespace, keycloak_release
             )
 
         # Install the identity broker from a local chart when provided (it is
-        # unpublished, so a chart path is required to install it here).
+        # unpublished, so a chart path is required to install it here). The
+        # ExtProc token-exchange component is enabled when token exchange is on.
         if aib_chart_path:
+            aib_extra_set = (
+                _build_aib_extproc_args(
+                    AUTH_EXT_PROC_CLIENT_ID, AUTH_EXT_PROC_CLIENT_SECRET
+                )
+                if token_exchange
+                else None
+            )
             if not _install_aib(
-                auth_namespace, auth_release, aib_chart_path, aib_values_path, wait
+                auth_namespace,
+                auth_release,
+                aib_chart_path,
+                aib_values_path,
+                wait,
+                extra_set=aib_extra_set,
             ):
                 typer.echo(
                     "Warning: identity broker installation failed, continuing...",
                     err=True,
+                )
+            elif token_exchange:
+                _provision_token_exchange(
+                    auth_admin_url,
+                    AUTH_EXT_PROC_CLIENT_ID,
+                    DEFAULT_THIRD_PARTY_SERVICE_ID,
+                    auth_issuer,
                 )
         else:
             typer.echo(
@@ -1179,6 +1317,11 @@ def install_command(
                 credential_secret_prefix,
                 user_issuer=resolved_user_issuer,
                 user_audience=user_auth_audience if user_auth else "",
+                ext_proc_url=(
+                    ext_proc_url or _default_ext_proc_url(auth_namespace, auth_release)
+                    if token_exchange
+                    else ""
+                ),
             )
         )
 

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -115,6 +115,19 @@ def install(
         help="Override the broker issuer URL propagated to agent pods. Defaults to the "
         "broker enduser service in the auth namespace.",
     ),
+    token_exchange: bool = typer.Option(
+        True,
+        "--token-exchange/--no-token-exchange",
+        help="Enable the RFC 8693 token-exchange path: deploy the broker ExtProc "
+        "component and wire the gateway ext_proc backend. Effective only with "
+        "--auth-enabled.",
+    ),
+    ext_proc_url: str | None = typer.Option(
+        None,
+        "--ext-proc-url",
+        help="Override the token-exchange ext_proc gRPC backend host:port. Defaults "
+        "to the broker ExtProc service in the auth namespace.",
+    ),
     aib_chart_path: str | None = typer.Option(
         None,
         "--aib-chart-path",
@@ -192,6 +205,8 @@ def install(
         auth_namespace=auth_namespace,
         ext_authz_url=ext_authz_url,
         auth_issuer=auth_issuer,
+        token_exchange=token_exchange,
+        ext_proc_url=ext_proc_url,
         aib_chart_path=aib_chart_path,
         aib_values_path=aib_values_path,
         sync_chart_path=sync_chart_path,

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -997,6 +997,48 @@ class TestAuthWiring:
         joined = " ".join(args)
         assert "security.userAuth" not in joined
 
+    def test_build_auth_operator_args_includes_ext_proc_url(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            ext_proc_url="aib-agentic-identity-broker-extproc.aib-system:50051",
+        )
+        joined = " ".join(args)
+        assert (
+            "security.agentAuth.extProcUrl="
+            "aib-agentic-identity-broker-extproc.aib-system:50051" in joined
+        )
+
+    def test_build_auth_operator_args_omits_ext_proc_url_when_unset(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+        )
+        assert "security.agentAuth.extProcUrl=" not in " ".join(args)
+
+    def test_default_ext_proc_url(self):
+        from kaos_cli.install import _default_ext_proc_url
+
+        url = _default_ext_proc_url("custom-ns", "aib")
+        assert url == (
+            "aib-agentic-identity-broker-extproc.custom-ns.svc.cluster.local:50051"
+        )
+
+    def test_build_aib_extproc_args(self):
+        from kaos_cli.install import _build_aib_extproc_args
+
+        args = _build_aib_extproc_args("extproc-gateway", "secret")
+        joined = " ".join(args)
+        assert "extProc.enabled=true" in joined
+        assert "extProc.oauth2.clientId=extproc-gateway" in joined
+        assert "extProc.oauth2.clientSecret=secret" in joined
+
     def test_default_user_auth_issuer(self):
         from kaos_cli.install import _default_user_auth_issuer
 

--- a/operator/chart/templates/kaos-operator-rbac.yaml
+++ b/operator/chart/templates/kaos-operator-rbac.yaml
@@ -64,6 +64,7 @@ rules:
 - apiGroups:
   - gateway.envoyproxy.io
   resources:
+  - envoyextensionpolicies
   - securitypolicies
   verbs:
   - create

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -34,6 +34,9 @@ data:
   {{- if .extAuthzUrl }}
   SECURITY_AGENT_AUTH_EXT_AUTHZ_URL: {{ .extAuthzUrl | quote }}
   {{- end }}
+  {{- if .extProcUrl }}
+  SECURITY_AGENT_AUTH_EXT_PROC_URL: {{ .extProcUrl | quote }}
+  {{- end }}
   {{- if .issuer }}
   SECURITY_AGENT_AUTH_ISSUER: {{ .issuer | quote }}
   {{- end }}

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -81,6 +81,13 @@ security:
     # backend (AIB by default; OPA is a drop-in via the standard contract).
     # Example: aib-ext-authz.aib-system.svc.cluster.local:9002
     extAuthzUrl: ""
+    # extProcUrl is the host:port of the Envoy ext_proc token-exchange gRPC
+    # backend (AIB ExtProc by default). When set, the operator generates an
+    # EnvoyExtensionPolicy on protected routes so the backend can exchange the
+    # inbound user subject token for a delegated upstream token. Leaving it empty
+    # disables token exchange and leaves routing behavior unchanged.
+    # Example: aib-ext-proc.aib-system.svc.cluster.local:50051
+    extProcUrl: ""
     # issuer is the agent-auth OIDC issuer (the broker that mints agent actor
     # tokens). It is propagated to agent pods, which derive the token endpoint
     # from it. Example: http://aib-enduser.aib-system.svc.cluster.local:8000

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -51,6 +51,7 @@ rules:
 - apiGroups:
   - gateway.envoyproxy.io
   resources:
+  - envoyextensionpolicies
   - securitypolicies
   verbs:
   - create

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -324,15 +324,19 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			log.Error(err, "failed to reconcile HTTPRoute")
 		}
 
-		if secCfg := security.GetConfig(); secCfg.IsOperational() {
+		if secCfg := security.GetConfig(); secCfg.IsOperational() || secCfg.ExtProcEnabled() {
 			routeName := gateway.HTTPRouteName(gateway.ResourceTypeAgent, agent.Name)
-			if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, agent, security.PolicyParams{
+			policyParams := security.PolicyParams{
 				Name:      routeName,
 				Namespace: agent.Namespace,
 				RouteName: routeName,
 				Labels:    map[string]string{"app": "agent", "agent": agent.Name},
-			}, secCfg, log); err != nil {
+			}
+			if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, agent, policyParams, secCfg, log); err != nil {
 				log.Error(err, "failed to reconcile SecurityPolicy")
+			}
+			if err := security.ReconcileEnvoyExtensionPolicy(ctx, r.Client, r.Scheme, agent, policyParams, secCfg, log); err != nil {
+				log.Error(err, "failed to reconcile EnvoyExtensionPolicy")
 			}
 		}
 	}

--- a/operator/controllers/mcpserver_controller.go
+++ b/operator/controllers/mcpserver_controller.go
@@ -217,15 +217,19 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.Error(err, "failed to reconcile HTTPRoute")
 	}
 
-	if secCfg := security.GetConfig(); secCfg.IsOperational() {
+	if secCfg := security.GetConfig(); secCfg.IsOperational() || secCfg.ExtProcEnabled() {
 		routeName := gateway.HTTPRouteName(gateway.ResourceTypeMCP, mcpserver.Name)
-		if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, mcpserver, security.PolicyParams{
+		policyParams := security.PolicyParams{
 			Name:      routeName,
 			Namespace: mcpserver.Namespace,
 			RouteName: routeName,
 			Labels:    map[string]string{"app": "mcpserver", "mcpserver": mcpserver.Name},
-		}, secCfg, log); err != nil {
+		}
+		if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, mcpserver, policyParams, secCfg, log); err != nil {
 			log.Error(err, "failed to reconcile SecurityPolicy")
+		}
+		if err := security.ReconcileEnvoyExtensionPolicy(ctx, r.Client, r.Scheme, mcpserver, policyParams, secCfg, log); err != nil {
+			log.Error(err, "failed to reconcile EnvoyExtensionPolicy")
 		}
 	}
 

--- a/operator/controllers/modelapi_controller.go
+++ b/operator/controllers/modelapi_controller.go
@@ -291,15 +291,19 @@ func (r *ModelAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.Error(err, "failed to reconcile HTTPRoute")
 	}
 
-	if secCfg := security.GetConfig(); secCfg.IsOperational() {
+	if secCfg := security.GetConfig(); secCfg.IsOperational() || secCfg.ExtProcEnabled() {
 		routeName := gateway.HTTPRouteName(gateway.ResourceTypeModelAPI, modelapi.Name)
-		if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, modelapi, security.PolicyParams{
+		policyParams := security.PolicyParams{
 			Name:      routeName,
 			Namespace: modelapi.Namespace,
 			RouteName: routeName,
 			Labels:    map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
-		}, secCfg, log); err != nil {
+		}
+		if err := security.ReconcileSecurityPolicy(ctx, r.Client, r.Scheme, modelapi, policyParams, secCfg, log); err != nil {
 			log.Error(err, "failed to reconcile SecurityPolicy")
+		}
+		if err := security.ReconcileEnvoyExtensionPolicy(ctx, r.Client, r.Scheme, modelapi, policyParams, secCfg, log); err != nil {
+			log.Error(err, "failed to reconcile EnvoyExtensionPolicy")
 		}
 	}
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -31,6 +31,7 @@ var (
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=securitypolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=envoyextensionpolicies,verbs=get;list;watch;create;update;patch;delete
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -46,10 +46,19 @@ type Config struct {
 	// (userAuth.jwksUri). When empty it is derived from UserIssuer using the
 	// standard OIDC realm path.
 	UserJWKSURIOverride string
+
+	// ExtProcURL is the host:port of the AIB external-processing (ext_proc)
+	// token-exchange gRPC backend (agentAuth.extProcUrl). When set, the operator
+	// emits an EnvoyExtensionPolicy on protected routes so the gateway can perform
+	// an RFC 8693 token exchange and replace the upstream Authorization header.
+	// An empty value means token-exchange is disabled and existing routing is
+	// unchanged. It is independent of ExtAuthzURL.
+	ExtProcURL string
 }
 
 const (
 	envExtAuthzURL            = "SECURITY_AGENT_AUTH_EXT_AUTHZ_URL"
+	envExtProcURL             = "SECURITY_AGENT_AUTH_EXT_PROC_URL"
 	envIssuer                 = "SECURITY_AGENT_AUTH_ISSUER"
 	envCredentialSecretPrefix = "SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX"
 	envUserIssuer             = "SECURITY_USER_AUTH_ISSUER"
@@ -66,6 +75,7 @@ func GetConfig() Config {
 		UserIssuer:             os.Getenv(envUserIssuer),
 		UserAudience:           os.Getenv(envUserAudience),
 		UserJWKSURIOverride:    os.Getenv(envUserJWKSURI),
+		ExtProcURL:             os.Getenv(envExtProcURL),
 	}
 }
 
@@ -134,23 +144,48 @@ func (c Config) UserJWKSURI() string {
 	return issuer + "/protocol/openid-connect/certs"
 }
 
+// ExtProcEnabled reports whether the operator should emit an EnvoyExtensionPolicy
+// (ext_proc token exchange) on protected routes. It is true when ExtProcURL is
+// configured. This is independent of IsOperational (which gates ext_authz): a
+// deployment may enable token exchange without changing the ext_authz wiring.
+func (c Config) ExtProcEnabled() bool {
+	return strings.TrimSpace(c.ExtProcURL) != ""
+}
+
 // ExtAuthzBackendRef parses the configured ext_authz host:port URL into the
 // Kubernetes Service name, namespace, and port used to build the SecurityPolicy
 // gRPC backendRef. The host is expected as a Service DNS name in the form
 // "name[.namespace[.svc.cluster.local]]"; the namespace is empty when not present.
 func (c Config) ExtAuthzBackendRef() (name, namespace string, port int, err error) {
-	url := strings.TrimSpace(c.ExtAuthzURL)
+	return parseServiceHostPort(c.ExtAuthzURL, "ext_authz")
+}
+
+// ExtProcBackendRef parses the configured ext_proc host:port URL into the
+// Kubernetes Service name, namespace, and port used to build the
+// EnvoyExtensionPolicy gRPC backendRef. The host is expected as a Service DNS
+// name in the form "name[.namespace[.svc.cluster.local]]"; the namespace is empty
+// when not present.
+func (c Config) ExtProcBackendRef() (name, namespace string, port int, err error) {
+	return parseServiceHostPort(c.ExtProcURL, "ext_proc")
+}
+
+// parseServiceHostPort parses a "host:port" Service DNS URL into name, namespace,
+// and port. The label argument names the field in error messages. The host is
+// expected as "name[.namespace[.svc.cluster.local]]"; namespace is empty when the
+// host is a bare service name.
+func parseServiceHostPort(rawURL, label string) (name, namespace string, port int, err error) {
+	url := strings.TrimSpace(rawURL)
 	if url == "" {
-		return "", "", 0, fmt.Errorf("ext_authz URL is empty")
+		return "", "", 0, fmt.Errorf("%s URL is empty", label)
 	}
 
 	host, portStr, found := strings.Cut(url, ":")
 	if !found || host == "" || portStr == "" {
-		return "", "", 0, fmt.Errorf("ext_authz URL %q must be in host:port form", url)
+		return "", "", 0, fmt.Errorf("%s URL %q must be in host:port form", label, url)
 	}
 	port, err = strconv.Atoi(portStr)
 	if err != nil || port <= 0 {
-		return "", "", 0, fmt.Errorf("ext_authz URL %q has an invalid port", url)
+		return "", "", 0, fmt.Errorf("%s URL %q has an invalid port", label, url)
 	}
 
 	labels := strings.Split(host, ".")
@@ -159,7 +194,7 @@ func (c Config) ExtAuthzBackendRef() (name, namespace string, port int, err erro
 		namespace = labels[1]
 	}
 	if name == "" {
-		return "", "", 0, fmt.Errorf("ext_authz URL %q has an empty service name", url)
+		return "", "", 0, fmt.Errorf("%s URL %q has an empty service name", label, url)
 	}
 	return name, namespace, port, nil
 }

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -100,6 +100,7 @@ func TestGetConfigReadsAllFields(t *testing.T) {
 	t.Setenv(envUserIssuer, "http://keycloak.kaos-system.svc.cluster.local:8080/realms/kaos")
 	t.Setenv(envUserAudience, "kaos")
 	t.Setenv(envUserJWKSURI, "")
+	t.Setenv(envExtProcURL, "aib-extproc.aib-system.svc.cluster.local:50051")
 
 	cfg := GetConfig()
 
@@ -114,6 +115,31 @@ func TestGetConfigReadsAllFields(t *testing.T) {
 	}
 	if cfg.UserAudience != "kaos" {
 		t.Errorf("unexpected user audience %q", cfg.UserAudience)
+	}
+	if !cfg.ExtProcEnabled() {
+		t.Errorf("expected ext_proc enabled")
+	}
+	if cfg.ExtProcURL != "aib-extproc.aib-system.svc.cluster.local:50051" {
+		t.Errorf("unexpected ext_proc URL %q", cfg.ExtProcURL)
+	}
+}
+
+func TestExtProcEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"empty", "", false},
+		{"whitespace only", "   ", false},
+		{"set", "aib-extproc.aib-system:50051", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (Config{ExtProcURL: tc.url}).ExtProcEnabled(); got != tc.want {
+				t.Errorf("ExtProcEnabled() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -202,6 +228,42 @@ func TestExtAuthzBackendRef(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			name, ns, port, err := (Config{ExtAuthzURL: tc.url}).ExtAuthzBackendRef()
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.url)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if name != tc.wantName || ns != tc.wantNS || port != tc.wantPort {
+				t.Errorf("got (%q,%q,%d), want (%q,%q,%d)", name, ns, port, tc.wantName, tc.wantNS, tc.wantPort)
+			}
+		})
+	}
+}
+
+func TestExtProcBackendRef(t *testing.T) {
+	cases := []struct {
+		name      string
+		url       string
+		wantName  string
+		wantNS    string
+		wantPort  int
+		wantError bool
+	}{
+		{"fqdn", "aib-extproc.aib-system.svc.cluster.local:50051", "aib-extproc", "aib-system", 50051, false},
+		{"name and namespace", "aib-extproc.aib-system:50051", "aib-extproc", "aib-system", 50051, false},
+		{"name only", "aib-extproc:50051", "aib-extproc", "", 50051, false},
+		{"missing port", "aib-extproc.aib-system", "", "", 0, true},
+		{"empty", "", "", "", 0, true},
+		{"invalid port", "aib-extproc.aib-system:nope", "", "", 0, true},
+		{"zero port", "aib-extproc.aib-system:0", "", "", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name, ns, port, err := (Config{ExtProcURL: tc.url}).ExtProcBackendRef()
 			if tc.wantError {
 				if err == nil {
 					t.Fatalf("expected error for %q", tc.url)

--- a/operator/pkg/security/envoyextensionpolicy.go
+++ b/operator/pkg/security/envoyextensionpolicy.go
@@ -1,0 +1,122 @@
+package security
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Envoy Gateway EnvoyExtensionPolicy group/version/kind used to attach an
+// external-processing (ext_proc) token-exchange filter to a route. The group
+// and version match the SecurityPolicy CRD (gateway.envoyproxy.io/v1alpha1);
+// the verified field shape is from Envoy Gateway v1.4.6.
+const envoyExtensionPolicyKind = "EnvoyExtensionPolicy"
+
+// EnvoyExtensionPolicyGVK is the GroupVersionKind of the generated
+// EnvoyExtensionPolicy.
+var EnvoyExtensionPolicyGVK = schema.GroupVersionKind{
+	Group:   securityPolicyGroup,
+	Version: securityPolicyVersion,
+	Kind:    envoyExtensionPolicyKind,
+}
+
+// constructEnvoyExtensionPolicy builds an Envoy Gateway EnvoyExtensionPolicy (as
+// an unstructured object) that attaches the AIB ext_proc token-exchange service
+// to the target HTTPRoute. The filter runs after ext_authz in the gateway
+// pipeline; it inspects request headers and, when a delegated third-party token
+// is needed, replaces the upstream Authorization header with an exchanged token.
+// Only request headers are sent to the processor (no body), which is sufficient
+// for the header-based RFC 8693 exchange. It returns an error if the configured
+// ext_proc URL cannot be resolved to a Service backend reference.
+func constructEnvoyExtensionPolicy(params PolicyParams, cfg Config) (*unstructured.Unstructured, error) {
+	name, namespace, port, err := cfg.ExtProcBackendRef()
+	if err != nil {
+		return nil, err
+	}
+
+	policy := &unstructured.Unstructured{}
+	policy.SetGroupVersionKind(EnvoyExtensionPolicyGVK)
+	policy.SetName(params.Name)
+	policy.SetNamespace(params.Namespace)
+	if len(params.Labels) > 0 {
+		policy.SetLabels(params.Labels)
+	}
+
+	_ = unstructured.SetNestedSlice(policy.Object, []interface{}{
+		map[string]interface{}{
+			"group": httpRouteGroup,
+			"kind":  httpRouteKind,
+			"name":  params.RouteName,
+		},
+	}, "spec", "targetRefs")
+
+	backendRef := map[string]interface{}{
+		"group": "",
+		"kind":  "Service",
+		"name":  name,
+		"port":  int64(port),
+	}
+	if namespace != "" {
+		backendRef["namespace"] = namespace
+	}
+
+	_ = unstructured.SetNestedSlice(policy.Object, []interface{}{
+		map[string]interface{}{
+			"backendRefs": []interface{}{backendRef},
+			"processingMode": map[string]interface{}{
+				"request": map[string]interface{}{},
+			},
+		},
+	}, "spec", "extProc")
+
+	return policy, nil
+}
+
+// ReconcileEnvoyExtensionPolicy creates or updates the EnvoyExtensionPolicy that
+// attaches ext_proc token exchange to a protected route. It is a no-op unless
+// token exchange is enabled (cfg.ExtProcEnabled()).
+func ReconcileEnvoyExtensionPolicy(
+	ctx context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	params PolicyParams,
+	cfg Config,
+	log logr.Logger,
+) error {
+	if !cfg.ExtProcEnabled() {
+		return nil
+	}
+
+	desired, err := constructEnvoyExtensionPolicy(params, cfg)
+	if err != nil {
+		return fmt.Errorf("construct EnvoyExtensionPolicy: %w", err)
+	}
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(EnvoyExtensionPolicyGVK)
+	err = c.Get(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace}, existing)
+	if err != nil && apierrors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(owner, desired, scheme); err != nil {
+			return fmt.Errorf("set controller reference on EnvoyExtensionPolicy: %w", err)
+		}
+		log.Info("Creating EnvoyExtensionPolicy", "name", params.Name, "namespace", params.Namespace)
+		return c.Create(ctx, desired)
+	} else if err != nil {
+		return err
+	}
+
+	spec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+	if err := unstructured.SetNestedMap(existing.Object, spec, "spec"); err != nil {
+		return fmt.Errorf("update EnvoyExtensionPolicy spec: %w", err)
+	}
+	return c.Update(ctx, existing)
+}

--- a/operator/pkg/security/envoyextensionpolicy_test.go
+++ b/operator/pkg/security/envoyextensionpolicy_test.go
@@ -1,0 +1,98 @@
+package security
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func extProcConfig() Config {
+	return Config{ExtProcURL: "aib-extproc.kaos-system.svc.cluster.local:50051"}
+}
+
+func TestConstructEnvoyExtensionPolicyShape(t *testing.T) {
+	params := PolicyParams{
+		Name:      "mcp-github",
+		Namespace: "default",
+		RouteName: "mcp-github",
+		Labels:    map[string]string{"app": "kaos"},
+	}
+
+	policy, err := constructEnvoyExtensionPolicy(params, extProcConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gvk := policy.GroupVersionKind(); gvk != EnvoyExtensionPolicyGVK {
+		t.Fatalf("unexpected GVK %v", gvk)
+	}
+	if policy.GetName() != "mcp-github" || policy.GetNamespace() != "default" {
+		t.Fatalf("unexpected name/namespace %s/%s", policy.GetName(), policy.GetNamespace())
+	}
+	if policy.GetLabels()["app"] != "kaos" {
+		t.Errorf("expected app=kaos label")
+	}
+
+	targetRefs, found, err := unstructured.NestedSlice(policy.Object, "spec", "targetRefs")
+	if err != nil || !found || len(targetRefs) != 1 {
+		t.Fatalf("expected one targetRef, got found=%v err=%v len=%d", found, err, len(targetRefs))
+	}
+	ref := targetRefs[0].(map[string]interface{})
+	if ref["group"] != "gateway.networking.k8s.io" || ref["kind"] != "HTTPRoute" || ref["name"] != "mcp-github" {
+		t.Errorf("unexpected targetRef %#v", ref)
+	}
+
+	extProc, found, err := unstructured.NestedSlice(policy.Object, "spec", "extProc")
+	if err != nil || !found || len(extProc) != 1 {
+		t.Fatalf("expected one extProc entry, found=%v err=%v len=%d", found, err, len(extProc))
+	}
+	entry := extProc[0].(map[string]interface{})
+
+	backendRefs, ok := entry["backendRefs"].([]interface{})
+	if !ok || len(backendRefs) != 1 {
+		t.Fatalf("expected one backendRef, got %#v", entry["backendRefs"])
+	}
+	backendRef := backendRefs[0].(map[string]interface{})
+	if backendRef["name"] != "aib-extproc" || backendRef["namespace"] != "kaos-system" {
+		t.Errorf("unexpected backendRef name/namespace %#v", backendRef)
+	}
+	if backendRef["kind"] != "Service" || backendRef["port"] != int64(50051) {
+		t.Errorf("unexpected backendRef kind/port %#v", backendRef)
+	}
+
+	mode, ok := entry["processingMode"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected processingMode, got %#v", entry["processingMode"])
+	}
+	if _, ok := mode["request"]; !ok {
+		t.Errorf("expected processingMode.request to be present, got %#v", mode)
+	}
+}
+
+func TestConstructEnvoyExtensionPolicyBackendRefError(t *testing.T) {
+	params := PolicyParams{Name: "x", Namespace: "default", RouteName: "x"}
+	if _, err := constructEnvoyExtensionPolicy(params, Config{ExtProcURL: "no-port"}); err == nil {
+		t.Fatalf("expected error for malformed ext_proc URL")
+	}
+}
+
+func TestReconcileEnvoyExtensionPolicyNoopWhenDisabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	owner := &unstructured.Unstructured{}
+	owner.SetGroupVersionKind(SecurityPolicyGVK)
+	owner.SetName("owner")
+	owner.SetNamespace("default")
+
+	params := PolicyParams{Name: "mcp-github", Namespace: "default", RouteName: "mcp-github"}
+
+	// ExtProc disabled (empty URL): reconcile must be a no-op (early return before
+	// any client interaction) and never construct or create a policy.
+	if err := ReconcileEnvoyExtensionPolicy(context.Background(), c, scheme, owner, params, Config{}, ctrl.Log); err != nil {
+		t.Fatalf("expected no-op reconcile to succeed, got error: %v", err)
+	}
+}


### PR DESCRIPTION
Adds the `ext_proc` token-exchange stage to the gateway pipeline, completing `jwt_authn -> ext_authz -> ext_proc -> upstream`.

## What this adds
- **Operator**: `ExtProcURL` security config (`SECURITY_AGENT_AUTH_EXT_PROC_URL`) with `ExtProcEnabled()`/`ExtProcBackendRef()`; a new `EnvoyExtensionPolicy` generator + reconciler wired into the Agent/MCPServer/ModelAPI controllers (gated, default-off, independent of `ext_authz`); `envoyextensionpolicies` RBAC.
- **Operator chart**: `security.agentAuth.extProcUrl` rendered into the operator ConfigMap when set.
- **AIB broker chart**: optional ExtProc Deployment+Service (`extProc.enabled`, default off) running the token-exchange image, configured via `EXTPROC_*` env (committed in the AIB repo).
- **CLI**: `--token-exchange/--no-token-exchange` + `--ext-proc-url`; enables the broker ExtProc component, resolves and wires the gateway `extProcUrl`, and provisions the ExtProc OAuth client + a dummy third-party service for validation.

## Validation
- Operator unit + integration tests, chart `helm template`/`lint`, 83 CLI tests — all green locally.
- The operator-generated `EnvoyExtensionPolicy` shape is `Accepted=True` on live Envoy Gateway v1.4.6.
- Default-off gating contains the internal-traffic regression risk: no `EnvoyExtensionPolicy` renders unless `extProcUrl` is configured.
- Full delegated-exchange data path is local-KIND only (unpublished broker/ExtProc images) and requires a seeded OAuth2-server-mode broker; see PR comment report.

Stacked on `feat/gateway-user-authentication`.