### PR TITLE
PR-ADR-KAOS-8: Managed actor-token lifecycle in the agent runtime

### DIFF
--- a/operator/controllers/agent_auth_env_test.go
+++ b/operator/controllers/agent_auth_env_test.go
@@ -77,6 +77,42 @@ func TestBuildAgentAuthEnvVarsEnabled(t *testing.T) {
 	if !ok || endpoint.Value != "http://aib-enduser.aib-system.svc.cluster.local:8000/oauth2/token" {
 		t.Errorf("AGENT_AUTH_TOKEN_ENDPOINT = %q, want the issuer token endpoint", endpoint.Value)
 	}
+
+	secretFile, ok := envByName(env, "AGENT_AUTH_CLIENT_SECRET_FILE")
+	if !ok || secretFile.Value != "/var/run/aib/client_secret" {
+		t.Errorf("AGENT_AUTH_CLIENT_SECRET_FILE = %q, want /var/run/aib/client_secret", secretFile.Value)
+	}
+}
+
+func TestBuildAgentAuthVolumeDisabled(t *testing.T) {
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "")
+	t.Setenv("SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX", "")
+
+	if volume, mount := buildAgentAuthVolume(newAgent("demo", "researcher")); volume != nil || mount != nil {
+		t.Errorf("expected no credential volume when mounting is disabled, got %v / %v", volume, mount)
+	}
+}
+
+func TestBuildAgentAuthVolumeEnabled(t *testing.T) {
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "aib-ext-authz.aib-system:9002")
+	t.Setenv("SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX", "kaos-aib")
+
+	volume, mount := buildAgentAuthVolume(newAgent("demo", "researcher"))
+	if volume == nil || mount == nil {
+		t.Fatalf("expected a credential volume and mount when mounting is enabled")
+	}
+	if volume.Secret == nil || volume.Secret.SecretName != "kaos-aib-researcher" {
+		t.Errorf("volume secret name = %v, want kaos-aib-researcher", volume.Secret)
+	}
+	if volume.Secret.Optional == nil || !*volume.Secret.Optional {
+		t.Errorf("credential volume secret must be optional so the pod can start before the Secret exists")
+	}
+	if mount.MountPath != "/var/run/aib" || !mount.ReadOnly {
+		t.Errorf("mount = %s (readOnly=%v), want /var/run/aib read-only", mount.MountPath, mount.ReadOnly)
+	}
+	if mount.Name != volume.Name {
+		t.Errorf("mount name %q must match volume name %q", mount.Name, volume.Name)
+	}
 }
 
 func TestBuildAgentAuthEnvVarsWithoutIssuer(t *testing.T) {

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -433,6 +433,13 @@ func (r *AgentReconciler) constructDeployment(agent *kaosv1alpha1.Agent, modelap
 		Containers: []corev1.Container{container},
 	}
 
+	// Mount the per-agent credential Secret as a file so the runtime can re-read the
+	// client_secret on rotation (when credential mounting is enabled).
+	if volume, mount := buildAgentAuthVolume(agent); volume != nil {
+		basePodSpec.Volumes = append(basePodSpec.Volumes, *volume)
+		basePodSpec.Containers[0].VolumeMounts = append(basePodSpec.Containers[0].VolumeMounts, *mount)
+	}
+
 	// Apply spec.container override using strategic merge patch
 	if agent.Spec.Container != nil {
 		containerPatch := containerOverrideToPodSpecPatch(*agent.Spec.Container)
@@ -753,7 +760,41 @@ func buildAgentAuthEnvVars(agent *kaosv1alpha1.Agent) []corev1.EnvVar {
 	if endpoint := cfg.TokenEndpoint(); endpoint != "" {
 		env = append(env, corev1.EnvVar{Name: "AGENT_AUTH_TOKEN_ENDPOINT", Value: endpoint})
 	}
+	// Point the runtime at the mounted client_secret file so it can re-read the
+	// credential on rotation. The SecretKeyRef env above stays as a startup fallback.
+	env = append(env, corev1.EnvVar{
+		Name:  "AGENT_AUTH_CLIENT_SECRET_FILE",
+		Value: cfg.CredentialSecretFilePath(),
+	})
 	return env
+}
+
+// buildAgentAuthVolume returns the projected credential volume and its read-only mount
+// for the agent container when credential mounting is enabled, or nil otherwise. The
+// per-agent credential Secret is mounted at the configured directory so the runtime can
+// re-read the client_secret on rotation. The Secret reference is optional so the pod can
+// start before the sync service has written it.
+func buildAgentAuthVolume(agent *kaosv1alpha1.Agent) (*corev1.Volume, *corev1.VolumeMount) {
+	cfg := security.GetConfig()
+	if !cfg.CredentialMountingEnabled() {
+		return nil, nil
+	}
+	optional := true
+	volume := &corev1.Volume{
+		Name: "agent-auth-credentials",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: cfg.CredentialSecretName(agent.Name),
+				Optional:   &optional,
+			},
+		},
+	}
+	mount := &corev1.VolumeMount{
+		Name:      "agent-auth-credentials",
+		MountPath: cfg.CredentialMountDir(),
+		ReadOnly:  true,
+	}
+	return volume, mount
 }
 
 // constructService creates a Service for A2A communication

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -109,6 +109,30 @@ func (c Config) TokenEndpoint() string {
 	return issuer + "/oauth2/token"
 }
 
+// credentialMountDir is the directory into which the per-agent credential Secret is
+// projected in agent pods. The client_secret is exposed as a file under this directory
+// so the runtime can re-read it on rotation rather than relying on a static env value.
+const credentialMountDir = "/var/run/aib"
+
+// credentialSecretKey is the Secret data key holding the agent's client secret.
+const credentialSecretKey = "client_secret"
+
+// CredentialMountDir returns the directory under which the credential Secret is mounted.
+func (c Config) CredentialMountDir() string {
+	return credentialMountDir
+}
+
+// CredentialSecretKey returns the Secret data key holding the agent's client secret.
+func (c Config) CredentialSecretKey() string {
+	return credentialSecretKey
+}
+
+// CredentialSecretFilePath returns the absolute path of the mounted client_secret file
+// that the runtime reads (and re-reads on rotation) to mint actor tokens.
+func (c Config) CredentialSecretFilePath() string {
+	return credentialMountDir + "/" + credentialSecretKey
+}
+
 // JWTEnabled reports whether the operator should emit jwt_authn providers on
 // protected routes. It is true when either the agent issuer or the user issuer
 // is configured. This is independent of IsOperational (which gates ext_authz):

--- a/pydantic-ai-server/aib/__init__.py
+++ b/pydantic-ai-server/aib/__init__.py
@@ -18,6 +18,15 @@ The SDK is *not* the enforcement boundary; it only propagates.
 
 from __future__ import annotations
 
+from .client import (
+    AccessDecision,
+    AccessDenied,
+    AccessRequest,
+    AsyncClient,
+    Client,
+    ReauthenticationRequired,
+    TokenResult,
+)
 from .identity import (
     AIBUnavailable,
     ActorTokenManager,
@@ -57,6 +66,13 @@ __all__ = [
     "reset_manager",
     "ActorTokenManager",
     "AIBUnavailable",
+    "Client",
+    "AsyncClient",
+    "AccessRequest",
+    "AccessDecision",
+    "AccessDenied",
+    "ReauthenticationRequired",
+    "TokenResult",
     "HEADER_REQUEST_ID",
     "HEADER_SESSION_ID",
     "HEADER_PRINCIPAL",

--- a/pydantic-ai-server/aib/__init__.py
+++ b/pydantic-ai-server/aib/__init__.py
@@ -18,6 +18,15 @@ The SDK is *not* the enforcement boundary; it only propagates.
 
 from __future__ import annotations
 
+from .identity import (
+    AIBUnavailable,
+    ActorTokenManager,
+    actor_token,
+    actor_token_async,
+    get_manager,
+    instrument_agent_identity,
+    reset_manager,
+)
 from .instrument import (
     HEADER_ACTOR,
     HEADER_ACTOR_TOKEN,
@@ -41,6 +50,13 @@ __all__ = [
     "to_headers",
     "instrument_fastapi",
     "instrument_httpx",
+    "instrument_agent_identity",
+    "actor_token",
+    "actor_token_async",
+    "get_manager",
+    "reset_manager",
+    "ActorTokenManager",
+    "AIBUnavailable",
     "HEADER_REQUEST_ID",
     "HEADER_SESSION_ID",
     "HEADER_PRINCIPAL",

--- a/pydantic-ai-server/aib/client.py
+++ b/pydantic-ai-server/aib/client.py
@@ -1,0 +1,337 @@
+"""Optional off-gateway client for the broker's access-check and token endpoints.
+
+The KAOS gateway already performs actor/subject authentication, edge authorization
+(``ext_authz``) and delegated token exchange (``ext_proc``) for traffic that flows
+through it. This client is for the **off-gateway** case: a custom server or tool that
+wants to ask the broker directly whether the calling agent may act on a resource, or to
+obtain a delegated third-party token, without sitting behind the gateway. It is not the
+enforcement boundary — it is a convenience over the broker's HTTP API.
+
+Principal / actor / request-id default from the request-local :data:`aib.ctx` so an
+in-request caller does not have to thread them manually.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .identity import AIBUnavailable, actor_token, actor_token_async
+from .instrument import ctx
+
+_TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange"
+_ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+# Reasons (or reason prefixes) that mean the user must re-authenticate / re-consent.
+_REAUTH_REASONS = ("reauth", "consent", "user_action_required", "reauthentication_required")
+
+
+class AccessDenied(RuntimeError):
+    """Raised by :meth:`Client.require_access` when access is not allowed."""
+
+    def __init__(self, decision: "AccessDecision") -> None:
+        super().__init__(f"access denied: {decision.reason or 'not allowed'}")
+        self.decision = decision
+
+
+class ReauthenticationRequired(AccessDenied):
+    """Raised when the denial is recoverable by user re-authentication / re-consent."""
+
+    def __init__(self, decision: "AccessDecision") -> None:
+        super().__init__(decision)
+        self.reauth_url = decision.reauth_url
+
+
+@dataclass
+class AccessRequest:
+    """A resource-level access-check question."""
+
+    resource: str
+    action: str = "access"
+    actor_token: Optional[str] = None
+    principal: Optional[str] = None
+    request_id: Optional[str] = None
+
+
+@dataclass
+class AccessDecision:
+    """The broker's structured allow/deny decision."""
+
+    allowed: bool
+    reason: str = ""
+    actor: str = ""
+    resource: str = ""
+    action: str = ""
+    reauth_url: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def requires_reauth(self) -> bool:
+        """True when the denial is recoverable via user re-authentication / re-consent."""
+        reason = (self.reason or "").lower()
+        return bool(self.reauth_url) or any(reason.startswith(r) for r in _REAUTH_REASONS)
+
+
+@dataclass
+class TokenResult:
+    """A delegated token returned by the broker token endpoint."""
+
+    access_token: str
+    token_type: str = "Bearer"
+    expires_in: int = 0
+    scope: str = ""
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+def _default_base_url(base_url: Optional[str]) -> str:
+    return base_url or os.environ.get("AGENT_AUTH_BASE_URL", "") or ""
+
+
+def _default_token_endpoint(token_endpoint: Optional[str], base_url: str) -> str:
+    if token_endpoint:
+        return token_endpoint
+    env = os.environ.get("AGENT_AUTH_TOKEN_ENDPOINT", "")
+    if env:
+        return env
+    if base_url:
+        return f"{base_url.rstrip('/')}/oauth2/token"
+    return ""
+
+
+def _resolve_actor_token(explicit: Optional[str]) -> Optional[str]:
+    """Actor token to present: explicit, else managed lifecycle, else request ctx."""
+    if explicit:
+        return explicit
+    managed = actor_token()
+    if managed:
+        return managed
+    return ctx.get("actor_token")
+
+
+def _build_check_body(req: AccessRequest) -> Dict[str, Any]:
+    body: Dict[str, Any] = {"resource": req.resource, "action": req.action or "access"}
+    token = _resolve_actor_token(req.actor_token)
+    if token:
+        body["actor_token"] = token
+    return body
+
+
+def _parse_decision(data: Dict[str, Any]) -> AccessDecision:
+    return AccessDecision(
+        allowed=bool(data.get("allowed", False)),
+        reason=str(data.get("reason", "") or ""),
+        actor=str(data.get("actor", "") or ""),
+        resource=str(data.get("resource", "") or ""),
+        action=str(data.get("action", "") or ""),
+        reauth_url=data.get("reauth_url") or data.get("error_uri") or None,
+        raw=data,
+    )
+
+
+def _parse_token(data: Dict[str, Any]) -> TokenResult:
+    token = data.get("access_token")
+    if not token:
+        raise AIBUnavailable("broker token response missing access_token")
+    return TokenResult(
+        access_token=token,
+        token_type=str(data.get("token_type", "Bearer") or "Bearer"),
+        expires_in=int(data.get("expires_in", 0) or 0),
+        scope=str(data.get("scope", "") or ""),
+        raw=data,
+    )
+
+
+def _exchange_form(subject_token: str, audience: str, scopes: str) -> Dict[str, str]:
+    form = {
+        "grant_type": _TOKEN_EXCHANGE_GRANT,
+        "subject_token": subject_token,
+        "subject_token_type": _ACCESS_TOKEN_TYPE,
+    }
+    if audience:
+        form["audience"] = audience
+    if scopes:
+        form["scope"] = scopes
+    return form
+
+
+def _raise_for_decision(decision: AccessDecision) -> None:
+    if decision.allowed:
+        return
+    if decision.requires_reauth:
+        raise ReauthenticationRequired(decision)
+    raise AccessDenied(decision)
+
+
+class Client:
+    """Synchronous off-gateway client over the broker access-check + token endpoints."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        token_endpoint: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self._base_url = _default_base_url(base_url)
+        self._token_endpoint = _default_token_endpoint(token_endpoint, self._base_url)
+        self._timeout = timeout
+
+    def _access_check_url(self) -> str:
+        return f"{self._base_url.rstrip('/')}/api/access/check"
+
+    def check_access(
+        self,
+        resource: str,
+        action: str = "access",
+        *,
+        actor_token: Optional[str] = None,
+        principal: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ) -> AccessDecision:
+        """Ask the broker whether the calling agent may perform ``action`` on ``resource``."""
+        req = AccessRequest(
+            resource=resource,
+            action=action,
+            actor_token=actor_token,
+            principal=principal or ctx.get("principal"),
+            request_id=request_id or ctx.get("request_id"),
+        )
+        try:
+            resp = httpx.post(
+                self._access_check_url(),
+                json=_build_check_body(req),
+                headers=_ctx_headers(req),
+                timeout=self._timeout,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise AIBUnavailable(f"access-check request failed: {exc}") from exc
+        return _parse_decision(resp.json())
+
+    def require_access(
+        self, resource: str, action: str = "access", **kwargs: Any
+    ) -> AccessDecision:
+        """Like :meth:`check_access` but raise on a non-allow decision."""
+        decision = self.check_access(resource, action, **kwargs)
+        _raise_for_decision(decision)
+        return decision
+
+    def exchange_token(
+        self, subject_token: str, audience: str = "", scopes: str = ""
+    ) -> TokenResult:
+        """Exchange a subject token for a delegated token (RFC 8693)."""
+        try:
+            resp = httpx.post(
+                self._token_endpoint,
+                data=_exchange_form(subject_token, audience, scopes),
+                timeout=self._timeout,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise AIBUnavailable(f"token exchange failed: {exc}") from exc
+        return _parse_token(resp.json())
+
+    def get_token(self, resource: str, scopes: str = "") -> TokenResult:
+        """Obtain a delegated token for ``resource`` using the request's subject token."""
+        subject_token = ctx.get("subject_token")
+        if not subject_token:
+            raise AIBUnavailable("no subject token in context for get_token")
+        return self.exchange_token(subject_token, audience=resource, scopes=scopes)
+
+
+class AsyncClient:
+    """Asynchronous counterpart of :class:`Client`."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        token_endpoint: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self._base_url = _default_base_url(base_url)
+        self._token_endpoint = _default_token_endpoint(token_endpoint, self._base_url)
+        self._timeout = timeout
+
+    def _access_check_url(self) -> str:
+        return f"{self._base_url.rstrip('/')}/api/access/check"
+
+    async def check_access(
+        self,
+        resource: str,
+        action: str = "access",
+        *,
+        actor_token: Optional[str] = None,
+        principal: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ) -> AccessDecision:
+        """Async variant of :meth:`Client.check_access`."""
+        req = AccessRequest(
+            resource=resource,
+            action=action,
+            actor_token=await _resolve_actor_token_async(actor_token),
+            principal=principal or ctx.get("principal"),
+            request_id=request_id or ctx.get("request_id"),
+        )
+        body: Dict[str, Any] = {"resource": req.resource, "action": req.action or "access"}
+        if req.actor_token:
+            body["actor_token"] = req.actor_token
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.post(
+                    self._access_check_url(), json=body, headers=_ctx_headers(req)
+                )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise AIBUnavailable(f"access-check request failed: {exc}") from exc
+        return _parse_decision(resp.json())
+
+    async def require_access(
+        self, resource: str, action: str = "access", **kwargs: Any
+    ) -> AccessDecision:
+        """Async variant of :meth:`Client.require_access`."""
+        decision = await self.check_access(resource, action, **kwargs)
+        _raise_for_decision(decision)
+        return decision
+
+    async def exchange_token(
+        self, subject_token: str, audience: str = "", scopes: str = ""
+    ) -> TokenResult:
+        """Async variant of :meth:`Client.exchange_token`."""
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.post(
+                    self._token_endpoint, data=_exchange_form(subject_token, audience, scopes)
+                )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise AIBUnavailable(f"token exchange failed: {exc}") from exc
+        return _parse_token(resp.json())
+
+    async def get_token(self, resource: str, scopes: str = "") -> TokenResult:
+        """Async variant of :meth:`Client.get_token`."""
+        subject_token = ctx.get("subject_token")
+        if not subject_token:
+            raise AIBUnavailable("no subject token in context for get_token")
+        return await self.exchange_token(subject_token, audience=resource, scopes=scopes)
+
+
+async def _resolve_actor_token_async(explicit: Optional[str]) -> Optional[str]:
+    if explicit:
+        return explicit
+    managed = await actor_token_async()
+    if managed:
+        return managed
+    return ctx.get("actor_token")
+
+
+def _ctx_headers(req: AccessRequest) -> Dict[str, str]:
+    """Correlation/principal headers carried alongside an access-check request."""
+    headers: Dict[str, str] = {}
+    if req.principal:
+        headers["x-principal"] = req.principal
+    if req.request_id:
+        headers["x-request-id"] = req.request_id
+    return headers

--- a/pydantic-ai-server/aib/identity.py
+++ b/pydantic-ai-server/aib/identity.py
@@ -55,17 +55,49 @@ def _derive_token_endpoint(token_endpoint: str, issuer: str) -> str:
 
 
 class _Credential:
-    """Source of the client secret. Env-backed; a file source is layered on later."""
+    """Source of the client secret: a projected-volume file when configured, else env.
 
-    def __init__(self, *, secret_env: str = "AGENT_AUTH_CLIENT_SECRET") -> None:
+    When a ``secret_file`` is set the contents are cached and re-read only when the file's
+    mtime changes, so a rotated Kubernetes Secret is picked up on the next acquire without
+    a process restart and without a background watcher. A missing/unreadable file falls
+    back to the env secret (covers the pod-starts-before-Secret race).
+    """
+
+    def __init__(
+        self,
+        *,
+        secret_env: str = "AGENT_AUTH_CLIENT_SECRET",
+        secret_file: Optional[str] = None,
+    ) -> None:
         self._secret_env = secret_env
+        self._secret_file = secret_file
+        self._cached_secret: Optional[str] = None
+        self._cached_mtime: Optional[float] = None
 
-    def secret(self) -> str:
-        """Current client secret (empty when unset)."""
+    def _env_secret(self) -> str:
         return os.environ.get(self._secret_env, "") or ""
 
+    def secret(self) -> str:
+        """Current client secret (file-first, env fallback; empty when unset)."""
+        if not self._secret_file:
+            return self._env_secret()
+        try:
+            mtime = os.path.getmtime(self._secret_file)
+        except OSError:
+            return self._env_secret()
+        if self._cached_secret is None or mtime != self._cached_mtime:
+            try:
+                with open(self._secret_file, "r", encoding="utf-8") as fh:
+                    self._cached_secret = fh.read().strip()
+                self._cached_mtime = mtime
+            except OSError:
+                return self._env_secret()
+        return self._cached_secret or ""
+
     def reload(self) -> None:
-        """Force the next :meth:`secret` to re-read its source (no-op for env)."""
+        """Force the next :meth:`secret` to re-read the file (e.g. after a rotation 401)."""
+        self._cached_secret = None
+        self._cached_mtime = None
 
 
 class ActorTokenManager:
@@ -242,21 +274,27 @@ def instrument_agent_identity(
     issuer_env: str = "AGENT_AUTH_ISSUER",
     client_id_env: str = "AGENT_AUTH_CLIENT_ID",
     client_secret_env: str = "AGENT_AUTH_CLIENT_SECRET",
+    client_secret_file_env: str = "AGENT_AUTH_CLIENT_SECRET_FILE",
+    client_secret_file: Optional[str] = None,
     scope: str = "",
     refresh_fraction: float = _DEFAULT_REFRESH_FRACTION,
 ) -> Optional[ActorTokenManager]:
     """Configure the process-global managed actor-token lifecycle.
 
     Reads the broker coordinates from the provider-agnostic ``AGENT_AUTH_*`` environment
-    the operator injects. Returns the manager, or ``None`` when no credentials are present
-    (the static-token / simulation path then remains in effect). Safe to call repeatedly.
+    the operator injects. The client secret is sourced file-first from
+    ``client_secret_file`` (or the ``AGENT_AUTH_CLIENT_SECRET_FILE`` env when not passed
+    explicitly), falling back to ``AGENT_AUTH_CLIENT_SECRET``; a rotated file is reloaded
+    on its next use. Returns the manager, or ``None`` when no credentials are present (the
+    static-token / simulation path then remains in effect). Safe to call repeatedly.
     """
     global _manager
     token_endpoint = _derive_token_endpoint(
         os.environ.get(token_endpoint_env, ""), os.environ.get(issuer_env, "")
     )
     client_id = os.environ.get(client_id_env, "")
-    credential = _Credential(secret_env=client_secret_env)
+    secret_file = client_secret_file or os.environ.get(client_secret_file_env, "") or None
+    credential = _Credential(secret_env=client_secret_env, secret_file=secret_file)
     manager = ActorTokenManager(
         token_endpoint=token_endpoint,
         client_id=client_id,

--- a/pydantic-ai-server/aib/identity.py
+++ b/pydantic-ai-server/aib/identity.py
@@ -1,0 +1,296 @@
+"""Machine actor-token lifecycle for the agent's own identity.
+
+The propagation SDK (:mod:`aib.instrument`) forwards identities but does not *mint*
+them. This module lets an agent authenticate as itself without a static, pre-minted
+token: it acquires the agent **actor** token via an OAuth2 ``client_credentials`` grant
+against the configured broker, caches it with refresh-ahead so the request path rarely
+blocks, single-flights concurrent refreshes, backs off on broker unavailability, and
+**fails closed** — it never hands back an empty or expired token as if it were valid.
+
+Configuration comes from the provider-agnostic ``AGENT_AUTH_*`` environment the operator
+injects into the agent pod: ``AGENT_AUTH_CLIENT_ID``, ``AGENT_AUTH_CLIENT_SECRET`` and
+``AGENT_AUTH_TOKEN_ENDPOINT`` (or ``AGENT_AUTH_ISSUER`` from which the token endpoint is
+derived). The minted token's subject is the agent's logical identity, which the operator
+also exports as ``AGENT_AUTH_IDENTITY``.
+
+When no credentials are configured the module is inert: :func:`actor_token` returns
+``None`` and the existing static-token / simulation path is unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from typing import Optional
+
+import httpx
+
+# Refresh when this fraction of the token lifetime remains (refresh-ahead at ~80% TTL).
+_DEFAULT_REFRESH_FRACTION = 0.2
+# Bounded retry/backoff for the client_credentials grant before failing closed.
+_MAX_ATTEMPTS = 3
+_BACKOFF_BASE_SECONDS = 0.2
+_BACKOFF_CAP_SECONDS = 2.0
+# Assumed lifetime when the token response omits ``expires_in``.
+_FALLBACK_LIFETIME_SECONDS = 300.0
+
+
+class AIBUnavailable(RuntimeError):
+    """Raised when a fresh actor token cannot be obtained from the broker.
+
+    The lifecycle fails closed: callers must treat this as an authentication failure
+    rather than proceeding with a missing or stale token.
+    """
+
+
+def _derive_token_endpoint(token_endpoint: str, issuer: str) -> str:
+    """Token endpoint, preferring an explicit value, else ``<issuer>/oauth2/token``."""
+    if token_endpoint:
+        return token_endpoint
+    if issuer:
+        return f"{issuer.rstrip('/')}/oauth2/token"
+    return ""
+
+
+class _Credential:
+    """Source of the client secret. Env-backed; a file source is layered on later."""
+
+    def __init__(self, *, secret_env: str = "AGENT_AUTH_CLIENT_SECRET") -> None:
+        self._secret_env = secret_env
+
+    def secret(self) -> str:
+        """Current client secret (empty when unset)."""
+        return os.environ.get(self._secret_env, "") or ""
+
+    def reload(self) -> None:
+        """Force the next :meth:`secret` to re-read its source (no-op for env)."""
+
+
+class ActorTokenManager:
+    """Acquires and caches the agent actor token via ``client_credentials``.
+
+    The manager serves a cached token until the refresh-ahead point (``refresh_fraction``
+    of the lifetime remaining), then transparently re-acquires. Refreshes are
+    single-flighted across both sync and async callers. On broker failure it retries with
+    bounded backoff and then raises :class:`AIBUnavailable`; a still-valid cached token is
+    preferred over failing, but an absent/expired token never silently passes.
+    """
+
+    def __init__(
+        self,
+        *,
+        token_endpoint: str,
+        client_id: str,
+        credential: _Credential,
+        scope: str = "",
+        refresh_fraction: float = _DEFAULT_REFRESH_FRACTION,
+    ) -> None:
+        self._token_endpoint = token_endpoint
+        self._client_id = client_id
+        self._credential = credential
+        self._scope = scope
+        self._refresh_fraction = refresh_fraction
+        self._token: Optional[str] = None
+        self._expires_at = 0.0
+        self._refresh_at = 0.0
+        self._sync_lock = threading.Lock()
+        self._async_lock = asyncio.Lock()
+
+    @property
+    def configured(self) -> bool:
+        """True when the manager has enough to attempt a grant."""
+        return bool(self._token_endpoint and self._client_id and self._credential.secret())
+
+    def _cached_valid(self) -> Optional[str]:
+        """Return the cached token if it is still within its lifetime, else ``None``."""
+        if self._token and time.monotonic() < self._expires_at:
+            return self._token
+        return None
+
+    def _needs_refresh(self) -> bool:
+        return self._token is None or time.monotonic() >= self._refresh_at
+
+    def _store(self, token: str, expires_in: float) -> None:
+        now = time.monotonic()
+        lifetime = expires_in if expires_in > 0 else _FALLBACK_LIFETIME_SECONDS
+        self._token = token
+        self._expires_at = now + lifetime
+        self._refresh_at = now + lifetime * (1.0 - self._refresh_fraction)
+
+    def _grant_params(self) -> dict[str, str]:
+        params = {
+            "grant_type": "client_credentials",
+            "client_id": self._client_id,
+            "client_secret": self._credential.secret(),
+        }
+        if self._scope:
+            params["scope"] = self._scope
+        return params
+
+    @staticmethod
+    def _parse(response: httpx.Response) -> tuple[str, float]:
+        data = response.json()
+        token = data.get("access_token")
+        if not token:
+            raise AIBUnavailable("broker token response missing access_token")
+        return token, float(data.get("expires_in", 0) or 0)
+
+    # --- sync ---------------------------------------------------------------
+
+    def token(self) -> Optional[str]:
+        """Return a fresh actor token, refreshing ahead of expiry. ``None`` if inert."""
+        if not self.configured:
+            return None
+        if not self._needs_refresh():
+            return self._token
+        with self._sync_lock:
+            if not self._needs_refresh():
+                return self._token
+            try:
+                self._store(*self._acquire_sync())
+            except AIBUnavailable:
+                cached = self._cached_valid()
+                if cached is not None:
+                    return cached
+                raise
+        return self._token
+
+    def force_refresh(self) -> Optional[str]:
+        """Invalidate the cache and acquire a new token synchronously."""
+        self.invalidate()
+        return self.token()
+
+    def invalidate(self) -> None:
+        """Drop the cached token so the next :meth:`token` re-acquires."""
+        with self._sync_lock:
+            self._token = None
+            self._expires_at = 0.0
+            self._refresh_at = 0.0
+
+    def _acquire_sync(self) -> tuple[str, float]:
+        last_exc: Optional[Exception] = None
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                resp = httpx.post(self._token_endpoint, data=self._grant_params(), timeout=10.0)
+                if resp.status_code == 401:
+                    self._credential.reload()
+                resp.raise_for_status()
+                return self._parse(resp)
+            except (httpx.HTTPError, AIBUnavailable) as exc:
+                last_exc = exc
+                if attempt < _MAX_ATTEMPTS - 1:
+                    time.sleep(_backoff(attempt))
+        raise AIBUnavailable(f"could not acquire actor token: {last_exc}") from last_exc
+
+    # --- async --------------------------------------------------------------
+
+    async def token_async(self) -> Optional[str]:
+        """Async variant of :meth:`token`."""
+        if not self.configured:
+            return None
+        if not self._needs_refresh():
+            return self._token
+        async with self._async_lock:
+            if not self._needs_refresh():
+                return self._token
+            try:
+                self._store(*await self._acquire_async())
+            except AIBUnavailable:
+                cached = self._cached_valid()
+                if cached is not None:
+                    return cached
+                raise
+        return self._token
+
+    async def force_refresh_async(self) -> Optional[str]:
+        """Async variant of :meth:`force_refresh`."""
+        self.invalidate()
+        return await self.token_async()
+
+    async def _acquire_async(self) -> tuple[str, float]:
+        last_exc: Optional[Exception] = None
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    resp = await client.post(self._token_endpoint, data=self._grant_params())
+                if resp.status_code == 401:
+                    self._credential.reload()
+                resp.raise_for_status()
+                return self._parse(resp)
+            except (httpx.HTTPError, AIBUnavailable) as exc:
+                last_exc = exc
+                if attempt < _MAX_ATTEMPTS - 1:
+                    await asyncio.sleep(_backoff(attempt))
+        raise AIBUnavailable(f"could not acquire actor token: {last_exc}") from last_exc
+
+
+def _backoff(attempt: int) -> float:
+    """Bounded exponential backoff for grant retries."""
+    return min(_BACKOFF_BASE_SECONDS * (2**attempt), _BACKOFF_CAP_SECONDS)
+
+
+# --- process-global manager + module accessors --------------------------------
+
+_manager: Optional[ActorTokenManager] = None
+
+
+def instrument_agent_identity(
+    *,
+    token_endpoint_env: str = "AGENT_AUTH_TOKEN_ENDPOINT",
+    issuer_env: str = "AGENT_AUTH_ISSUER",
+    client_id_env: str = "AGENT_AUTH_CLIENT_ID",
+    client_secret_env: str = "AGENT_AUTH_CLIENT_SECRET",
+    scope: str = "",
+    refresh_fraction: float = _DEFAULT_REFRESH_FRACTION,
+) -> Optional[ActorTokenManager]:
+    """Configure the process-global managed actor-token lifecycle.
+
+    Reads the broker coordinates from the provider-agnostic ``AGENT_AUTH_*`` environment
+    the operator injects. Returns the manager, or ``None`` when no credentials are present
+    (the static-token / simulation path then remains in effect). Safe to call repeatedly.
+    """
+    global _manager
+    token_endpoint = _derive_token_endpoint(
+        os.environ.get(token_endpoint_env, ""), os.environ.get(issuer_env, "")
+    )
+    client_id = os.environ.get(client_id_env, "")
+    credential = _Credential(secret_env=client_secret_env)
+    manager = ActorTokenManager(
+        token_endpoint=token_endpoint,
+        client_id=client_id,
+        credential=credential,
+        scope=scope,
+        refresh_fraction=refresh_fraction,
+    )
+    if not manager.configured:
+        _manager = None
+        return None
+    _manager = manager
+    return manager
+
+
+def get_manager() -> Optional[ActorTokenManager]:
+    """Return the configured process-global manager, if any."""
+    return _manager
+
+
+def reset_manager() -> None:
+    """Clear the process-global manager (primarily for tests)."""
+    global _manager
+    _manager = None
+
+
+def actor_token() -> Optional[str]:
+    """Fresh managed actor token, or ``None`` when no managed identity is configured."""
+    if _manager is None:
+        return None
+    return _manager.token()
+
+
+async def actor_token_async() -> Optional[str]:
+    """Async variant of :func:`actor_token`."""
+    if _manager is None:
+        return None
+    return await _manager.token_async()

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -78,8 +78,10 @@ class _Context(MutableMapping[str, Any]):
     def __iter__(self) -> Iterator[str]:
         return iter(self._data())
 
-    def get(self, key: str, default: Any = None) -> Any:
-        return self._data().get(key, default)
+    def get(self, key: object, default: Any = None) -> Any:
+        if isinstance(key, str):
+            return self._data().get(key, default)
+        return default
 
     def __len__(self) -> int:
         return len(self._data())

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -78,6 +78,9 @@ class _Context(MutableMapping[str, Any]):
     def __iter__(self) -> Iterator[str]:
         return iter(self._data())
 
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._data().get(key, default)
+
     def __len__(self) -> int:
         return len(self._data())
 

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -301,11 +301,46 @@ def _inject_request_headers(request: Any) -> None:
     """Merge the current context's propagation headers into an outbound request.
 
     Strictly **additive**: a header already present on the request (for example the
-    ModelAPI/LLM provider's own ``Authorization`` API key) is never overwritten.
+    ModelAPI/LLM provider's own ``Authorization`` API key) is never overwritten. When the
+    request-local context carries no actor token but a managed actor-token lifecycle is
+    active (see :func:`aib.instrument_agent_identity`), this agent's minted actor token is
+    injected so each hop authenticates as itself even without a static token.
     """
     for header, value in ctx.to_headers().items():
         if header not in request.headers:
             request.headers[header] = value
+    if HEADER_ACTOR_TOKEN not in request.headers:
+        token = _managed_actor_token()
+        if token:
+            request.headers[HEADER_ACTOR_TOKEN] = _as_bearer(token)
+
+
+def _managed_actor_token() -> Optional[str]:
+    """Return the managed actor token, or ``None`` when no managed identity is active."""
+    from . import identity
+
+    manager = identity.get_manager()
+    if manager is None:
+        return None
+    return manager.token()
+
+
+async def _inject_request_headers_async(request: Any) -> None:
+    """Async variant of :func:`_inject_request_headers`.
+
+    Acquires the managed actor token without blocking the event loop on a refresh.
+    """
+    for header, value in ctx.to_headers().items():
+        if header not in request.headers:
+            request.headers[header] = value
+    if HEADER_ACTOR_TOKEN not in request.headers:
+        from . import identity
+
+        manager = identity.get_manager()
+        if manager is not None:
+            token = await manager.token_async()
+            if token:
+                request.headers[HEADER_ACTOR_TOKEN] = _as_bearer(token)
 
 
 def _refresh_actor_header_sync(request: Any) -> bool:
@@ -377,7 +412,7 @@ def instrument_httpx() -> None:
         return response
 
     async def _patched_async_send(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-        _inject_request_headers(request)
+        await _inject_request_headers_async(request)
         had_actor = HEADER_ACTOR_TOKEN in request.headers
         response = await async_send(self, request, *args, **kwargs)
         if response.status_code == 401 and had_actor and await _refresh_actor_header_async(request):

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -305,6 +305,38 @@ def _inject_request_headers(request: Any) -> None:
             request.headers[header] = value
 
 
+def _refresh_actor_header_sync(request: Any) -> bool:
+    """Replace the request's actor-token header with a freshly minted token.
+
+    Returns ``True`` when a managed identity produced a new token and the header was
+    updated (so the caller may replay), ``False`` otherwise.
+    """
+    from . import identity
+
+    manager = identity.get_manager()
+    if manager is None:
+        return False
+    token = manager.force_refresh()
+    if not token:
+        return False
+    request.headers[HEADER_ACTOR_TOKEN] = _as_bearer(token)
+    return True
+
+
+async def _refresh_actor_header_async(request: Any) -> bool:
+    """Async variant of :func:`_refresh_actor_header_sync`."""
+    from . import identity
+
+    manager = identity.get_manager()
+    if manager is None:
+        return False
+    token = await manager.force_refresh_async()
+    if not token:
+        return False
+    request.headers[HEADER_ACTOR_TOKEN] = _as_bearer(token)
+    return True
+
+
 def instrument_httpx() -> None:
     """Patch ``httpx`` so outbound requests carry the propagation headers.
 
@@ -312,6 +344,13 @@ def instrument_httpx() -> None:
     through ``send``, so patching ``send`` covers every transport — A2A, MCP, and
     ModelAPI clients alike — and injection happens at request time, so clients built once
     at startup still propagate per-request context. Idempotent.
+
+    When a managed actor-token identity is active (see :func:`aib.instrument_agent_identity`)
+    and an instrumented request that carried ``x-agent-authorization`` receives a ``401``,
+    the actor token is refreshed once and the request replayed a single time — covering the
+    case where the cached token expired or the credential rotated mid-flight. Requests with
+    no managed identity, no actor-token header, or a non-401 response behave exactly as
+    before (no retry).
 
     Injection is additive and reads from :data:`ctx`; in internet-facing deployments,
     callers are responsible for not placing sensitive tokens in :data:`ctx` for requests
@@ -328,11 +367,19 @@ def instrument_httpx() -> None:
 
     def _patched_sync_send(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
         _inject_request_headers(request)
-        return sync_send(self, request, *args, **kwargs)
+        had_actor = HEADER_ACTOR_TOKEN in request.headers
+        response = sync_send(self, request, *args, **kwargs)
+        if response.status_code == 401 and had_actor and _refresh_actor_header_sync(request):
+            response = sync_send(self, request, *args, **kwargs)
+        return response
 
     async def _patched_async_send(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
         _inject_request_headers(request)
-        return await async_send(self, request, *args, **kwargs)
+        had_actor = HEADER_ACTOR_TOKEN in request.headers
+        response = await async_send(self, request, *args, **kwargs)
+        if response.status_code == 401 and had_actor and await _refresh_actor_header_async(request):
+            response = await async_send(self, request, *args, **kwargs)
+        return response
 
     httpx.Client.send = _patched_sync_send  # ty: ignore[invalid-assignment]
     httpx.AsyncClient.send = _patched_async_send  # ty: ignore[invalid-assignment]

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -145,6 +145,12 @@ class AgentServer:
             actor_token=self.settings.security_actor_token or None,
             principal=self.settings.security_principal or None,
         )
+        # When no static actor token is configured, set up the managed actor-token
+        # lifecycle: if broker credentials are mounted (AGENT_AUTH_CLIENT_ID/SECRET/
+        # TOKEN_ENDPOINT), the runtime mints and refreshes this agent's actor token and
+        # injects it on outbound calls. Inert when credentials are absent.
+        if not self.settings.security_actor_token:
+            aib.instrument_agent_identity()
         aib.instrument_httpx()
 
         self._setup_routes()

--- a/pydantic-ai-server/tests/test_aib_client.py
+++ b/pydantic-ai-server/tests/test_aib_client.py
@@ -1,0 +1,165 @@
+"""Unit tests for the optional off-gateway broker client (access-check + token)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+import aib
+from aib import client as aib_client
+from aib import identity
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    for var in (
+        "AGENT_AUTH_BASE_URL",
+        "AGENT_AUTH_TOKEN_ENDPOINT",
+        "AGENT_AUTH_CLIENT_ID",
+        "AGENT_AUTH_CLIENT_SECRET",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    identity.reset_manager()
+    aib.ctx.replace({})
+    yield
+    identity.reset_manager()
+    aib.ctx.replace({})
+
+
+def _response(status, json_body, url="http://broker/api/access/check"):
+    return httpx.Response(status, json=json_body, request=httpx.Request("POST", url))
+
+
+class _Recorder:
+    """Captures POST calls and returns a scripted response."""
+
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+
+    def __call__(self, url, json=None, data=None, headers=None, timeout=None):
+        self.calls.append({"url": url, "json": json, "data": data, "headers": headers or {}})
+        return self._response
+
+
+def test_check_access_allowed(monkeypatch):
+    rec = _Recorder(_response(200, {"allowed": True, "reason": "ok", "actor": "agent-x"}))
+    monkeypatch.setattr(httpx, "post", rec)
+    c = aib_client.Client(base_url="http://broker")
+    decision = c.check_access("svc:db", "read")
+    assert decision.allowed is True
+    assert decision.actor == "agent-x"
+    assert rec.calls[0]["url"] == "http://broker/api/access/check"
+    assert rec.calls[0]["json"] == {"resource": "svc:db", "action": "read"}
+
+
+def test_check_access_includes_actor_token_from_ctx(monkeypatch):
+    rec = _Recorder(_response(200, {"allowed": True}))
+    monkeypatch.setattr(httpx, "post", rec)
+    aib.ctx.replace({"actor_token": "tok-123", "principal": "user@example.com"})
+    c = aib_client.Client(base_url="http://broker")
+    c.check_access("svc:db")
+    assert rec.calls[0]["json"]["actor_token"] == "tok-123"
+    assert rec.calls[0]["headers"]["x-principal"] == "user@example.com"
+
+
+def test_require_access_raises_on_deny(monkeypatch):
+    rec = _Recorder(_response(200, {"allowed": False, "reason": "not_permitted"}))
+    monkeypatch.setattr(httpx, "post", rec)
+    c = aib_client.Client(base_url="http://broker")
+    with pytest.raises(aib_client.AccessDenied) as excinfo:
+        c.require_access("svc:db")
+    assert excinfo.value.decision.reason == "not_permitted"
+
+
+def test_require_access_raises_reauth_on_recoverable_denial(monkeypatch):
+    rec = _Recorder(
+        _response(
+            200, {"allowed": False, "reason": "reauth_required", "reauth_url": "http://login"}
+        )
+    )
+    monkeypatch.setattr(httpx, "post", rec)
+    c = aib_client.Client(base_url="http://broker")
+    with pytest.raises(aib_client.ReauthenticationRequired) as excinfo:
+        c.require_access("svc:db")
+    assert excinfo.value.reauth_url == "http://login"
+
+
+def test_check_access_transport_error_is_unavailable(monkeypatch):
+    def _boom(*args, **kwargs):
+        raise httpx.ConnectError("down", request=httpx.Request("POST", "http://broker"))
+
+    monkeypatch.setattr(httpx, "post", _boom)
+    c = aib_client.Client(base_url="http://broker")
+    with pytest.raises(identity.AIBUnavailable):
+        c.check_access("svc:db")
+
+
+def test_exchange_token(monkeypatch):
+    rec = _Recorder(
+        _response(
+            200,
+            {"access_token": "delegated-xyz", "token_type": "Bearer", "expires_in": 600},
+            url="http://broker/oauth2/token",
+        )
+    )
+    monkeypatch.setattr(httpx, "post", rec)
+    c = aib_client.Client(base_url="http://broker")
+    result = c.exchange_token("subject-tok", audience="svc:db", scopes="read")
+    assert result.access_token == "delegated-xyz"
+    assert result.expires_in == 600
+    form = rec.calls[0]["data"]
+    assert form["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange"
+    assert form["subject_token"] == "subject-tok"
+    assert form["audience"] == "svc:db"
+    assert rec.calls[0]["url"] == "http://broker/oauth2/token"
+
+
+def test_get_token_uses_subject_token_from_ctx(monkeypatch):
+    rec = _Recorder(_response(200, {"access_token": "deleg"}, url="http://broker/oauth2/token"))
+    monkeypatch.setattr(httpx, "post", rec)
+    aib.ctx.replace({"subject_token": "user-jwt"})
+    c = aib_client.Client(base_url="http://broker")
+    result = c.get_token("svc:db")
+    assert result.access_token == "deleg"
+    assert rec.calls[0]["data"]["subject_token"] == "user-jwt"
+    assert rec.calls[0]["data"]["audience"] == "svc:db"
+
+
+def test_get_token_without_subject_is_unavailable(monkeypatch):
+    c = aib_client.Client(base_url="http://broker")
+    with pytest.raises(identity.AIBUnavailable):
+        c.get_token("svc:db")
+
+
+def test_token_endpoint_derived_from_base_url():
+    c = aib_client.Client(base_url="http://broker/")
+    assert c._token_endpoint == "http://broker/oauth2/token"
+
+
+def test_async_check_access_allowed(monkeypatch):
+    captured = {}
+
+    class _FakeAsyncClient:
+        def __init__(self, timeout=None):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, json=None, data=None, headers=None):
+            captured["url"] = url
+            captured["json"] = json
+            return _response(200, {"allowed": True, "actor": "agent-y"}, url=url)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    c = aib_client.AsyncClient(base_url="http://broker")
+    decision = asyncio.run(c.check_access("svc:db"))
+    assert decision.allowed is True
+    assert decision.actor == "agent-y"
+    assert captured["url"] == "http://broker/api/access/check"

--- a/pydantic-ai-server/tests/test_aib_identity.py
+++ b/pydantic-ai-server/tests/test_aib_identity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 
 import httpx
 import pytest
@@ -162,6 +163,96 @@ def test_force_refresh_reacquires(monkeypatch):
     assert mgr.token() == "tok-1"
     assert mgr.force_refresh() == "tok-2"
     assert len(rec.calls) == 2
+
+
+def test_credential_uses_file_secret(monkeypatch, tmp_path):
+    secret_file = tmp_path / "client_secret"
+    secret_file.write_text("file-secret")
+    rec = _Recorder([_resp(200, {"access_token": "tok", "expires_in": 300})])
+    monkeypatch.setattr(httpx, "post", rec)
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_SECRET", "env-secret")
+    mgr = identity.instrument_agent_identity(client_secret_file=str(secret_file))
+    assert mgr is not None
+    assert mgr.token() == "tok"
+    assert rec.calls[0]["client_secret"] == "file-secret"
+
+
+def test_credential_reloads_on_mtime_change(monkeypatch, tmp_path):
+    secret_file = tmp_path / "client_secret"
+    secret_file.write_text("secret-v1")
+    os.utime(secret_file, (1000, 1000))
+    rec = _Recorder(
+        [
+            _resp(200, {"access_token": "tok-1", "expires_in": 100}),
+            _resp(200, {"access_token": "tok-2", "expires_in": 100}),
+        ]
+    )
+    monkeypatch.setattr(httpx, "post", rec)
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    mgr = identity.instrument_agent_identity(
+        client_secret_file=str(secret_file), refresh_fraction=0.2
+    )
+    assert mgr is not None
+    assert mgr.token() == "tok-1"
+    assert rec.calls[0]["client_secret"] == "secret-v1"
+
+    secret_file.write_text("secret-v2")
+    os.utime(secret_file, (2000, 2000))
+    mgr._refresh_at = 0.0
+    assert mgr.token() == "tok-2"
+    assert rec.calls[1]["client_secret"] == "secret-v2"
+
+
+def test_credential_env_fallback_when_no_file(monkeypatch):
+    rec = _Recorder([_resp(200, {"access_token": "tok", "expires_in": 300})])
+    monkeypatch.setattr(httpx, "post", rec)
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_SECRET", "env-secret")
+    mgr = identity.instrument_agent_identity()
+    assert mgr is not None
+    assert mgr.token() == "tok"
+    assert rec.calls[0]["client_secret"] == "env-secret"
+
+
+def test_credential_missing_file_falls_back_to_env(monkeypatch, tmp_path):
+    rec = _Recorder([_resp(200, {"access_token": "tok", "expires_in": 300})])
+    monkeypatch.setattr(httpx, "post", rec)
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_SECRET", "env-secret")
+    missing = tmp_path / "does-not-exist"
+    mgr = identity.instrument_agent_identity(client_secret_file=str(missing))
+    assert mgr is not None
+    assert mgr.token() == "tok"
+    assert rec.calls[0]["client_secret"] == "env-secret"
+
+
+def test_401_reloads_credential_and_retries(monkeypatch, tmp_path):
+    secret_file = tmp_path / "client_secret"
+    secret_file.write_text("stale-secret")
+    os.utime(secret_file, (1000, 1000))
+
+    state = {"n": 0}
+
+    def _post(url, data=None, timeout=None):
+        state["n"] += 1
+        if state["n"] == 1:
+            secret_file.write_text("fresh-secret")
+            os.utime(secret_file, (2000, 2000))
+            return _resp(401, {"error": "invalid_client"})
+        return _resp(200, {"access_token": "tok", "expires_in": 300})
+
+    monkeypatch.setattr(httpx, "post", _post)
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    mgr = identity.instrument_agent_identity(client_secret_file=str(secret_file))
+    assert mgr is not None
+    assert mgr.token() == "tok"
+    assert state["n"] == 2
 
 
 def test_async_token_mints(monkeypatch):

--- a/pydantic-ai-server/tests/test_aib_identity.py
+++ b/pydantic-ai-server/tests/test_aib_identity.py
@@ -369,7 +369,9 @@ def test_outbound_non_401_does_not_retry(monkeypatch):
 
 
 def test_outbound_401_without_actor_header_does_not_retry(monkeypatch):
-    _configured_manager(monkeypatch)
+    mgr = _configured_manager(monkeypatch)
+    assert mgr is not None
+    monkeypatch.setattr(mgr, "token", lambda: None)  # no token to inject
     aib.instrument_httpx()
 
     seen = []
@@ -416,3 +418,77 @@ def test_outbound_async_401_refreshes_and_replays_once(monkeypatch):
     resp = asyncio.run(_run())
     assert resp.status_code == 200
     assert seen == ["Bearer stale-token", "Bearer fresh-async"]
+
+
+def test_outbound_injects_managed_actor_token_when_none_present(monkeypatch):
+    _configured_manager(monkeypatch, mint_token="minted-actor")
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request.headers.get("x-agent-authorization"))
+        return httpx.Response(200)
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    request = client.build_request("GET", "http://upstream/api")
+    response = client.send(request)
+
+    assert response.status_code == 200
+    assert seen == ["Bearer minted-actor"]
+
+
+def test_outbound_does_not_override_existing_actor_token(monkeypatch):
+    _configured_manager(monkeypatch, mint_token="minted-actor")
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request.headers.get("x-agent-authorization"))
+        return httpx.Response(200)
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    request = client.build_request("GET", "http://upstream/api")
+    request.headers["x-agent-authorization"] = "Bearer caller-supplied"
+    client.send(request)
+
+    assert seen == ["Bearer caller-supplied"]
+
+
+def test_outbound_no_manager_injects_nothing(monkeypatch):
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request.headers.get("x-agent-authorization"))
+        return httpx.Response(200)
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    request = client.build_request("GET", "http://upstream/api")
+    client.send(request)
+
+    assert seen == [None]
+
+
+def test_outbound_async_injects_managed_actor_token(monkeypatch):
+    mgr = _configured_manager(monkeypatch, mint_token="minted-async")
+    assert mgr is not None
+    mgr.token()  # prime the cache via the mocked sync grant so no async network call is made
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request.headers.get("x-agent-authorization"))
+        return httpx.Response(200)
+
+    async def _run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+            request = client.build_request("GET", "http://upstream/api")
+            return await client.send(request)
+
+    resp = asyncio.run(_run())
+    assert resp.status_code == 200
+    assert seen == ["Bearer minted-async"]

--- a/pydantic-ai-server/tests/test_aib_identity.py
+++ b/pydantic-ai-server/tests/test_aib_identity.py
@@ -23,8 +23,10 @@ def _reset(monkeypatch):
     ):
         monkeypatch.delenv(var, raising=False)
     identity.reset_manager()
+    aib.ctx.replace({})
     yield
     identity.reset_manager()
+    aib.ctx.replace({})
 
 
 class _Recorder:
@@ -287,3 +289,130 @@ def test_async_token_mints(monkeypatch):
     assert first == "atok"
     assert second == "atok"
     assert captured["calls"] == 1
+
+
+# --- reactive 401 retry in outbound httpx instrumentation ---------------------
+
+
+def _configured_manager(monkeypatch, mint_token="fresh-token"):
+    """Configure a managed identity whose force_refresh mints ``mint_token``."""
+
+    def _post(url, data=None, timeout=None):
+        return _resp(200, {"access_token": mint_token, "expires_in": 300})
+
+    monkeypatch.setattr(httpx, "post", _post)
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_SECRET", "sec")
+    return identity.instrument_agent_identity()
+
+
+def test_outbound_401_refreshes_and_replays_once(monkeypatch):
+    _configured_manager(monkeypatch, mint_token="fresh-token")
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request.headers.get("x-agent-authorization"))
+        if len(seen) == 1:
+            return httpx.Response(401)
+        return httpx.Response(200)
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    request = client.build_request("GET", "http://upstream/api")
+    request.headers["x-agent-authorization"] = "Bearer stale-token"
+    response = client.send(request)
+
+    assert response.status_code == 200
+    assert len(seen) == 2  # one retry only
+    assert seen[0] == "Bearer stale-token"
+    assert seen[1] == "Bearer fresh-token"  # replayed with the refreshed token
+
+
+def test_outbound_401_no_manager_does_not_retry(monkeypatch):
+    identity.reset_manager()
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request)
+        return httpx.Response(401)
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    request = client.build_request("GET", "http://upstream/api")
+    request.headers["x-agent-authorization"] = "Bearer stale-token"
+    response = client.send(request)
+
+    assert response.status_code == 401
+    assert len(seen) == 1  # no retry without a managed identity
+
+
+def test_outbound_non_401_does_not_retry(monkeypatch):
+    _configured_manager(monkeypatch)
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request)
+        return httpx.Response(500)
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    request = client.build_request("GET", "http://upstream/api")
+    request.headers["x-agent-authorization"] = "Bearer stale-token"
+    response = client.send(request)
+
+    assert response.status_code == 500
+    assert len(seen) == 1  # only 401 triggers a retry
+
+
+def test_outbound_401_without_actor_header_does_not_retry(monkeypatch):
+    _configured_manager(monkeypatch)
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request)
+        return httpx.Response(401)
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    request = client.build_request("GET", "http://upstream/api")
+    response = client.send(request)
+
+    assert response.status_code == 401
+    assert len(seen) == 1  # no actor token was carried, so no refresh/replay
+
+
+def test_outbound_async_401_refreshes_and_replays_once(monkeypatch):
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_SECRET", "sec")
+    mgr = identity.instrument_agent_identity()
+    assert mgr is not None
+
+    async def _fake_refresh():
+        return "fresh-async"
+
+    monkeypatch.setattr(mgr, "force_refresh_async", _fake_refresh)
+    aib.instrument_httpx()
+
+    seen = []
+
+    def _handler(request):
+        seen.append(request.headers.get("x-agent-authorization"))
+        if len(seen) == 1:
+            return httpx.Response(401)
+        return httpx.Response(200)
+
+    async def _run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+            request = client.build_request("GET", "http://upstream/api")
+            request.headers["x-agent-authorization"] = "Bearer stale-token"
+            return await client.send(request)
+
+    resp = asyncio.run(_run())
+    assert resp.status_code == 200
+    assert seen == ["Bearer stale-token", "Bearer fresh-async"]

--- a/pydantic-ai-server/tests/test_aib_identity.py
+++ b/pydantic-ai-server/tests/test_aib_identity.py
@@ -1,0 +1,198 @@
+"""Unit tests for the managed actor-token lifecycle (acquire + refresh + fail-closed)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+import aib
+from aib import identity
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    """Isolate each test: clear env + the process-global manager."""
+    for var in (
+        "AGENT_AUTH_TOKEN_ENDPOINT",
+        "AGENT_AUTH_ISSUER",
+        "AGENT_AUTH_CLIENT_ID",
+        "AGENT_AUTH_CLIENT_SECRET",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    identity.reset_manager()
+    yield
+    identity.reset_manager()
+
+
+class _Recorder:
+    """Records grant POSTs and returns scripted responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def __call__(self, url, data=None, timeout=None):
+        self.calls.append(dict(data or {}))
+        if len(self._responses) > 1:
+            return self._responses.pop(0)
+        return self._responses[0]
+
+
+def _resp(status, json_body):
+    return httpx.Response(
+        status, json=json_body, request=httpx.Request("POST", "http://b/oauth2/token")
+    )
+
+
+def _manager(monkeypatch, recorder, *, refresh_fraction=0.2):
+    monkeypatch.setattr(httpx, "post", recorder)
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "kaos-agent-default-researcher")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_SECRET", "s3cr3t")
+    return identity.instrument_agent_identity(refresh_fraction=refresh_fraction)
+
+
+def test_no_credentials_is_inert(monkeypatch):
+    mgr = identity.instrument_agent_identity()
+    assert mgr is None
+    assert identity.get_manager() is None
+    assert aib.actor_token() is None
+
+
+def test_token_endpoint_derived_from_issuer(monkeypatch):
+    monkeypatch.setenv("AGENT_AUTH_ISSUER", "http://broker/")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_SECRET", "sec")
+    mgr = identity.instrument_agent_identity()
+    assert mgr is not None
+    assert mgr._token_endpoint == "http://broker/oauth2/token"
+
+
+def test_first_call_mints_and_caches(monkeypatch):
+    rec = _Recorder([_resp(200, {"access_token": "tok-1", "expires_in": 300})])
+    _manager(monkeypatch, rec)
+    assert aib.actor_token() == "tok-1"
+    # Second call within TTL serves the cache without re-POSTing.
+    assert aib.actor_token() == "tok-1"
+    assert len(rec.calls) == 1
+    assert rec.calls[0]["grant_type"] == "client_credentials"
+    assert rec.calls[0]["client_id"] == "kaos-agent-default-researcher"
+    assert rec.calls[0]["client_secret"] == "s3cr3t"
+
+
+def test_refresh_ahead_reacquires_past_threshold(monkeypatch):
+    rec = _Recorder(
+        [
+            _resp(200, {"access_token": "tok-1", "expires_in": 100}),
+            _resp(200, {"access_token": "tok-2", "expires_in": 100}),
+        ]
+    )
+    mgr = _manager(monkeypatch, rec, refresh_fraction=0.2)
+    assert mgr.token() == "tok-1"
+    # Simulate crossing the refresh-ahead threshold (80% of lifetime elapsed).
+    mgr._refresh_at = 0.0
+    assert mgr.token() == "tok-2"
+    assert len(rec.calls) == 2
+
+
+def test_concurrent_callers_single_flight(monkeypatch):
+    rec = _Recorder([_resp(200, {"access_token": "tok", "expires_in": 300})])
+    mgr = _manager(monkeypatch, rec)
+
+    results = []
+
+    def _worker():
+        results.append(mgr.token())
+
+    import threading
+
+    threads = [threading.Thread(target=_worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results == ["tok"] * 8
+    assert len(rec.calls) == 1  # single-flighted
+
+
+def test_endpoint_failure_fails_closed(monkeypatch):
+    def _boom(url, data=None, timeout=None):
+        raise httpx.ConnectError("broker down", request=httpx.Request("POST", url))
+
+    mgr = _manager(monkeypatch, _Recorder([]))
+    monkeypatch.setattr(httpx, "post", _boom)
+    with pytest.raises(identity.AIBUnavailable):
+        mgr.token()
+
+
+def test_missing_access_token_fails_closed(monkeypatch):
+    rec = _Recorder([_resp(200, {"expires_in": 300})])
+    mgr = _manager(monkeypatch, rec)
+    with pytest.raises(identity.AIBUnavailable):
+        mgr.token()
+
+
+def test_valid_cache_survives_refresh_failure(monkeypatch):
+    rec = _Recorder([_resp(200, {"access_token": "tok-1", "expires_in": 100})])
+    mgr = _manager(monkeypatch, rec, refresh_fraction=0.2)
+    assert mgr.token() == "tok-1"
+
+    # Past refresh-ahead but still within lifetime; broker now fails.
+    mgr._refresh_at = 0.0
+
+    def _boom(url, data=None, timeout=None):
+        raise httpx.ConnectError("broker down", request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx, "post", _boom)
+    # Still-valid cached token is served rather than failing the request.
+    assert mgr.token() == "tok-1"
+
+
+def test_force_refresh_reacquires(monkeypatch):
+    rec = _Recorder(
+        [
+            _resp(200, {"access_token": "tok-1", "expires_in": 300}),
+            _resp(200, {"access_token": "tok-2", "expires_in": 300}),
+        ]
+    )
+    mgr = _manager(monkeypatch, rec)
+    assert mgr.token() == "tok-1"
+    assert mgr.force_refresh() == "tok-2"
+    assert len(rec.calls) == 2
+
+
+def test_async_token_mints(monkeypatch):
+    captured = {"calls": 0}
+
+    class _FakeAsyncClient:
+        def __init__(self, timeout=None):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, data=None):
+            captured["calls"] += 1
+            return _resp(200, {"access_token": "atok", "expires_in": 300})
+
+    monkeypatch.setenv("AGENT_AUTH_TOKEN_ENDPOINT", "http://broker/oauth2/token")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("AGENT_AUTH_CLIENT_SECRET", "sec")
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    identity.instrument_agent_identity()
+
+    async def _run():
+        first = await aib.actor_token_async()
+        second = await aib.actor_token_async()
+        return first, second
+
+    first, second = asyncio.run(_run())
+    assert first == "atok"
+    assert second == "atok"
+    assert captured["calls"] == 1


### PR DESCRIPTION
Adds a self-contained actor-token lifecycle to the AIB SDK and wires it into the agent runtime and operator.

- Managed `ActorTokenManager`: client_credentials mint, refresh-ahead, single-flight, bounded backoff, fail-closed (serves a still-valid cache on refresh failure).
- Rotatable client secret sourced file-first from the mounted `AGENT_AUTH_CLIENT_SECRET_FILE` (mtime reload + env fallback; reload-and-retry on invalid_client).
- Reactive single 401 refresh-and-replay on outbound httpx (sync + async).
- Outbound injection of the managed actor token when none is present, additive, non-blocking on the async path.
- Optional off-gateway `Client`/`AsyncClient` over /api/access/check and /oauth2/token (structured AccessDecision + RFC 8693 token exchange).
- Operator projects the per-agent credential Secret read-only at /var/run/aib and exports `AGENT_AUTH_CLIENT_SECRET_FILE`.

Stacked on `feat/crd-identity-override`.