### PR TITLE
PR-ADR-KAOS-10: Network policy, gateway routing, and TLS termination

### DIFF
--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -580,6 +580,13 @@ def _build_auth_operator_args(
     user_audience: str = "",
     user_jwks_uri: str = "",
     ext_proc_url: str = "",
+    network_policy: bool = True,
+    gateway_routing: bool = False,
+    gateway_host: str = "",
+    tls_mode: str = "",
+    tls_issuer_name: str = "",
+    tls_issuer_kind: str = "ClusterIssuer",
+    tls_secret_name: str = "",
 ) -> list[str]:
     """Build the operator Helm --set arguments that enable agent-auth wiring.
 
@@ -588,6 +595,11 @@ def _build_auth_operator_args(
     are appended only when a user issuer is supplied, keeping agent-only and
     autonomous-only installs unchanged. The token-exchange ext_proc backend
     (``security.agentAuth.extProcUrl``) is appended only when supplied.
+
+    Bypass-prevention and transport-security arguments are appended too:
+    NetworkPolicy is on unless explicitly disabled, gateway routing and host are
+    set when requested, and ``security.tls.*`` is configured when a TLS mode is
+    supplied.
     """
     args: list[str] = []
     args.extend(["--set", f"security.agentAuth.extAuthzUrl={ext_authz_url}"])
@@ -606,6 +618,24 @@ def _build_auth_operator_args(
         args.extend(["--set", f"security.userAuth.audience={user_audience}"])
     if user_jwks_uri:
         args.extend(["--set", f"security.userAuth.jwksUri={user_jwks_uri}"])
+    if not network_policy:
+        args.extend(["--set", "security.networkPolicy.enabled=false"])
+    if gateway_routing:
+        args.extend(["--set", "security.gatewayRouting.enabled=true"])
+    if gateway_host:
+        args.extend(["--set", f"security.gatewayHost={gateway_host}"])
+    if tls_mode:
+        args.extend(["--set", f"security.tls.mode={tls_mode}"])
+        if tls_issuer_name:
+            args.extend(
+                ["--set", f"security.tls.certManager.issuerRef.name={tls_issuer_name}"]
+            )
+        if tls_issuer_kind:
+            args.extend(
+                ["--set", f"security.tls.certManager.issuerRef.kind={tls_issuer_kind}"]
+            )
+        if tls_secret_name:
+            args.extend(["--set", f"security.tls.secretName={tls_secret_name}"])
     return args
 
 
@@ -1088,6 +1118,13 @@ def install_command(
     keycloak_chart_path: str | None = None,
     user_auth_issuer: str | None = None,
     user_auth_audience: str = DEFAULT_USER_AUTH_AUDIENCE,
+    network_policy: bool = True,
+    gateway_routing: bool = False,
+    gateway_host: str | None = None,
+    tls_mode: str | None = None,
+    tls_issuer_name: str | None = None,
+    tls_issuer_kind: str = "ClusterIssuer",
+    tls_secret_name: str | None = None,
 ) -> None:
     """Install the KAOS operator using Helm."""
     if not check_helm_installed():
@@ -1322,6 +1359,13 @@ def install_command(
                     if token_exchange
                     else ""
                 ),
+                network_policy=network_policy,
+                gateway_routing=gateway_routing,
+                gateway_host=gateway_host or "",
+                tls_mode=tls_mode or "",
+                tls_issuer_name=tls_issuer_name or "",
+                tls_issuer_kind=tls_issuer_kind,
+                tls_secret_name=tls_secret_name or "",
             )
         )
 

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -181,6 +181,46 @@ def install(
         "--user-auth-audience",
         help="Expected audience claim for user subject tokens.",
     ),
+    network_policy: bool = typer.Option(
+        True,
+        "--network-policy/--no-network-policy",
+        help="Generate NetworkPolicies that deny direct workload-to-workload traffic "
+        "so the Envoy Gateway cannot be bypassed. Effective only with --auth-enabled.",
+    ),
+    gateway_routing: bool = typer.Option(
+        False,
+        "--gateway-routing/--no-gateway-routing",
+        help="Route internal agent->ModelAPI/MCP/peer traffic through the gateway so "
+        "gateway authentication and authorization apply to it. Effective only with "
+        "--auth-enabled.",
+    ),
+    gateway_host: str | None = typer.Option(
+        None,
+        "--gateway-host",
+        help="In-cluster host[:port] of the Envoy Gateway used for gateway routing. "
+        "Defaults to the Gateway resource's status address.",
+    ),
+    tls_mode: str | None = typer.Option(
+        None,
+        "--tls-mode",
+        help="Enable HTTPS termination on the gateway. One of: selfSigned, "
+        "certManager, provided.",
+    ),
+    tls_issuer_name: str | None = typer.Option(
+        None,
+        "--tls-issuer-name",
+        help="cert-manager Issuer/ClusterIssuer name (with --tls-mode certManager).",
+    ),
+    tls_issuer_kind: str = typer.Option(
+        "ClusterIssuer",
+        "--tls-issuer-kind",
+        help="cert-manager issuer kind: Issuer or ClusterIssuer.",
+    ),
+    tls_secret_name: str | None = typer.Option(
+        None,
+        "--tls-secret-name",
+        help="Existing kubernetes.io/tls Secret name (with --tls-mode provided).",
+    ),
 ) -> None:
     """Install the KAOS operator using Helm."""
     # Default to signoz if flag provided without value
@@ -218,6 +258,13 @@ def install(
         keycloak_chart_path=keycloak_chart_path,
         user_auth_issuer=user_auth_issuer,
         user_auth_audience=user_auth_audience,
+        network_policy=network_policy,
+        gateway_routing=gateway_routing,
+        gateway_host=gateway_host,
+        tls_mode=tls_mode,
+        tls_issuer_name=tls_issuer_name,
+        tls_issuer_kind=tls_issuer_kind,
+        tls_secret_name=tls_secret_name,
     )
 
 

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -1022,6 +1022,107 @@ class TestAuthWiring:
         )
         assert "security.agentAuth.extProcUrl=" not in " ".join(args)
 
+    def test_build_auth_operator_args_network_policy_default_on(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+        )
+        # NetworkPolicy is enabled by default in the chart, so no override is emitted.
+        assert "security.networkPolicy.enabled=false" not in " ".join(args)
+
+    def test_build_auth_operator_args_disable_network_policy(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            network_policy=False,
+        )
+        assert "security.networkPolicy.enabled=false" in " ".join(args)
+
+    def test_build_auth_operator_args_gateway_routing_and_host(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            gateway_routing=True,
+            gateway_host="172.18.0.200",
+        )
+        joined = " ".join(args)
+        assert "security.gatewayRouting.enabled=true" in joined
+        assert "security.gatewayHost=172.18.0.200" in joined
+
+    def test_build_auth_operator_args_omits_routing_when_default(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+        )
+        joined = " ".join(args)
+        assert "security.gatewayRouting.enabled=true" not in joined
+        assert "security.gatewayHost=" not in joined
+
+    def test_build_auth_operator_args_tls_self_signed(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            tls_mode="selfSigned",
+        )
+        joined = " ".join(args)
+        assert "security.tls.mode=selfSigned" in joined
+        assert "security.tls.certManager.issuerRef.name=" not in joined
+
+    def test_build_auth_operator_args_tls_cert_manager(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            tls_mode="certManager",
+            tls_issuer_name="letsencrypt-prod",
+            tls_issuer_kind="ClusterIssuer",
+        )
+        joined = " ".join(args)
+        assert "security.tls.mode=certManager" in joined
+        assert "security.tls.certManager.issuerRef.name=letsencrypt-prod" in joined
+        assert "security.tls.certManager.issuerRef.kind=ClusterIssuer" in joined
+
+    def test_build_auth_operator_args_tls_provided(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            tls_mode="provided",
+            tls_secret_name="my-gateway-tls",
+        )
+        joined = " ".join(args)
+        assert "security.tls.mode=provided" in joined
+        assert "security.tls.secretName=my-gateway-tls" in joined
+
+    def test_build_auth_operator_args_omits_tls_when_unset(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+        )
+        assert "security.tls.mode=" not in " ".join(args)
+
     def test_default_ext_proc_url(self):
         from kaos_cli.install import _default_ext_proc_url
 

--- a/operator/chart/templates/gateway-tls.yaml
+++ b/operator/chart/templates/gateway-tls.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.createGateway }}
+{{- with .Values.security.tls }}
+{{- $gatewayName := $.Values.gatewayAPI.gatewayName | default "kaos-gateway" }}
+{{- $secretName := printf "%s-tls" $gatewayName }}
+{{- $host := $.Values.security.gatewayHost | default $gatewayName }}
+{{- $cn := splitList ":" $host | first }}
+{{- if eq .mode "selfSigned" }}
+{{- $existing := lookup "v1" "Secret" $.Release.Namespace $secretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+type: kubernetes.io/tls
+data:
+{{- if and $existing $existing.data }}
+  # Reuse the existing certificate so helm upgrade does not churn the cert.
+  tls.crt: {{ index $existing.data "tls.crt" }}
+  tls.key: {{ index $existing.data "tls.key" }}
+{{- else }}
+{{- $cert := genSelfSignedCert $cn nil (list $cn) 3650 }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+{{- end }}
+{{- else if eq .mode "certManager" }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  secretName: {{ $secretName }}
+  dnsNames:
+  - {{ $cn | quote }}
+  issuerRef:
+    name: {{ required "security.tls.certManager.issuerRef.name is required when security.tls.mode is certManager" .certManager.issuerRef.name }}
+    kind: {{ .certManager.issuerRef.kind | default "ClusterIssuer" }}
+    group: cert-manager.io
+{{- end }}
+{{- end }}
+{{- end }}

--- a/operator/chart/templates/gateway.yaml
+++ b/operator/chart/templates/gateway.yaml
@@ -15,4 +15,19 @@ spec:
     allowedRoutes:
       namespaces:
         from: All
+{{- with .Values.security.tls }}
+{{- if .mode }}
+  - name: https
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: {{ if eq .mode "provided" }}{{ required "security.tls.secretName is required when security.tls.mode is provided" .secretName }}{{ else }}{{ $.Values.gatewayAPI.gatewayName | default "kaos-gateway" }}-tls{{ end }}
+    allowedRoutes:
+      namespaces:
+        from: All
+{{- end }}
+{{- end }}
 {{- end }}

--- a/operator/chart/templates/kaos-operator-rbac.yaml
+++ b/operator/chart/templates/kaos-operator-rbac.yaml
@@ -75,6 +75,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - kaos.tools
   resources:
   - agents

--- a/operator/chart/templates/kaos-operator-rbac.yaml
+++ b/operator/chart/templates/kaos-operator-rbac.yaml
@@ -52,6 +52,14 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - httproutes
   verbs:
   - create

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -55,6 +55,21 @@ data:
   SECURITY_USER_AUTH_JWKS_URI: {{ .jwksUri | quote }}
   {{- end }}
   {{- end }}
+  # Bypass-prevention and gateway-routing configuration. These only take effect
+  # when security is operational (agentAuth.extAuthzUrl set).
+  SECURITY_OPERATOR_NAMESPACE: {{ $.Release.Namespace | quote }}
+  {{- if .gatewayNamespace }}
+  SECURITY_GATEWAY_NAMESPACE: {{ .gatewayNamespace | quote }}
+  {{- end }}
+  {{- if .gatewayHost }}
+  SECURITY_GATEWAY_HOST: {{ .gatewayHost | quote }}
+  {{- end }}
+  {{- if and .networkPolicy (not .networkPolicy.enabled) }}
+  SECURITY_NETWORK_POLICY_DISABLED: "true"
+  {{- end }}
+  {{- if and .gatewayRouting .gatewayRouting.enabled }}
+  SECURITY_GATEWAY_ROUTING_ENABLED: "true"
+  {{- end }}
   {{- end }}
   # Global telemetry configuration (defaults for all components)
   {{- if .Values.telemetry.enabled }}

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -113,6 +113,26 @@ security:
     # it is derived from the issuer using the standard OIDC realm path
     # (<issuer>/protocol/openid-connect/certs).
     jwksUri: ""
+  # gatewayNamespace is the namespace of the Envoy Gateway data plane. It is the
+  # ingress source allowed by generated NetworkPolicies so the gateway can reach
+  # protected workloads.
+  gatewayNamespace: "envoy-gateway-system"
+  # gatewayHost is the in-cluster host[:port] of the Envoy Gateway used when
+  # gatewayRouting is enabled. When empty, the operator resolves it from the
+  # Gateway resource's status address.
+  gatewayHost: ""
+  # networkPolicy denies direct workload-to-workload traffic so the gateway
+  # cannot be bypassed. It only takes effect when security is operational
+  # (agentAuth.extAuthzUrl set) and the cluster CNI enforces NetworkPolicy.
+  networkPolicy:
+    enabled: true
+  # gatewayRouting injects gateway-routed endpoint URLs into agents so internal
+  # agent->ModelAPI/MCP/peer traffic flows through the gateway (where jwt_authn,
+  # ext_authz and ext_proc apply) rather than directly to the workload Service.
+  # Off by default; enable together with networkPolicy to make the gateway the
+  # only application path between workloads.
+  gatewayRouting:
+    enabled: false
 serviceAccount:
   annotations: {}
   automount: true

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -133,6 +133,23 @@ security:
   # only application path between workloads.
   gatewayRouting:
     enabled: false
+  # tls configures HTTPS termination on the Gateway's external boundary. When
+  # mode is empty, only the HTTP listener is created and behavior is unchanged.
+  tls:
+    # mode selects how the serving certificate is provided:
+    #   ""           - disabled (HTTP only)
+    #   selfSigned   - the chart generates a self-signed kubernetes.io/tls Secret
+    #   certManager  - the chart creates a cert-manager Certificate (issuerRef below)
+    #   provided     - reference an existing kubernetes.io/tls Secret (secretName below)
+    mode: ""
+    certManager:
+      issuerRef:
+        # name of the cert-manager Issuer/ClusterIssuer (mode=certManager).
+        name: ""
+        # kind is Issuer or ClusterIssuer.
+        kind: ClusterIssuer
+    # secretName is the existing kubernetes.io/tls Secret to use (mode=provided).
+    secretName: ""
 serviceAccount:
   annotations: {}
   automount: true

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -64,6 +64,14 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - httproutes
   verbs:
   - create

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -105,3 +105,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -212,6 +212,11 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}
 
+	// When gateway routing is enabled, repoint internal endpoints at the gateway so
+	// agent->ModelAPI/MCP/peer traffic traverses jwt_authn/ext_authz/ext_proc rather
+	// than reaching the workload Service directly (which NetworkPolicy denies).
+	r.applyGatewayRouting(ctx, agent, modelapi, mcpServers, peerAgents, log)
+
 	// Create or update Deployment
 	deployment := &appsv1.Deployment{}
 	deploymentName := fmt.Sprintf("agent-%s", agent.Name)
@@ -377,6 +382,50 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// applyGatewayRouting rewrites the resolved ModelAPI, MCP, and peer endpoints to
+// gateway-routed URLs when gateway routing is enabled. All referenced resources
+// live in the agent's namespace, so each URL becomes
+// http://<gatewayHost>/<namespace>/<type>/<name>, which the per-resource
+// HTTPRoute matches and rewrites back to the workload. The gateway host is taken
+// from explicit config or, failing that, the Gateway resource's status address;
+// when neither is available the direct Service URLs are left untouched so
+// connectivity is never silently broken.
+func (r *AgentReconciler) applyGatewayRouting(
+	ctx context.Context,
+	agent *kaosv1alpha1.Agent,
+	modelapi *kaosv1alpha1.ModelAPI,
+	mcpServers map[string]string,
+	peerAgents map[string]string,
+	log logr.Logger,
+) {
+	secCfg := security.GetConfig()
+	if !secCfg.GatewayRoutingEnabled() {
+		return
+	}
+
+	host := strings.TrimSpace(secCfg.GatewayHost)
+	if host == "" {
+		resolved, err := gateway.StatusAddress(ctx, r.Client)
+		if err != nil {
+			log.Error(err, "failed to resolve gateway address for routing; using direct endpoints")
+			return
+		}
+		host = resolved
+	}
+	if host == "" {
+		log.Info("gateway routing enabled but no gateway host resolved; using direct endpoints")
+		return
+	}
+
+	modelapi.Status.Endpoint = gateway.GatewayEndpoint(host, agent.Namespace, gateway.ResourceTypeModelAPI, modelapi.Name)
+	for name := range mcpServers {
+		mcpServers[name] = gateway.GatewayEndpoint(host, agent.Namespace, gateway.ResourceTypeMCP, name)
+	}
+	for name := range peerAgents {
+		peerAgents[name] = gateway.GatewayEndpoint(host, agent.Namespace, gateway.ResourceTypeAgent, name)
+	}
 }
 
 // constructDeployment creates a Deployment for the Agent

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -338,6 +338,14 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			if err := security.ReconcileEnvoyExtensionPolicy(ctx, r.Client, r.Scheme, agent, policyParams, secCfg, log); err != nil {
 				log.Error(err, "failed to reconcile EnvoyExtensionPolicy")
 			}
+			if err := security.ReconcileNetworkPolicy(ctx, r.Client, r.Scheme, agent, security.NetworkPolicyParams{
+				Name:        routeName,
+				Namespace:   agent.Namespace,
+				PodSelector: map[string]string{"app": "agent", "agent": agent.Name},
+				Labels:      map[string]string{"app": "agent", "agent": agent.Name},
+			}, secCfg, log); err != nil {
+				log.Error(err, "failed to reconcile NetworkPolicy")
+			}
 		}
 	}
 

--- a/operator/controllers/agent_gateway_routing_test.go
+++ b/operator/controllers/agent_gateway_routing_test.go
@@ -1,0 +1,81 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kaosv1alpha1 "github.com/axsaucedo/kaos/operator/api/v1alpha1"
+)
+
+func routingModelAPI(namespace, name string) *kaosv1alpha1.ModelAPI {
+	m := &kaosv1alpha1.ModelAPI{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+	m.Status.Endpoint = "http://modelapi-" + name + "." + namespace + ".svc.cluster.local:8000"
+	return m
+}
+
+func TestApplyGatewayRoutingRepointsToGateway(t *testing.T) {
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "svc:9191")
+	t.Setenv("SECURITY_GATEWAY_ROUTING_ENABLED", "true")
+	t.Setenv("SECURITY_GATEWAY_HOST", "172.18.0.4:80")
+
+	agent := newAgent("demo", "researcher")
+	modelapi := routingModelAPI("demo", "gpt")
+	mcpServers := map[string]string{"github": "http://mcp-github.demo.svc.cluster.local:8000"}
+	peerAgents := map[string]string{"helper": "http://agent-helper.demo.svc.cluster.local:8000"}
+
+	r := &AgentReconciler{}
+	r.applyGatewayRouting(context.Background(), agent, modelapi, mcpServers, peerAgents, logr.Discard())
+
+	if got, want := modelapi.Status.Endpoint, "http://172.18.0.4:80/demo/modelapi/gpt"; got != want {
+		t.Errorf("modelapi endpoint = %q, want %q", got, want)
+	}
+	if got, want := mcpServers["github"], "http://172.18.0.4:80/demo/mcp/github"; got != want {
+		t.Errorf("mcp endpoint = %q, want %q", got, want)
+	}
+	if got, want := peerAgents["helper"], "http://172.18.0.4:80/demo/agent/helper"; got != want {
+		t.Errorf("peer endpoint = %q, want %q", got, want)
+	}
+}
+
+func TestApplyGatewayRoutingDisabledLeavesDirectURLs(t *testing.T) {
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "svc:9191")
+	t.Setenv("SECURITY_GATEWAY_ROUTING_ENABLED", "")
+	t.Setenv("SECURITY_GATEWAY_HOST", "172.18.0.4:80")
+
+	agent := newAgent("demo", "researcher")
+	modelapi := routingModelAPI("demo", "gpt")
+	direct := modelapi.Status.Endpoint
+	mcpServers := map[string]string{"github": "http://mcp-github.demo.svc.cluster.local:8000"}
+
+	r := &AgentReconciler{}
+	r.applyGatewayRouting(context.Background(), agent, modelapi, mcpServers, map[string]string{}, logr.Discard())
+
+	if modelapi.Status.Endpoint != direct {
+		t.Errorf("modelapi endpoint changed while routing disabled: %q", modelapi.Status.Endpoint)
+	}
+	if mcpServers["github"] != "http://mcp-github.demo.svc.cluster.local:8000" {
+		t.Errorf("mcp endpoint changed while routing disabled: %q", mcpServers["github"])
+	}
+}
+
+func TestApplyGatewayRoutingNoHostKeepsDirectURLs(t *testing.T) {
+	t.Setenv("SECURITY_AGENT_AUTH_EXT_AUTHZ_URL", "svc:9191")
+	t.Setenv("SECURITY_GATEWAY_ROUTING_ENABLED", "true")
+	t.Setenv("SECURITY_GATEWAY_HOST", "")
+	// No GATEWAY_NAME configured, so StatusAddress returns "" and routing is skipped.
+	t.Setenv("GATEWAY_NAME", "")
+
+	modelapi := routingModelAPI("demo", "gpt")
+	direct := modelapi.Status.Endpoint
+
+	r := &AgentReconciler{}
+	r.applyGatewayRouting(context.Background(), newAgent("demo", "researcher"), modelapi,
+		map[string]string{}, map[string]string{}, logr.Discard())
+
+	if modelapi.Status.Endpoint != direct {
+		t.Errorf("modelapi endpoint changed without a resolvable host: %q", modelapi.Status.Endpoint)
+	}
+}

--- a/operator/controllers/mcpserver_controller.go
+++ b/operator/controllers/mcpserver_controller.go
@@ -231,6 +231,14 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err := security.ReconcileEnvoyExtensionPolicy(ctx, r.Client, r.Scheme, mcpserver, policyParams, secCfg, log); err != nil {
 			log.Error(err, "failed to reconcile EnvoyExtensionPolicy")
 		}
+		if err := security.ReconcileNetworkPolicy(ctx, r.Client, r.Scheme, mcpserver, security.NetworkPolicyParams{
+			Name:        routeName,
+			Namespace:   mcpserver.Namespace,
+			PodSelector: map[string]string{"app": "mcpserver", "mcpserver": mcpserver.Name},
+			Labels:      map[string]string{"app": "mcpserver", "mcpserver": mcpserver.Name},
+		}, secCfg, log); err != nil {
+			log.Error(err, "failed to reconcile NetworkPolicy")
+		}
 	}
 
 	// Copy deployment status for rolling update visibility

--- a/operator/controllers/modelapi_controller.go
+++ b/operator/controllers/modelapi_controller.go
@@ -305,6 +305,14 @@ func (r *ModelAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if err := security.ReconcileEnvoyExtensionPolicy(ctx, r.Client, r.Scheme, modelapi, policyParams, secCfg, log); err != nil {
 			log.Error(err, "failed to reconcile EnvoyExtensionPolicy")
 		}
+		if err := security.ReconcileNetworkPolicy(ctx, r.Client, r.Scheme, modelapi, security.NetworkPolicyParams{
+			Name:        routeName,
+			Namespace:   modelapi.Namespace,
+			PodSelector: map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
+			Labels:      map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
+		}, secCfg, log); err != nil {
+			log.Error(err, "failed to reconcile NetworkPolicy")
+		}
 	}
 
 	// Copy deployment status for rolling update visibility

--- a/operator/main.go
+++ b/operator/main.go
@@ -30,6 +30,7 @@ var (
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 //+kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=securitypolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=envoyextensionpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/operator/main.go
+++ b/operator/main.go
@@ -32,6 +32,7 @@ var (
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=securitypolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=envoyextensionpolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))

--- a/operator/pkg/gateway/gateway.go
+++ b/operator/pkg/gateway/gateway.go
@@ -79,6 +79,31 @@ func GatewayEndpoint(gatewayHost string, namespace string, resourceType Resource
 	return fmt.Sprintf("http://%s/%s/%s/%s", gatewayHost, namespace, resourceType, resourceName)
 }
 
+// StatusAddress returns the first status address reported by the configured
+// Gateway resource, or an empty string when the Gateway is not found or has no
+// address yet. It lets the operator discover the in-cluster gateway host
+// (e.g. the LoadBalancer/MetalLB address) without it being configured explicitly.
+func StatusAddress(ctx context.Context, c client.Client) (string, error) {
+	config := GetConfig()
+	if config.GatewayName == "" {
+		return "", nil
+	}
+	gw := &gatewayv1.Gateway{}
+	err := c.Get(ctx, types.NamespacedName{Name: config.GatewayName, Namespace: config.GatewayNamespace}, gw)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	for _, addr := range gw.Status.Addresses {
+		if addr.Value != "" {
+			return addr.Value, nil
+		}
+	}
+	return "", nil
+}
+
 // HTTPRouteParams holds parameters for creating an HTTPRoute
 type HTTPRouteParams struct {
 	ResourceType ResourceType

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -54,6 +54,23 @@ type Config struct {
 	// An empty value means token-exchange is disabled and existing routing is
 	// unchanged. It is independent of ExtAuthzURL.
 	ExtProcURL string
+
+	// GatewayNamespace is the namespace of the Envoy Gateway data plane
+	// (security.gatewayNamespace). It is the ingress source allowed by the
+	// generated NetworkPolicy so the Gateway can reach protected workloads. An
+	// empty value defaults to "envoy-gateway-system".
+	GatewayNamespace string
+
+	// OperatorNamespace is the namespace the operator runs in. It is the ingress
+	// source allowed by the generated NetworkPolicy so the operator can still poll
+	// workload ClusterIP status endpoints. It is read from SECURITY_OPERATOR_NAMESPACE,
+	// falling back to POD_NAMESPACE; an empty value defaults to "kaos-system".
+	OperatorNamespace string
+
+	// NetworkPolicyDisabled is an escape hatch (security.networkPolicy.enabled=false)
+	// that suppresses NetworkPolicy generation even when security is operational, for
+	// CNIs that misbehave or clusters that manage isolation externally.
+	NetworkPolicyDisabled bool
 }
 
 const (
@@ -64,10 +81,24 @@ const (
 	envUserIssuer             = "SECURITY_USER_AUTH_ISSUER"
 	envUserAudience           = "SECURITY_USER_AUTH_AUDIENCE"
 	envUserJWKSURI            = "SECURITY_USER_AUTH_JWKS_URI"
+	envGatewayNamespace       = "SECURITY_GATEWAY_NAMESPACE"
+	envOperatorNamespace      = "SECURITY_OPERATOR_NAMESPACE"
+	envPodNamespace           = "POD_NAMESPACE"
+	envNetworkPolicyDisabled  = "SECURITY_NETWORK_POLICY_DISABLED"
+)
+
+// Default namespaces used by NetworkPolicy ingress rules when not configured.
+const (
+	defaultGatewayNamespace  = "envoy-gateway-system"
+	defaultOperatorNamespace = "kaos-system"
 )
 
 // GetConfig reads security configuration from environment variables.
 func GetConfig() Config {
+	operatorNamespace := os.Getenv(envOperatorNamespace)
+	if strings.TrimSpace(operatorNamespace) == "" {
+		operatorNamespace = os.Getenv(envPodNamespace)
+	}
 	return Config{
 		ExtAuthzURL:            os.Getenv(envExtAuthzURL),
 		Issuer:                 os.Getenv(envIssuer),
@@ -76,7 +107,20 @@ func GetConfig() Config {
 		UserAudience:           os.Getenv(envUserAudience),
 		UserJWKSURIOverride:    os.Getenv(envUserJWKSURI),
 		ExtProcURL:             os.Getenv(envExtProcURL),
+		GatewayNamespace:       os.Getenv(envGatewayNamespace),
+		OperatorNamespace:      operatorNamespace,
+		NetworkPolicyDisabled:  parseBoolEnv(envNetworkPolicyDisabled),
 	}
+}
+
+// parseBoolEnv reads a boolean environment variable, returning false when the
+// variable is unset or not a recognizable truthy value.
+func parseBoolEnv(key string) bool {
+	v, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(key)))
+	if err != nil {
+		return false
+	}
+	return v
 }
 
 // IsOperational reports whether gateway authorization enforcement is configured.
@@ -174,6 +218,36 @@ func (c Config) UserJWKSURI() string {
 // deployment may enable token exchange without changing the ext_authz wiring.
 func (c Config) ExtProcEnabled() bool {
 	return strings.TrimSpace(c.ExtProcURL) != ""
+}
+
+// NetworkPolicyEnabled reports whether the operator should generate a
+// NetworkPolicy for each protected workload. It requires security to be
+// operational and the escape hatch not to be set. When true, direct
+// workload-to-workload application traffic is denied so the Gateway cannot be
+// bypassed.
+func (c Config) NetworkPolicyEnabled() bool {
+	return c.IsOperational() && !c.NetworkPolicyDisabled
+}
+
+// GatewayNamespaceOrDefault returns the configured Envoy Gateway data-plane
+// namespace, defaulting to "envoy-gateway-system" when unset. It is the ingress
+// source allowed by generated NetworkPolicies.
+func (c Config) GatewayNamespaceOrDefault() string {
+	if ns := strings.TrimSpace(c.GatewayNamespace); ns != "" {
+		return ns
+	}
+	return defaultGatewayNamespace
+}
+
+// OperatorNamespaceOrDefault returns the namespace the operator runs in,
+// defaulting to "kaos-system" when neither SECURITY_OPERATOR_NAMESPACE nor
+// POD_NAMESPACE is set. It is the ingress source allowed by generated
+// NetworkPolicies so the operator can poll workload status endpoints.
+func (c Config) OperatorNamespaceOrDefault() string {
+	if ns := strings.TrimSpace(c.OperatorNamespace); ns != "" {
+		return ns
+	}
+	return defaultOperatorNamespace
 }
 
 // ExtAuthzBackendRef parses the configured ext_authz host:port URL into the

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -71,6 +71,21 @@ type Config struct {
 	// that suppresses NetworkPolicy generation even when security is operational, for
 	// CNIs that misbehave or clusters that manage isolation externally.
 	NetworkPolicyDisabled bool
+
+	// GatewayHost is the host[:port] of the Envoy Gateway as reachable from inside
+	// the cluster (security.gatewayHost). When gateway routing is enabled and this
+	// is set, the operator injects gateway-routed URLs into agents so internal
+	// agent->MCP/ModelAPI/peer traffic flows through the gateway (where jwt_authn,
+	// ext_authz and ext_proc apply) instead of directly to the workload Service. An
+	// empty value lets the controller resolve the host from the Gateway resource's
+	// status address.
+	GatewayHost string
+
+	// GatewayRouting enables injecting gateway-routed endpoint URLs into agents
+	// (security.gatewayRouting.enabled). Default off so existing installs keep using
+	// direct Service URLs; it is enabled together with NetworkPolicy to force the
+	// gateway to be the only application path between workloads.
+	GatewayRouting bool
 }
 
 const (
@@ -85,6 +100,8 @@ const (
 	envOperatorNamespace      = "SECURITY_OPERATOR_NAMESPACE"
 	envPodNamespace           = "POD_NAMESPACE"
 	envNetworkPolicyDisabled  = "SECURITY_NETWORK_POLICY_DISABLED"
+	envGatewayHost            = "SECURITY_GATEWAY_HOST"
+	envGatewayRouting         = "SECURITY_GATEWAY_ROUTING_ENABLED"
 )
 
 // Default namespaces used by NetworkPolicy ingress rules when not configured.
@@ -110,6 +127,8 @@ func GetConfig() Config {
 		GatewayNamespace:       os.Getenv(envGatewayNamespace),
 		OperatorNamespace:      operatorNamespace,
 		NetworkPolicyDisabled:  parseBoolEnv(envNetworkPolicyDisabled),
+		GatewayHost:            os.Getenv(envGatewayHost),
+		GatewayRouting:         parseBoolEnv(envGatewayRouting),
 	}
 }
 
@@ -248,6 +267,16 @@ func (c Config) OperatorNamespaceOrDefault() string {
 		return ns
 	}
 	return defaultOperatorNamespace
+}
+
+// GatewayRoutingEnabled reports whether the operator should inject gateway-routed
+// endpoint URLs into agents so internal agent->MCP/ModelAPI/peer traffic flows
+// through the gateway. It is off unless explicitly enabled. The actual gateway
+// host is resolved separately (explicit GatewayHost or the Gateway status
+// address); when no host can be resolved the controller falls back to direct
+// Service URLs so connectivity is never silently broken.
+func (c Config) GatewayRoutingEnabled() bool {
+	return c.GatewayRouting
 }
 
 // ExtAuthzBackendRef parses the configured ext_authz host:port URL into the

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -279,3 +279,72 @@ func TestExtProcBackendRef(t *testing.T) {
 		})
 	}
 }
+
+func TestNetworkPolicyEnabled(t *testing.T) {
+	cases := []struct {
+		name       string
+		extAuthz   string
+		npDisabled bool
+		want       bool
+	}{
+		{"operational and not disabled", "svc:9191", false, true},
+		{"operational but disabled", "svc:9191", true, false},
+		{"not operational", "", false, false},
+		{"not operational and disabled", "", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{ExtAuthzURL: tc.extAuthz, NetworkPolicyDisabled: tc.npDisabled}
+			if got := cfg.NetworkPolicyEnabled(); got != tc.want {
+				t.Errorf("NetworkPolicyEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGatewayNamespaceOrDefault(t *testing.T) {
+	if got := (Config{}).GatewayNamespaceOrDefault(); got != defaultGatewayNamespace {
+		t.Errorf("default = %q, want %q", got, defaultGatewayNamespace)
+	}
+	if got := (Config{GatewayNamespace: "eg"}).GatewayNamespaceOrDefault(); got != "eg" {
+		t.Errorf("explicit = %q, want eg", got)
+	}
+	if got := (Config{GatewayNamespace: "  "}).GatewayNamespaceOrDefault(); got != defaultGatewayNamespace {
+		t.Errorf("whitespace = %q, want default", got)
+	}
+}
+
+func TestOperatorNamespaceOrDefault(t *testing.T) {
+	if got := (Config{}).OperatorNamespaceOrDefault(); got != defaultOperatorNamespace {
+		t.Errorf("default = %q, want %q", got, defaultOperatorNamespace)
+	}
+	if got := (Config{OperatorNamespace: "ops"}).OperatorNamespaceOrDefault(); got != "ops" {
+		t.Errorf("explicit = %q, want ops", got)
+	}
+}
+
+func TestGetConfigOperatorNamespaceFallsBackToPodNamespace(t *testing.T) {
+	t.Setenv(envExtAuthzURL, "svc:9191")
+	t.Setenv(envOperatorNamespace, "")
+	t.Setenv(envPodNamespace, "kaos-system")
+	if got := GetConfig().OperatorNamespace; got != "kaos-system" {
+		t.Errorf("OperatorNamespace = %q, want kaos-system (from POD_NAMESPACE)", got)
+	}
+
+	t.Setenv(envOperatorNamespace, "explicit-ns")
+	if got := GetConfig().OperatorNamespace; got != "explicit-ns" {
+		t.Errorf("OperatorNamespace = %q, want explicit-ns (SECURITY_OPERATOR_NAMESPACE wins)", got)
+	}
+}
+
+func TestGetConfigNetworkPolicyDisabledParsing(t *testing.T) {
+	t.Setenv(envExtAuthzURL, "svc:9191")
+	t.Setenv(envNetworkPolicyDisabled, "true")
+	if !GetConfig().NetworkPolicyDisabled {
+		t.Errorf("expected NetworkPolicyDisabled=true")
+	}
+	t.Setenv(envNetworkPolicyDisabled, "")
+	if GetConfig().NetworkPolicyDisabled {
+		t.Errorf("expected NetworkPolicyDisabled=false when unset")
+	}
+}

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -348,3 +348,25 @@ func TestGetConfigNetworkPolicyDisabledParsing(t *testing.T) {
 		t.Errorf("expected NetworkPolicyDisabled=false when unset")
 	}
 }
+
+func TestGatewayRoutingEnabled(t *testing.T) {
+	if (Config{}).GatewayRoutingEnabled() {
+		t.Errorf("expected routing disabled by default")
+	}
+	if !(Config{GatewayRouting: true}).GatewayRoutingEnabled() {
+		t.Errorf("expected routing enabled when flag set")
+	}
+}
+
+func TestGetConfigReadsGatewayRoutingFields(t *testing.T) {
+	t.Setenv(envExtAuthzURL, "svc:9191")
+	t.Setenv(envGatewayHost, "172.18.0.4:80")
+	t.Setenv(envGatewayRouting, "true")
+	cfg := GetConfig()
+	if cfg.GatewayHost != "172.18.0.4:80" {
+		t.Errorf("GatewayHost = %q, want 172.18.0.4:80", cfg.GatewayHost)
+	}
+	if !cfg.GatewayRoutingEnabled() {
+		t.Errorf("expected GatewayRoutingEnabled true")
+	}
+}

--- a/operator/pkg/security/networkpolicy.go
+++ b/operator/pkg/security/networkpolicy.go
@@ -1,0 +1,115 @@
+package security
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// namespaceNameLabel is the well-known label Kubernetes stamps on every
+// Namespace, holding the namespace's own name. It is used by NetworkPolicy
+// namespaceSelectors to allow ingress from specific namespaces.
+const namespaceNameLabel = "kubernetes.io/metadata.name"
+
+// NetworkPolicyParams describes the protected workload a NetworkPolicy should
+// guard.
+type NetworkPolicyParams struct {
+	// Name is the NetworkPolicy name (typically the workload's route name).
+	Name string
+	// Namespace is the namespace of the NetworkPolicy and the target workload.
+	Namespace string
+	// PodSelector selects the protected workload's pods (e.g. {"app":"mcpserver","mcpserver":name}).
+	PodSelector map[string]string
+	// Labels are applied to the generated NetworkPolicy.
+	Labels map[string]string
+}
+
+// constructNetworkPolicy builds a typed NetworkPolicy that denies direct
+// workload-to-workload application traffic to the selected pods, allowing
+// ingress only from the Envoy Gateway data-plane namespace (so the Gateway can
+// route requests) and from the operator namespace (so the operator can poll
+// ClusterIP status endpoints). Selecting the pods with PolicyTypes [Ingress] and
+// only these explicit allow-from rules yields a default-deny ingress baseline for
+// the workload, closing the gateway-bypass path. Egress is intentionally not
+// restricted in this policy: workloads still need DNS, registry, gateway, broker,
+// and (for ModelAPI) external-provider egress.
+func constructNetworkPolicy(params NetworkPolicyParams, cfg Config) *networkingv1.NetworkPolicy {
+	gatewayNS := cfg.GatewayNamespaceOrDefault()
+	operatorNS := cfg.OperatorNamespaceOrDefault()
+
+	from := []networkingv1.NetworkPolicyPeer{
+		{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{namespaceNameLabel: gatewayNS},
+			},
+		},
+	}
+	// Avoid emitting a duplicate peer when the operator shares the gateway namespace.
+	if operatorNS != gatewayNS {
+		from = append(from, networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{namespaceNameLabel: operatorNS},
+			},
+		})
+	}
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.Name,
+			Namespace: params.Namespace,
+			Labels:    params.Labels,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: params.PodSelector},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{From: from},
+			},
+		},
+	}
+}
+
+// ReconcileNetworkPolicy creates or updates the NetworkPolicy that prevents the
+// Gateway from being bypassed for a protected workload. It is a no-op unless
+// NetworkPolicy generation is enabled (security operational and not disabled).
+func ReconcileNetworkPolicy(
+	ctx context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	params NetworkPolicyParams,
+	cfg Config,
+	log logr.Logger,
+) error {
+	if !cfg.NetworkPolicyEnabled() {
+		return nil
+	}
+
+	desired := constructNetworkPolicy(params, cfg)
+
+	existing := &networkingv1.NetworkPolicy{}
+	err := c.Get(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace}, existing)
+	if err != nil && apierrors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(owner, desired, scheme); err != nil {
+			return fmt.Errorf("set controller reference on NetworkPolicy: %w", err)
+		}
+		log.Info("Creating NetworkPolicy", "name", params.Name, "namespace", params.Namespace)
+		return c.Create(ctx, desired)
+	} else if err != nil {
+		return err
+	}
+
+	existing.Spec = desired.Spec
+	if len(desired.Labels) > 0 {
+		existing.Labels = desired.Labels
+	}
+	return c.Update(ctx, existing)
+}

--- a/operator/pkg/security/networkpolicy_test.go
+++ b/operator/pkg/security/networkpolicy_test.go
@@ -1,0 +1,92 @@
+package security
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func mcpPodSelector() map[string]string {
+	return map[string]string{"app": "mcpserver", "mcpserver": "github"}
+}
+
+func TestConstructNetworkPolicyShape(t *testing.T) {
+	cfg := Config{
+		ExtAuthzURL:       "aib-access-check.kaos-system.svc.cluster.local:9191",
+		GatewayNamespace:  "envoy-gateway-system",
+		OperatorNamespace: "kaos-system",
+	}
+	params := NetworkPolicyParams{
+		Name:        "mcp-github",
+		Namespace:   "default",
+		PodSelector: mcpPodSelector(),
+		Labels:      map[string]string{"app": "kaos"},
+	}
+
+	np := constructNetworkPolicy(params, cfg)
+
+	if np.Name != "mcp-github" || np.Namespace != "default" {
+		t.Fatalf("unexpected name/namespace %s/%s", np.Name, np.Namespace)
+	}
+	if np.Labels["app"] != "kaos" {
+		t.Errorf("expected app=kaos label")
+	}
+	if got := np.Spec.PodSelector.MatchLabels; got["app"] != "mcpserver" || got["mcpserver"] != "github" {
+		t.Errorf("unexpected podSelector %#v", got)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
+		t.Fatalf("expected PolicyTypes [Ingress], got %#v", np.Spec.PolicyTypes)
+	}
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("expected one ingress rule, got %d", len(np.Spec.Ingress))
+	}
+	if len(np.Spec.Egress) != 0 {
+		t.Errorf("expected no egress rules, got %d", len(np.Spec.Egress))
+	}
+
+	peers := np.Spec.Ingress[0].From
+	if len(peers) != 2 {
+		t.Fatalf("expected two ingress peers (gateway + operator), got %d", len(peers))
+	}
+	got := map[string]bool{}
+	for _, p := range peers {
+		if p.NamespaceSelector == nil {
+			t.Fatalf("expected namespaceSelector peer, got %#v", p)
+		}
+		got[p.NamespaceSelector.MatchLabels[namespaceNameLabel]] = true
+	}
+	if !got["envoy-gateway-system"] || !got["kaos-system"] {
+		t.Errorf("expected gateway + operator namespaces, got %#v", got)
+	}
+}
+
+func TestConstructNetworkPolicyDeduplicatesSharedNamespace(t *testing.T) {
+	cfg := Config{
+		ExtAuthzURL:       "svc:9191",
+		GatewayNamespace:  "shared",
+		OperatorNamespace: "shared",
+	}
+	np := constructNetworkPolicy(NetworkPolicyParams{
+		Name: "a", Namespace: "default", PodSelector: mcpPodSelector(),
+	}, cfg)
+
+	if peers := np.Spec.Ingress[0].From; len(peers) != 1 {
+		t.Fatalf("expected a single deduplicated peer, got %d", len(peers))
+	}
+}
+
+func TestConstructNetworkPolicyDefaultNamespaces(t *testing.T) {
+	cfg := Config{ExtAuthzURL: "svc:9191"}
+	np := constructNetworkPolicy(NetworkPolicyParams{
+		Name: "a", Namespace: "default", PodSelector: mcpPodSelector(),
+	}, cfg)
+
+	got := map[string]bool{}
+	for _, p := range np.Spec.Ingress[0].From {
+		got[p.NamespaceSelector.MatchLabels[namespaceNameLabel]] = true
+	}
+	if !got[defaultGatewayNamespace] || !got[defaultOperatorNamespace] {
+		t.Errorf("expected default namespaces %q/%q, got %#v",
+			defaultGatewayNamespace, defaultOperatorNamespace, got)
+	}
+}

--- a/operator/pkg/security/networkpolicy_test.go
+++ b/operator/pkg/security/networkpolicy_test.go
@@ -1,9 +1,17 @@
 package security
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func mcpPodSelector() map[string]string {
@@ -88,5 +96,72 @@ func TestConstructNetworkPolicyDefaultNamespaces(t *testing.T) {
 	if !got[defaultGatewayNamespace] || !got[defaultOperatorNamespace] {
 		t.Errorf("expected default namespaces %q/%q, got %#v",
 			defaultGatewayNamespace, defaultOperatorNamespace, got)
+	}
+}
+
+func reconcileScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := networkingv1.AddToScheme(s); err != nil {
+		t.Fatalf("add networkingv1: %v", err)
+	}
+	return s
+}
+
+func TestReconcileNetworkPolicyCreatesWhenOperational(t *testing.T) {
+	scheme := reconcileScheme(t)
+	owner := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcp-github", Namespace: "default", UID: "owner-uid"},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).Build()
+
+	cfg := Config{ExtAuthzURL: "svc:9191"}
+	params := NetworkPolicyParams{
+		Name: "mcp-github", Namespace: "default", PodSelector: mcpPodSelector(),
+	}
+	if err := ReconcileNetworkPolicy(context.Background(), cl, scheme, owner, params, cfg, logr.Discard()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &networkingv1.NetworkPolicy{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "mcp-github", Namespace: "default"}, got); err != nil {
+		t.Fatalf("expected NetworkPolicy to be created: %v", err)
+	}
+	if len(got.OwnerReferences) != 1 || got.OwnerReferences[0].UID != "owner-uid" {
+		t.Errorf("expected controller owner reference, got %#v", got.OwnerReferences)
+	}
+
+	// Idempotent re-reconcile must not error.
+	if err := ReconcileNetworkPolicy(context.Background(), cl, scheme, owner, params, cfg, logr.Discard()); err != nil {
+		t.Fatalf("re-reconcile: %v", err)
+	}
+}
+
+func TestReconcileNetworkPolicyNoopWhenNotEnabled(t *testing.T) {
+	scheme := reconcileScheme(t)
+	owner := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcp-github", Namespace: "default", UID: "owner-uid"},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).Build()
+
+	cases := map[string]Config{
+		"not operational":     {ExtAuthzURL: ""},
+		"operational but off": {ExtAuthzURL: "svc:9191", NetworkPolicyDisabled: true},
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			params := NetworkPolicyParams{Name: "mcp-github", Namespace: "default", PodSelector: mcpPodSelector()}
+			if err := ReconcileNetworkPolicy(context.Background(), cl, scheme, owner, params, cfg, logr.Discard()); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+			got := &networkingv1.NetworkPolicy{}
+			err := cl.Get(context.Background(), types.NamespacedName{Name: "mcp-github", Namespace: "default"}, got)
+			if !apierrors.IsNotFound(err) {
+				t.Errorf("expected no NetworkPolicy, got err=%v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes the gateway-bypass gap that the gateway authentication/authorization phases depended on without enforcing.

## What this adds

- **Per-workload NetworkPolicy**: the operator reconciles an ingress-only NetworkPolicy for every Agent/MCPServer/ModelAPI that allows ingress only from the gateway and operator namespaces, so a workload can only be reached through the Envoy Gateway. No-op unless agent-auth is operational and NetworkPolicy is enabled.
- **Gateway routing**: when enabled, the agent controller repoints internal agent→ModelAPI/MCP/peer URLs to `http://<gatewayHost>/<ns>/<type>/<name>` so the existing HTTPRoutes forward them through the gateway and its JWT/ext_authz/ext_proc filters apply. Gateway host comes from explicit config or the Gateway status address; falls back to direct URLs if unresolved. Default-off.
- **Gateway TLS**: a `security.tls` block adds an HTTPS/443 listener supporting `selfSigned`, `certManager`, and `provided` modes. No mode set = HTTP only (unchanged).
- **CLI flags**: `--network-policy/--no-network-policy`, `--gateway-routing/--no-gateway-routing`, `--gateway-host`, `--tls-mode`, `--tls-issuer-name`, `--tls-issuer-kind`, `--tls-secret-name`.

## Why

The operator injects direct `svc.cluster.local` URLs for internal hops, so agent→MCP/ModelAPI traffic bypassed the gateway entirely and gateway authz was never enforced on it. NetworkPolicy blocks the bypass; gateway routing reroutes the traffic through the gateway. They are designed to be enabled together.

## Validation

- Operator: `go test ./pkg/security/ ./pkg/gateway/ ./controllers/` pass; `go vet`/`gofmt` clean.
- CLI: `pytest tests/` 91 passed; `black --check` clean.
- Chart: `helm lint` clean; `helm template` renders all TLS modes + routing/netpol env + HTTPS listener with auth wiring without conflict.
- In-cluster NetworkPolicy enforcement requires a Calico/Cilium CNI (kindnet does not enforce) and is validated in the dedicated end-to-end block that follows.

Stacked on `feat/sync-service-productionisation`.