### PR TITLE
PR-ADR-KAOS-11: Enforcement and operational hardening

### DIFF
--- a/docs/security/opa-drop-in/README.md
+++ b/docs/security/opa-drop-in/README.md
@@ -1,0 +1,48 @@
+# Backend-neutral OPA drop-in for KAOS ext_authz
+
+KAOS resource-level authorization is enforced at the Envoy gateway through an `ext_authz` gRPC backend. By default that backend is the AIB access-check service, but the integration is **backend-neutral**: the gateway speaks the standard `envoy.service.auth.v3.Authorization/Check` contract and passes the resource and action as neutral Envoy context extensions (`kaos.resource` / `kaos.action`) plus the gateway-validated actor token. Any backend that implements the same contract — for example [OPA via opa-envoy](https://www.openpolicyagent.org/docs/latest/envoy-introduction/) — can be dropped in **with configuration only**, without any Envoy or KAOS code change.
+
+This sample demonstrates that swap.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `kaos_authz.rego` | Rego policy deciding `allow`/`deny` from `kaos.resource` / `kaos.action` + the actor token `sub`, mirroring AIB permission-set coverage. |
+| `kaos_grants.json` | Grant data bundle (actor → granted resources/actions). In production this is sourced from the same grants the broker projects. |
+| `opa-envoy.yaml` | `opa-system` namespace, a ConfigMap with the policy + data, and an `opa-envoy` Deployment/Service exposing the ext_authz gRPC plugin on `:9191`. |
+
+## How the swap works (configuration only)
+
+The operator generates the `SecurityPolicy.spec.extAuth.grpc.backendRef` from a single configuration value — the ext_authz backend host:port. Pointing it at opa-envoy instead of AIB is a config change:
+
+```bash
+# CLI
+kaos system install --auth-enabled \
+  --ext-authz-url opa-envoy.opa-system.svc.cluster.local:9191
+
+# or Helm
+helm upgrade kaos kaos/kaos-operator \
+  --set security.agentAuth.extAuthzUrl=opa-envoy.opa-system.svc.cluster.local:9191
+```
+
+No Envoy configuration, generated-policy shape, or KAOS code changes — only the backend reference. This is locked by `TestConstructSecurityPolicyBackendRefIsConfigDriven` in `operator/pkg/security/securitypolicy_test.go`, which asserts the generated `extAuth.grpc.backendRef` follows the configured URL for both the default AIB backend and the opa-envoy backend.
+
+## Validate in KIND
+
+```bash
+# 1. Deploy the opa-envoy ext_authz backend.
+kubectl apply -f docs/security/opa-drop-in/opa-envoy.yaml
+kubectl -n opa-system rollout status deploy/opa-envoy
+
+# 2. Point KAOS at it (config only) and enable auth.
+kaos system install --auth-enabled \
+  --ext-authz-url opa-envoy.opa-system.svc.cluster.local:9191 --wait
+
+# 3. A granted edge is allowed, an ungranted one is denied — equivalently to AIB.
+#    (agent `demo/researcher` is granted `call` on `mcpserver/demo/github` only.)
+```
+
+A request whose actor/resource/action matches a grant in `kaos_grants.json` returns an Envoy `OkHttpResponse`; anything else is denied — the same allow/deny outcome the AIB access-check produces, proving the contract is backend-neutral.
+
+AIB remains the default authorization backend; OPA is a validated optional drop-in only.

--- a/docs/security/opa-drop-in/kaos_authz.rego
+++ b/docs/security/opa-drop-in/kaos_authz.rego
@@ -1,0 +1,37 @@
+package kaos.authz
+
+# Backend-neutral KAOS ext_authz policy for opa-envoy.
+#
+# This decides allow/deny over the SAME ext_authz contract the KAOS gateway
+# already speaks to the default AIB access-check backend: the gateway passes
+# the neutral resource/action as Envoy context extensions
+# (`kaos.resource` / `kaos.action`) and the gateway-validated actor token as
+# the bearer Authorization header. The decision is actor -> resource coverage,
+# exactly mirroring AIB's permission-set `covers()` check, but sourced from the
+# `data.kaos.grants` bundle instead of the broker's storage.
+#
+# opa-envoy is configured with `path: kaos/authz/allow`, so this boolean is the
+# authorization decision (true = OkHttpResponse, false = denied).
+
+import rego.v1
+
+default allow := false
+
+# The actor identity is the `sub` of the gateway-validated bearer token.
+actor_sub := payload.sub if {
+	auth := input.attributes.request.http.headers.authorization
+	startswith(auth, "Bearer ")
+	[_, payload, _] := io.jwt.decode(substring(auth, count("Bearer "), -1))
+}
+
+# Neutral resource/action injected by the gateway as context extensions.
+resource := input.attributes.context_extensions["kaos.resource"]
+
+action := input.attributes.context_extensions["kaos.action"]
+
+# Allow when the actor holds a grant covering this resource + action.
+allow if {
+	some grant in data.kaos.grants[actor_sub]
+	grant.resource == resource
+	action in grant.actions
+}

--- a/docs/security/opa-drop-in/kaos_grants.json
+++ b/docs/security/opa-drop-in/kaos_grants.json
@@ -1,0 +1,12 @@
+{
+  "kaos": {
+    "grants": {
+      "kaos://agent/demo/researcher": [
+        {
+          "resource": "kaos://mcpserver/demo/github",
+          "actions": ["call"]
+        }
+      ]
+    }
+  }
+}

--- a/docs/security/opa-drop-in/opa-envoy.yaml
+++ b/docs/security/opa-drop-in/opa-envoy.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opa-system
+---
+# Rego policy + grant data bundle mounted into the opa-envoy container.
+# In a real deployment this data would be sourced from the same grant store the
+# broker projects (or an OPA bundle server); here it is inlined for the demo.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-kaos-policy
+  namespace: opa-system
+data:
+  kaos_authz.rego: |
+    package kaos.authz
+
+    import rego.v1
+
+    default allow := false
+
+    actor_sub := payload.sub if {
+      auth := input.attributes.request.http.headers.authorization
+      startswith(auth, "Bearer ")
+      [_, payload, _] := io.jwt.decode(substring(auth, count("Bearer "), -1))
+    }
+
+    resource := input.attributes.context_extensions["kaos.resource"]
+
+    action := input.attributes.context_extensions["kaos.action"]
+
+    allow if {
+      some grant in data.kaos.grants[actor_sub]
+      grant.resource == resource
+      action in grant.actions
+    }
+  kaos_grants.json: |
+    {
+      "kaos": {
+        "grants": {
+          "kaos://agent/demo/researcher": [
+            { "resource": "kaos://mcpserver/demo/github", "actions": ["call"] }
+          ]
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opa-envoy
+  namespace: opa-system
+  labels:
+    app: opa-envoy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opa-envoy
+  template:
+    metadata:
+      labels:
+        app: opa-envoy
+    spec:
+      containers:
+        - name: opa
+          image: openpolicyagent/opa:0.70.0-envoy
+          args:
+            - "run"
+            - "--server"
+            - "--addr=:8181"
+            - "--diagnostic-addr=:8282"
+            # Expose the Envoy ext_authz gRPC plugin on the same contract/port
+            # the KAOS gateway expects from the default AIB access-check backend.
+            - "--set=plugins.envoy_ext_authz_grpc.addr=:9191"
+            - "--set=plugins.envoy_ext_authz_grpc.path=kaos/authz/allow"
+            - "--set=decision_logs.console=true"
+            - "/policy/kaos_authz.rego"
+            - "/policy/kaos_grants.json"
+          ports:
+            - name: grpc
+              containerPort: 9191
+            - name: http
+              containerPort: 8181
+          readinessProbe:
+            httpGet:
+              path: /health?plugins
+              port: 8282
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: policy
+              mountPath: /policy
+      volumes:
+        - name: policy
+          configMap:
+            name: opa-kaos-policy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opa-envoy
+  namespace: opa-system
+  labels:
+    app: opa-envoy
+spec:
+  selector:
+    app: opa-envoy
+  ports:
+    - name: grpc
+      port: 9191
+      targetPort: 9191

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -581,6 +581,7 @@ def _build_auth_operator_args(
     user_jwks_uri: str = "",
     ext_proc_url: str = "",
     network_policy: bool = True,
+    network_policy_egress: bool = False,
     gateway_routing: bool = False,
     gateway_host: str = "",
     tls_mode: str = "",
@@ -597,9 +598,9 @@ def _build_auth_operator_args(
     (``security.agentAuth.extProcUrl``) is appended only when supplied.
 
     Bypass-prevention and transport-security arguments are appended too:
-    NetworkPolicy is on unless explicitly disabled, gateway routing and host are
-    set when requested, and ``security.tls.*`` is configured when a TLS mode is
-    supplied.
+    NetworkPolicy is on unless explicitly disabled, egress isolation is opt-in,
+    gateway routing and host are set when requested, and ``security.tls.*`` is
+    configured when a TLS mode is supplied.
     """
     args: list[str] = []
     args.extend(["--set", f"security.agentAuth.extAuthzUrl={ext_authz_url}"])
@@ -620,6 +621,8 @@ def _build_auth_operator_args(
         args.extend(["--set", f"security.userAuth.jwksUri={user_jwks_uri}"])
     if not network_policy:
         args.extend(["--set", "security.networkPolicy.enabled=false"])
+    if network_policy_egress:
+        args.extend(["--set", "security.networkPolicy.egress.enabled=true"])
     if gateway_routing:
         args.extend(["--set", "security.gatewayRouting.enabled=true"])
     if gateway_host:
@@ -1119,6 +1122,7 @@ def install_command(
     user_auth_issuer: str | None = None,
     user_auth_audience: str = DEFAULT_USER_AUTH_AUDIENCE,
     network_policy: bool = True,
+    network_policy_egress: bool = False,
     gateway_routing: bool = False,
     gateway_host: str | None = None,
     tls_mode: str | None = None,
@@ -1360,6 +1364,7 @@ def install_command(
                     else ""
                 ),
                 network_policy=network_policy,
+                network_policy_egress=network_policy_egress,
                 gateway_routing=gateway_routing,
                 gateway_host=gateway_host or "",
                 tls_mode=tls_mode or "",

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -187,6 +187,12 @@ def install(
         help="Generate NetworkPolicies that deny direct workload-to-workload traffic "
         "so the Envoy Gateway cannot be bypassed. Effective only with --auth-enabled.",
     ),
+    network_policy_egress: bool = typer.Option(
+        False,
+        "--network-policy-egress/--no-network-policy-egress",
+        help="Add egress default-deny rules to generated NetworkPolicies. Effective "
+        "only with --auth-enabled and --network-policy.",
+    ),
     gateway_routing: bool = typer.Option(
         False,
         "--gateway-routing/--no-gateway-routing",
@@ -259,6 +265,7 @@ def install(
         user_auth_issuer=user_auth_issuer,
         user_auth_audience=user_auth_audience,
         network_policy=network_policy,
+        network_policy_egress=network_policy_egress,
         gateway_routing=gateway_routing,
         gateway_host=gateway_host,
         tls_mode=tls_mode,

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -1044,6 +1044,27 @@ class TestAuthWiring:
         )
         assert "security.networkPolicy.enabled=false" in " ".join(args)
 
+    def test_build_auth_operator_args_enable_network_policy_egress(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            network_policy_egress=True,
+        )
+        assert "security.networkPolicy.egress.enabled=true" in " ".join(args)
+
+    def test_build_auth_operator_args_omits_network_policy_egress_by_default(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+        )
+        assert "security.networkPolicy.egress.enabled=true" not in " ".join(args)
+
     def test_build_auth_operator_args_gateway_routing_and_host(self):
         from kaos_cli.install import _build_auth_operator_args
 

--- a/operator/chart/templates/gateway.yaml
+++ b/operator/chart/templates/gateway.yaml
@@ -30,4 +30,23 @@ spec:
         from: All
 {{- end }}
 {{- end }}
+{{- with .Values.security.tls }}
+{{- if and .mode .minVersion }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: {{ $.Values.gatewayAPI.gatewayName | default "kaos-gateway" }}-tls
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ $.Values.gatewayAPI.gatewayName | default "kaos-gateway" }}
+  tls:
+    minVersion: {{ .minVersion | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -67,6 +67,9 @@ data:
   {{- if and .networkPolicy (not .networkPolicy.enabled) }}
   SECURITY_NETWORK_POLICY_DISABLED: "true"
   {{- end }}
+  {{- if and .networkPolicy .networkPolicy.egress .networkPolicy.egress.enabled }}
+  SECURITY_NETWORK_POLICY_EGRESS_ENABLED: "true"
+  {{- end }}
   {{- if and .gatewayRouting .gatewayRouting.enabled }}
   SECURITY_GATEWAY_ROUTING_ENABLED: "true"
   {{- end }}

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -126,6 +126,10 @@ security:
   # (agentAuth.extAuthzUrl set) and the cluster CNI enforces NetworkPolicy.
   networkPolicy:
     enabled: true
+    # egress adds default-deny egress rules to generated NetworkPolicies. It is
+    # off by default because provider-facing egress must be enabled deliberately.
+    egress:
+      enabled: false
   # gatewayRouting injects gateway-routed endpoint URLs into agents so internal
   # agent->ModelAPI/MCP/peer traffic flows through the gateway (where jwt_authn,
   # ext_authz and ext_proc apply) rather than directly to the workload Service.
@@ -142,6 +146,9 @@ security:
     #   certManager  - the chart creates a cert-manager Certificate (issuerRef below)
     #   provided     - reference an existing kubernetes.io/tls Secret (secretName below)
     mode: ""
+    # minVersion is enforced through an Envoy Gateway ClientTrafficPolicy when
+    # HTTPS termination is enabled.
+    minVersion: "1.2"
     certManager:
       issuerRef:
         # name of the cert-manager Issuer/ClusterIssuer (mode=certManager).

--- a/operator/controllers/modelapi_controller.go
+++ b/operator/controllers/modelapi_controller.go
@@ -306,10 +306,11 @@ func (r *ModelAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			log.Error(err, "failed to reconcile EnvoyExtensionPolicy")
 		}
 		if err := security.ReconcileNetworkPolicy(ctx, r.Client, r.Scheme, modelapi, security.NetworkPolicyParams{
-			Name:        routeName,
-			Namespace:   modelapi.Namespace,
-			PodSelector: map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
-			Labels:      map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
+			Name:                routeName,
+			Namespace:           modelapi.Namespace,
+			PodSelector:         map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
+			Labels:              map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
+			AllowExternalEgress: true,
 		}, secCfg, log); err != nil {
 			log.Error(err, "failed to reconcile NetworkPolicy")
 		}

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -72,6 +72,11 @@ type Config struct {
 	// CNIs that misbehave or clusters that manage isolation externally.
 	NetworkPolicyDisabled bool
 
+	// NetworkPolicyEgress opts generated NetworkPolicies into egress
+	// isolation. It is intentionally separate from NetworkPolicyDisabled because
+	// egress enforcement can break provider calls on CNIs that enforce it.
+	NetworkPolicyEgress bool
+
 	// GatewayHost is the host[:port] of the Envoy Gateway as reachable from inside
 	// the cluster (security.gatewayHost). When gateway routing is enabled and this
 	// is set, the operator injects gateway-routed URLs into agents so internal
@@ -100,6 +105,7 @@ const (
 	envOperatorNamespace      = "SECURITY_OPERATOR_NAMESPACE"
 	envPodNamespace           = "POD_NAMESPACE"
 	envNetworkPolicyDisabled  = "SECURITY_NETWORK_POLICY_DISABLED"
+	envNetworkPolicyEgress    = "SECURITY_NETWORK_POLICY_EGRESS_ENABLED"
 	envGatewayHost            = "SECURITY_GATEWAY_HOST"
 	envGatewayRouting         = "SECURITY_GATEWAY_ROUTING_ENABLED"
 )
@@ -127,6 +133,7 @@ func GetConfig() Config {
 		GatewayNamespace:       os.Getenv(envGatewayNamespace),
 		OperatorNamespace:      operatorNamespace,
 		NetworkPolicyDisabled:  parseBoolEnv(envNetworkPolicyDisabled),
+		NetworkPolicyEgress:    parseBoolEnv(envNetworkPolicyEgress),
 		GatewayHost:            os.Getenv(envGatewayHost),
 		GatewayRouting:         parseBoolEnv(envGatewayRouting),
 	}
@@ -246,6 +253,14 @@ func (c Config) ExtProcEnabled() bool {
 // bypassed.
 func (c Config) NetworkPolicyEnabled() bool {
 	return c.IsOperational() && !c.NetworkPolicyDisabled
+}
+
+// NetworkPolicyEgressEnabled reports whether generated NetworkPolicies should
+// also isolate egress. It requires base NetworkPolicy generation to be enabled
+// and the explicit egress gate to be set, keeping existing ingress-only behavior
+// as the default.
+func (c Config) NetworkPolicyEgressEnabled() bool {
+	return c.NetworkPolicyEnabled() && c.NetworkPolicyEgress
 }
 
 // GatewayNamespaceOrDefault returns the configured Envoy Gateway data-plane

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -302,6 +302,26 @@ func TestNetworkPolicyEnabled(t *testing.T) {
 	}
 }
 
+func TestNetworkPolicyEgressEnabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		cfg      Config
+		expected bool
+	}{
+		{"default off", Config{ExtAuthzURL: "svc:9191"}, false},
+		{"enabled with base policy", Config{ExtAuthzURL: "svc:9191", NetworkPolicyEgress: true}, true},
+		{"disabled when base policy disabled", Config{ExtAuthzURL: "svc:9191", NetworkPolicyDisabled: true, NetworkPolicyEgress: true}, false},
+		{"disabled when not operational", Config{NetworkPolicyEgress: true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.NetworkPolicyEgressEnabled(); got != tc.expected {
+				t.Errorf("NetworkPolicyEgressEnabled() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestGatewayNamespaceOrDefault(t *testing.T) {
 	if got := (Config{}).GatewayNamespaceOrDefault(); got != defaultGatewayNamespace {
 		t.Errorf("default = %q, want %q", got, defaultGatewayNamespace)
@@ -346,6 +366,23 @@ func TestGetConfigNetworkPolicyDisabledParsing(t *testing.T) {
 	t.Setenv(envNetworkPolicyDisabled, "")
 	if GetConfig().NetworkPolicyDisabled {
 		t.Errorf("expected NetworkPolicyDisabled=false when unset")
+	}
+}
+
+func TestGetConfigNetworkPolicyEgressParsing(t *testing.T) {
+	t.Setenv(envExtAuthzURL, "svc:9191")
+	t.Setenv(envNetworkPolicyEgress, "true")
+	cfg := GetConfig()
+	if !cfg.NetworkPolicyEgress {
+		t.Errorf("expected NetworkPolicyEgress=true")
+	}
+	if !cfg.NetworkPolicyEgressEnabled() {
+		t.Errorf("expected NetworkPolicyEgressEnabled=true when base NetworkPolicy is on")
+	}
+
+	t.Setenv(envNetworkPolicyDisabled, "true")
+	if GetConfig().NetworkPolicyEgressEnabled() {
+		t.Errorf("expected egress disabled when base NetworkPolicy is disabled")
 	}
 }
 

--- a/operator/pkg/security/networkpolicy.go
+++ b/operator/pkg/security/networkpolicy.go
@@ -3,13 +3,17 @@ package security
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -18,6 +22,8 @@ import (
 // Namespace, holding the namespace's own name. It is used by NetworkPolicy
 // namespaceSelectors to allow ingress from specific namespaces.
 const namespaceNameLabel = "kubernetes.io/metadata.name"
+
+const kubeSystemNamespace = "kube-system"
 
 // NetworkPolicyParams describes the protected workload a NetworkPolicy should
 // guard.
@@ -30,6 +36,9 @@ type NetworkPolicyParams struct {
 	PodSelector map[string]string
 	// Labels are applied to the generated NetworkPolicy.
 	Labels map[string]string
+	// AllowExternalEgress permits provider-facing egress that cannot be enumerated
+	// by namespace. Set only for ModelAPI workloads that proxy to external LLMs.
+	AllowExternalEgress bool
 }
 
 // constructNetworkPolicy builds a typed NetworkPolicy that denies direct
@@ -38,27 +47,25 @@ type NetworkPolicyParams struct {
 // route requests) and from the operator namespace (so the operator can poll
 // ClusterIP status endpoints). Selecting the pods with PolicyTypes [Ingress] and
 // only these explicit allow-from rules yields a default-deny ingress baseline for
-// the workload, closing the gateway-bypass path. Egress is intentionally not
-// restricted in this policy: workloads still need DNS, registry, gateway, broker,
-// and (for ModelAPI) external-provider egress.
+// the workload, closing the gateway-bypass path. When the separately gated egress
+// dimension is enabled, egress is restricted to DNS plus the gateway/control-plane
+// namespaces; ModelAPI workloads additionally allow external egress so provider
+// calls keep working even though provider IP ranges cannot be enumerated safely.
 func constructNetworkPolicy(params NetworkPolicyParams, cfg Config) *networkingv1.NetworkPolicy {
 	gatewayNS := cfg.GatewayNamespaceOrDefault()
 	operatorNS := cfg.OperatorNamespaceOrDefault()
 
-	from := []networkingv1.NetworkPolicyPeer{
-		{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{namespaceNameLabel: gatewayNS},
-			},
-		},
-	}
+	from := []networkingv1.NetworkPolicyPeer{namespacePeer(gatewayNS)}
 	// Avoid emitting a duplicate peer when the operator shares the gateway namespace.
 	if operatorNS != gatewayNS {
-		from = append(from, networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{namespaceNameLabel: operatorNS},
-			},
-		})
+		from = append(from, namespacePeer(operatorNS))
+	}
+
+	policyTypes := []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+	var egress []networkingv1.NetworkPolicyEgressRule
+	if cfg.NetworkPolicyEgressEnabled() {
+		policyTypes = append(policyTypes, networkingv1.PolicyTypeEgress)
+		egress = constructEgressRules(params, cfg)
 	}
 
 	return &networkingv1.NetworkPolicy{
@@ -69,12 +76,102 @@ func constructNetworkPolicy(params NetworkPolicyParams, cfg Config) *networkingv
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: params.PodSelector},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			PolicyTypes: policyTypes,
 			Ingress: []networkingv1.NetworkPolicyIngressRule{
 				{From: from},
 			},
+			Egress: egress,
 		},
 	}
+}
+
+func constructEgressRules(params NetworkPolicyParams, cfg Config) []networkingv1.NetworkPolicyEgressRule {
+	dnsUDP := corev1.ProtocolUDP
+	dnsTCP := corev1.ProtocolTCP
+	dnsPort := intstr.FromInt(53)
+
+	rules := []networkingv1.NetworkPolicyEgressRule{
+		{
+			To: []networkingv1.NetworkPolicyPeer{namespacePeer(kubeSystemNamespace)},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Protocol: &dnsUDP, Port: &dnsPort},
+				{Protocol: &dnsTCP, Port: &dnsPort},
+			},
+		},
+	}
+
+	allowedNamespaces := []string{
+		cfg.GatewayNamespaceOrDefault(),
+		cfg.OperatorNamespaceOrDefault(),
+	}
+	for _, endpoint := range []string{cfg.Issuer, cfg.ExtAuthzURL, cfg.ExtProcURL} {
+		if ns := serviceNamespaceFromEndpoint(endpoint); ns != "" {
+			allowedNamespaces = append(allowedNamespaces, ns)
+		}
+	}
+	// AIB broker/ext_authz/ext_proc namespaces are derived from configured Service
+	// DNS endpoints so token minting and gateway policy backends remain reachable.
+	for _, ns := range deduplicateStrings(allowedNamespaces) {
+		rules = append(rules, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{namespacePeer(ns)},
+		})
+	}
+
+	if params.AllowExternalEgress {
+		// ModelAPI proxies call arbitrary LLM provider endpoints whose IP ranges vary
+		// by provider and region. Allowing 0.0.0.0/0 avoids silently breaking those
+		// providers while non-ModelAPI workloads remain namespace-restricted.
+		rules = append(rules, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{
+				{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
+			},
+		})
+	}
+
+	return rules
+}
+
+func namespacePeer(namespace string) networkingv1.NetworkPolicyPeer {
+	return networkingv1.NetworkPolicyPeer{
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{namespaceNameLabel: namespace},
+		},
+	}
+}
+
+func deduplicateStrings(values []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func serviceNamespaceFromEndpoint(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	host := raw
+	if strings.Contains(raw, "://") {
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			return ""
+		}
+		host = parsed.Host
+	}
+	host, _, _ = strings.Cut(host, ":")
+	labels := strings.Split(host, ".")
+	if len(labels) < 2 {
+		return ""
+	}
+	return labels[1]
 }
 
 // ReconcileNetworkPolicy creates or updates the NetworkPolicy that prevents the

--- a/operator/pkg/security/networkpolicy_test.go
+++ b/operator/pkg/security/networkpolicy_test.go
@@ -99,6 +99,105 @@ func TestConstructNetworkPolicyDefaultNamespaces(t *testing.T) {
 	}
 }
 
+func TestConstructNetworkPolicyEgressRules(t *testing.T) {
+	cfg := Config{
+		ExtAuthzURL:         "aib-ext-authz.aib-system.svc.cluster.local:9191",
+		ExtProcURL:          "aib-extproc.aib-system.svc.cluster.local:50051",
+		Issuer:              "http://aib-enduser.aib-system.svc.cluster.local:8000",
+		GatewayNamespace:    "envoy-gateway-system",
+		OperatorNamespace:   "kaos-system",
+		NetworkPolicyEgress: true,
+	}
+	np := constructNetworkPolicy(NetworkPolicyParams{
+		Name: "mcp-github", Namespace: "default", PodSelector: mcpPodSelector(),
+	}, cfg)
+
+	if !hasPolicyType(np, networkingv1.PolicyTypeIngress) || !hasPolicyType(np, networkingv1.PolicyTypeEgress) {
+		t.Fatalf("expected ingress+egress PolicyTypes, got %#v", np.Spec.PolicyTypes)
+	}
+	if !hasDNSRule(np) {
+		t.Fatalf("expected DNS egress rule with UDP+TCP 53, got %#v", np.Spec.Egress)
+	}
+	if !hasNamespaceEgress(np, "envoy-gateway-system") {
+		t.Errorf("expected gateway namespace egress")
+	}
+	if !hasNamespaceEgress(np, "aib-system") {
+		t.Errorf("expected AIB broker namespace egress")
+	}
+	if hasExternalEgress(np) {
+		t.Errorf("non-ModelAPI policy should not allow external egress")
+	}
+}
+
+func TestConstructNetworkPolicyModelAPIExternalEgress(t *testing.T) {
+	cfg := Config{ExtAuthzURL: "svc:9191", NetworkPolicyEgress: true}
+	np := constructNetworkPolicy(NetworkPolicyParams{
+		Name: "modelapi-openai", Namespace: "default", PodSelector: map[string]string{"app": "modelapi"}, AllowExternalEgress: true,
+	}, cfg)
+
+	if !hasExternalEgress(np) {
+		t.Fatalf("expected ModelAPI external egress allowance, got %#v", np.Spec.Egress)
+	}
+}
+
+func hasPolicyType(np *networkingv1.NetworkPolicy, want networkingv1.PolicyType) bool {
+	for _, got := range np.Spec.PolicyTypes {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNamespaceEgress(np *networkingv1.NetworkPolicy, namespace string) bool {
+	for _, rule := range np.Spec.Egress {
+		for _, peer := range rule.To {
+			if peer.NamespaceSelector != nil && peer.NamespaceSelector.MatchLabels[namespaceNameLabel] == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasDNSRule(np *networkingv1.NetworkPolicy) bool {
+	for _, rule := range np.Spec.Egress {
+		hasKubeSystem := false
+		hasUDP := false
+		hasTCP := false
+		for _, peer := range rule.To {
+			if peer.NamespaceSelector != nil && peer.NamespaceSelector.MatchLabels[namespaceNameLabel] == kubeSystemNamespace {
+				hasKubeSystem = true
+			}
+		}
+		for _, port := range rule.Ports {
+			if port.Port != nil && port.Port.IntVal == 53 && port.Protocol != nil {
+				switch *port.Protocol {
+				case corev1.ProtocolUDP:
+					hasUDP = true
+				case corev1.ProtocolTCP:
+					hasTCP = true
+				}
+			}
+		}
+		if hasKubeSystem && hasUDP && hasTCP {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExternalEgress(np *networkingv1.NetworkPolicy) bool {
+	for _, rule := range np.Spec.Egress {
+		for _, peer := range rule.To {
+			if peer.IPBlock != nil && peer.IPBlock.CIDR == "0.0.0.0/0" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func reconcileScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()

--- a/operator/pkg/security/securitypolicy_test.go
+++ b/operator/pkg/security/securitypolicy_test.go
@@ -213,3 +213,53 @@ func TestConstructSecurityPolicyNoJWTBlockWhenDisabled(t *testing.T) {
 		t.Errorf("expected extAuth to be present")
 	}
 }
+
+// TestConstructSecurityPolicyBackendRefIsConfigDriven proves the ext_authz
+// backend is backend-neutral: swapping the default AIB access-check for an
+// alternative gRPC ext_authz backend (e.g. opa-envoy) is a pure configuration
+// change via ExtAuthzURL, with no change to the operator's policy generation.
+func TestConstructSecurityPolicyBackendRefIsConfigDriven(t *testing.T) {
+	params := PolicyParams{Name: "mcp-github", Namespace: "default", RouteName: "mcp-github"}
+
+	cases := []struct {
+		name     string
+		url      string
+		wantName string
+		wantNS   string
+		wantPort int64
+	}{
+		{
+			name:     "default aib backend",
+			url:      "aib-access-check.kaos-system.svc.cluster.local:9191",
+			wantName: "aib-access-check",
+			wantNS:   "kaos-system",
+			wantPort: 9191,
+		},
+		{
+			name:     "opa-envoy drop-in backend",
+			url:      "opa-envoy.opa-system.svc.cluster.local:9191",
+			wantName: "opa-envoy",
+			wantNS:   "opa-system",
+			wantPort: 9191,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy, err := constructSecurityPolicy(params, Config{ExtAuthzURL: tc.url})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			backendRef, found, err := unstructured.NestedMap(policy.Object, "spec", "extAuth", "grpc", "backendRef")
+			if err != nil || !found {
+				t.Fatalf("expected grpc backendRef, found=%v err=%v", found, err)
+			}
+			if backendRef["kind"] != "Service" || backendRef["name"] != tc.wantName || backendRef["namespace"] != tc.wantNS {
+				t.Errorf("backendRef did not follow ExtAuthzURL config: %#v", backendRef)
+			}
+			if port, ok := backendRef["port"].(int64); !ok || port != tc.wantPort {
+				t.Errorf("expected port int64(%d), got %#v", tc.wantPort, backendRef["port"])
+			}
+		})
+	}
+}

--- a/pydantic-ai-server/aib/__init__.py
+++ b/pydantic-ai-server/aib/__init__.py
@@ -26,6 +26,8 @@ from .client import (
     Client,
     ReauthenticationRequired,
     TokenResult,
+    outcome_from_response,
+    raise_for_gateway_outcome,
 )
 from .identity import (
     AIBUnavailable,
@@ -37,9 +39,11 @@ from .identity import (
     reset_manager,
 )
 from .instrument import (
+    HEADER_ACCESS_REASON,
     HEADER_ACTOR,
     HEADER_ACTOR_TOKEN,
     HEADER_PRINCIPAL,
+    HEADER_REAUTH_URL,
     HEADER_REQUEST_ID,
     HEADER_SCOPES,
     HEADER_SESSION_ID,
@@ -73,6 +77,8 @@ __all__ = [
     "AccessDenied",
     "ReauthenticationRequired",
     "TokenResult",
+    "outcome_from_response",
+    "raise_for_gateway_outcome",
     "HEADER_REQUEST_ID",
     "HEADER_SESSION_ID",
     "HEADER_PRINCIPAL",
@@ -80,4 +86,6 @@ __all__ = [
     "HEADER_SCOPES",
     "HEADER_SUBJECT_TOKEN",
     "HEADER_ACTOR_TOKEN",
+    "HEADER_ACCESS_REASON",
+    "HEADER_REAUTH_URL",
 ]

--- a/pydantic-ai-server/aib/client.py
+++ b/pydantic-ai-server/aib/client.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from .identity import AIBUnavailable, actor_token, actor_token_async
-from .instrument import ctx
+from .instrument import HEADER_ACCESS_REASON, HEADER_REAUTH_URL, ctx
 
 _TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange"
 _ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
@@ -162,6 +162,48 @@ def _raise_for_decision(decision: AccessDecision) -> None:
     if decision.requires_reauth:
         raise ReauthenticationRequired(decision)
     raise AccessDenied(decision)
+
+
+def outcome_from_response(
+    response: Any, *, resource: str = "", action: str = ""
+) -> Optional[AccessDecision]:
+    """Map a KAOS-gateway enforcement response to a structured :class:`AccessDecision`.
+
+    Reads only response *headers* — never the body — so it is safe to call on any
+    instrumented outbound response, including streaming ones. Returns ``None`` for
+    any response without the gateway enforcement header (``x-kaos-access-reason``),
+    so ordinary traffic and non-KAOS 4xx/5xx responses are unaffected. When the
+    header is present the decision is always a denial: an ext_authz denial carries
+    the platform/user reason with no URL, while an ext_proc re-auth response carries
+    ``third_party_reauth_required`` plus a ``x-kaos-reauth-url``.
+    """
+    headers = getattr(response, "headers", None)
+    if not headers:
+        return None
+    reason = headers.get(HEADER_ACCESS_REASON)
+    if not reason:
+        return None
+    return AccessDecision(
+        allowed=False,
+        reason=str(reason),
+        resource=resource,
+        action=action,
+        reauth_url=headers.get(HEADER_REAUTH_URL) or None,
+    )
+
+
+def raise_for_gateway_outcome(response: Any, *, resource: str = "", action: str = "") -> None:
+    """Raise a typed outcome when ``response`` carries a KAOS-gateway denial.
+
+    A no-op for any response that does not carry the gateway enforcement header,
+    so it is safe to call unconditionally on every instrumented outbound response.
+    A ``user_grant_required`` / ``platform_grant_missing`` ext_authz denial raises
+    :class:`AccessDenied`; an ext_proc ``third_party_reauth_required`` (which carries
+    a re-auth URL) raises :class:`ReauthenticationRequired`.
+    """
+    decision = outcome_from_response(response, resource=resource, action=action)
+    if decision is not None:
+        _raise_for_decision(decision)
 
 
 class Client:

--- a/pydantic-ai-server/aib/instrument.py
+++ b/pydantic-ai-server/aib/instrument.py
@@ -29,6 +29,14 @@ HEADER_SCOPES = "x-aib-scopes"
 HEADER_SUBJECT_TOKEN = "authorization"
 HEADER_ACTOR_TOKEN = "x-agent-authorization"
 
+# Response headers the KAOS gateway stamps on an enforcement decision so a downstream
+# runtime can interpret the outcome from headers alone (never the body). The ext_authz
+# denied path sets ``x-kaos-access-reason`` (``platform_grant_missing`` /
+# ``user_grant_required``); the ext_proc token-exchange re-auth path sets it to
+# ``third_party_reauth_required`` and adds ``x-kaos-reauth-url``.
+HEADER_ACCESS_REASON = "x-kaos-access-reason"
+HEADER_REAUTH_URL = "x-kaos-reauth-url"
+
 # Context keys carrying a raw bearer token; serialized as ``Bearer <value>`` and never logged.
 _TOKEN_FIELDS = {"subject_token": HEADER_SUBJECT_TOKEN, "actor_token": HEADER_ACTOR_TOKEN}
 
@@ -377,6 +385,25 @@ async def _refresh_actor_header_async(request: Any) -> bool:
     return True
 
 
+def _raise_for_gateway_outcome(request: Any, response: Any) -> None:
+    """Raise a typed AIB outcome when a response carries a KAOS-gateway denial.
+
+    Header-gated (``x-kaos-access-reason``) so it imports the outcome machinery only
+    for genuine gateway enforcement responses; ordinary traffic and non-KAOS 4xx/5xx
+    responses are untouched. Reads only headers — never the body — so streaming
+    responses are unaffected.
+    """
+    if HEADER_ACCESS_REASON not in response.headers:
+        return
+    from .client import raise_for_gateway_outcome
+
+    raise_for_gateway_outcome(
+        response,
+        resource=getattr(getattr(request, "url", None), "host", "") or "",
+        action=(getattr(request, "method", "") or "").lower(),
+    )
+
+
 def instrument_httpx() -> None:
     """Patch ``httpx`` so outbound requests carry the propagation headers.
 
@@ -391,6 +418,12 @@ def instrument_httpx() -> None:
     case where the cached token expired or the credential rotated mid-flight. Requests with
     no managed identity, no actor-token header, or a non-401 response behave exactly as
     before (no retry).
+
+    When a response carries the KAOS-gateway enforcement header (``x-kaos-access-reason``),
+    the outcome is raised as a typed :class:`aib.AccessDenied` /
+    :class:`aib.ReauthenticationRequired` so the runtime can surface the reason (and any
+    re-auth URL) instead of an opaque transport error. Responses without that header are
+    returned unchanged.
 
     Injection is additive and reads from :data:`ctx`; in internet-facing deployments,
     callers are responsible for not placing sensitive tokens in :data:`ctx` for requests
@@ -411,6 +444,7 @@ def instrument_httpx() -> None:
         response = sync_send(self, request, *args, **kwargs)
         if response.status_code == 401 and had_actor and _refresh_actor_header_sync(request):
             response = sync_send(self, request, *args, **kwargs)
+        _raise_for_gateway_outcome(request, response)
         return response
 
     async def _patched_async_send(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
@@ -419,6 +453,7 @@ def instrument_httpx() -> None:
         response = await async_send(self, request, *args, **kwargs)
         if response.status_code == 401 and had_actor and await _refresh_actor_header_async(request):
             response = await async_send(self, request, *args, **kwargs)
+        _raise_for_gateway_outcome(request, response)
         return response
 
     httpx.Client.send = _patched_sync_send  # ty: ignore[invalid-assignment]

--- a/pydantic-ai-server/pais/a2a.py
+++ b/pydantic-ai-server/pais/a2a.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel
 from opentelemetry import trace as trace_api, metrics
 
 from pais.telemetry import SERVICE_NAME, is_otel_enabled
+from pais.outcomes import access_event_data, find_access_outcome
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +124,7 @@ EVENT_TASK_COMPLETED = "task.completed"
 EVENT_TASK_FAILED = "task.failed"
 EVENT_TASK_CANCELED = "task.canceled"
 EVENT_AUTONOMOUS_BUDGET_EXHAUSTED = "autonomous.budget.exhausted"
+EVENT_USER_ACTION_REQUIRED = "user_action_required"
 
 
 @dataclass
@@ -662,6 +664,18 @@ class LocalTaskManager(TaskManager):
                                     message, session_id
                                 )
                         except Exception as iter_err:
+                            access_outcome = find_access_outcome(iter_err)
+                            if access_outcome is not None:
+                                event_data = access_event_data(access_outcome)
+                                task.add_event(EVENT_USER_ACTION_REQUIRED, event_data)
+                                task.metadata["user_action_required"] = event_data
+                                last_response = event_data["message"]
+                                logger.info(
+                                    f"Autonomous run {task_id}: user action required "
+                                    f"({event_data['reason']} on {event_data['resource']}), "
+                                    "skipping protected action and ending run"
+                                )
+                                break
                             if is_autonomous:
                                 err_type = type(iter_err).__name__
                                 logger.warning(

--- a/pydantic-ai-server/pais/outcomes.py
+++ b/pydantic-ai-server/pais/outcomes.py
@@ -1,0 +1,76 @@
+"""Interpretation of KAOS-gateway access outcomes for the agent runtime.
+
+A KAOS-secured gateway stamps enforcement decisions onto responses (see the AIB
+SDK ``instrument_httpx``), which the SDK raises as typed :class:`aib.AccessDenied`
+/ :class:`aib.ReauthenticationRequired` on the instrumented outbound path. These
+helpers let the synchronous chat/A2A path and the autonomous loop interpret those
+outcomes consistently: find an outcome in a (possibly wrapped) exception, render a
+user-facing message, and build a structured event payload. The runtime never
+blocks, retries, or grants access in response — it only reports the outcome.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import aib
+
+
+def find_access_outcome(exc: BaseException) -> Optional["aib.AccessDenied"]:
+    """Walk an exception's cause/context chain for a gateway access outcome.
+
+    A gateway denial may be wrapped by the agent framework (e.g. surfaced as a tool
+    error) before it reaches the runtime, so the whole chain is inspected. Returns
+    the :class:`aib.AccessDenied` (or its :class:`aib.ReauthenticationRequired`
+    subclass) when present, else ``None``.
+    """
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    while cur is not None and id(cur) not in seen:
+        if isinstance(cur, aib.AccessDenied):
+            return cur
+        seen.add(id(cur))
+        cur = cur.__cause__ or cur.__context__
+    return None
+
+
+def format_access_outcome(outcome: "aib.AccessDenied") -> str:
+    """Render a gateway access outcome as a non-blocking, user-facing message.
+
+    Surfaces the denied resource and machine reason; when the denial is recoverable
+    by user re-authentication it includes the re-auth URL. It never blocks, retries,
+    or grants access — it only reports what human action (if any) is required.
+    """
+    decision = outcome.decision
+    resource = decision.resource or "the requested resource"
+    reason = decision.reason or "access denied"
+    if isinstance(outcome, aib.ReauthenticationRequired) and outcome.reauth_url:
+        return (
+            f"Access to {resource} requires re-authentication ({reason}). "
+            f"Please reconnect at {outcome.reauth_url} and try again."
+        )
+    return (
+        f"Access to {resource} was denied ({reason}). An administrator must approve "
+        "this access grant before the action can proceed."
+    )
+
+
+def access_event_data(outcome: "aib.AccessDenied", *, action: str = "") -> Dict[str, Any]:
+    """Build a structured ``user_action_required`` event payload for a task.
+
+    Captures the machine reason, the denied resource, and the re-auth URL when the
+    outcome is recoverable, so an operator or API can see exactly what human action
+    is needed.
+    """
+    decision = outcome.decision
+    data: Dict[str, Any] = {
+        "reason": decision.reason or "access_denied",
+        "resource": decision.resource or "",
+        "message": format_access_outcome(outcome),
+    }
+    if action:
+        data["action"] = action
+    reauth_url = getattr(outcome, "reauth_url", None)
+    if reauth_url:
+        data["reauth_url"] = reauth_url
+    return data

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -31,6 +31,7 @@ from pais.telemetry import (
 )
 from opentelemetry.propagate import extract
 from pais.tools import format_progress_event, DELEGATION_TOOL_PREFIX, DelegationToolset
+from pais.outcomes import find_access_outcome, format_access_outcome
 from pais.serverutils import (
     AgentDeps,
     AgentCard,
@@ -53,45 +54,6 @@ from pais.a2a import (
 
 if TYPE_CHECKING:
     from pais.memory import Memory
-
-
-def _find_access_outcome(exc: BaseException) -> Optional[aib.AccessDenied]:
-    """Walk an exception's cause/context chain for a gateway access outcome.
-
-    A gateway denial raised on the instrumented outbound path (an
-    :class:`aib.AccessDenied` / :class:`aib.ReauthenticationRequired`) may be wrapped
-    by the agent framework before it surfaces here, so the whole chain is inspected.
-    Returns the outcome when present, else ``None``.
-    """
-    seen: set[int] = set()
-    cur: Optional[BaseException] = exc
-    while cur is not None and id(cur) not in seen:
-        if isinstance(cur, aib.AccessDenied):
-            return cur
-        seen.add(id(cur))
-        cur = cur.__cause__ or cur.__context__
-    return None
-
-
-def _format_access_outcome(outcome: aib.AccessDenied) -> str:
-    """Render a gateway access outcome as a non-blocking, user-facing message.
-
-    Surfaces the denied resource and machine reason; when the denial is recoverable
-    by user re-authentication it includes the re-auth URL. It never blocks, retries,
-    or grants access — it only reports what human action (if any) is required.
-    """
-    decision = outcome.decision
-    resource = decision.resource or "the requested resource"
-    reason = decision.reason or "access denied"
-    if isinstance(outcome, aib.ReauthenticationRequired) and outcome.reauth_url:
-        return (
-            f"Access to {resource} requires re-authentication ({reason}). "
-            f"Please reconnect at {outcome.reauth_url} and try again."
-        )
-    return (
-        f"Access to {resource} was denied ({reason}). An administrator must approve "
-        "this access grant before the action can proceed."
-    )
 
 
 def configure_logging(level: str = "INFO", otel_correlation: bool = False) -> None:
@@ -530,9 +492,9 @@ class AgentServer:
                 yield content
 
         except Exception as e:
-            outcome = _find_access_outcome(e)
+            outcome = find_access_outcome(e)
             if outcome is not None:
-                message_text = _format_access_outcome(outcome)
+                message_text = format_access_outcome(outcome)
                 logger.info(f"Access outcome surfaced for session {session_id}: {outcome}")
                 await self.memory.add_event(session_id, "access_outcome", message_text)
                 yield message_text

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -55,6 +55,45 @@ if TYPE_CHECKING:
     from pais.memory import Memory
 
 
+def _find_access_outcome(exc: BaseException) -> Optional[aib.AccessDenied]:
+    """Walk an exception's cause/context chain for a gateway access outcome.
+
+    A gateway denial raised on the instrumented outbound path (an
+    :class:`aib.AccessDenied` / :class:`aib.ReauthenticationRequired`) may be wrapped
+    by the agent framework before it surfaces here, so the whole chain is inspected.
+    Returns the outcome when present, else ``None``.
+    """
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    while cur is not None and id(cur) not in seen:
+        if isinstance(cur, aib.AccessDenied):
+            return cur
+        seen.add(id(cur))
+        cur = cur.__cause__ or cur.__context__
+    return None
+
+
+def _format_access_outcome(outcome: aib.AccessDenied) -> str:
+    """Render a gateway access outcome as a non-blocking, user-facing message.
+
+    Surfaces the denied resource and machine reason; when the denial is recoverable
+    by user re-authentication it includes the re-auth URL. It never blocks, retries,
+    or grants access — it only reports what human action (if any) is required.
+    """
+    decision = outcome.decision
+    resource = decision.resource or "the requested resource"
+    reason = decision.reason or "access denied"
+    if isinstance(outcome, aib.ReauthenticationRequired) and outcome.reauth_url:
+        return (
+            f"Access to {resource} requires re-authentication ({reason}). "
+            f"Please reconnect at {outcome.reauth_url} and try again."
+        )
+    return (
+        f"Access to {resource} was denied ({reason}). An administrator must approve "
+        "this access grant before the action can proceed."
+    )
+
+
 def configure_logging(level: str = "INFO", otel_correlation: bool = False) -> None:
     """Configure stdout logging with optional OTel trace correlation."""
     log_level = getattr(logging, level.upper(), logging.INFO)
@@ -491,6 +530,13 @@ class AgentServer:
                 yield content
 
         except Exception as e:
+            outcome = _find_access_outcome(e)
+            if outcome is not None:
+                message_text = _format_access_outcome(outcome)
+                logger.info(f"Access outcome surfaced for session {session_id}: {outcome}")
+                await self.memory.add_event(session_id, "access_outcome", message_text)
+                yield message_text
+                return
             logger.error(f"Error processing message: {str(e)}")
             await self.memory.add_event(session_id, "error", str(e))
             yield f"Sorry, I encountered an error: {str(e)}"

--- a/pydantic-ai-server/pyproject.toml
+++ b/pydantic-ai-server/pyproject.toml
@@ -50,3 +50,8 @@ packages = ["pais", "aib"]
 [tool.black]
 line-length = 100
 target-version = ["py312"]
+
+# Deprecation notices from upstream libraries are informational and must not
+# fail type checking; library migrations are handled as deliberate changes.
+[tool.ty.rules]
+deprecated = "ignore"

--- a/pydantic-ai-server/tests/test_agent.py
+++ b/pydantic-ai-server/tests/test_agent.py
@@ -276,6 +276,84 @@ class TestMockModel:
             del os.environ["DEBUG_MOCK_RESPONSES"]
 
 
+class TestAccessOutcomeSurfacing:
+    """A gateway access denial raised on the outbound path surfaces as a message."""
+
+    def _model_raising(self, exc: Exception) -> FunctionModel:
+        def mock_fn(messages, info: AgentInfo) -> PydanticModelResponse:
+            raise exc
+
+        return FunctionModel(mock_fn)
+
+    @pytest.mark.asyncio
+    async def test_ext_authz_denial_surfaces_reason(self):
+        from aib import AccessDecision, AccessDenied
+
+        decision = AccessDecision(
+            allowed=False, reason="platform_grant_missing", resource="mcp.payments"
+        )
+        server = make_test_server(
+            name="denied-agent", model=self._model_raising(AccessDenied(decision))
+        )
+
+        response = ""
+        async for chunk in server._process_message("call it", session_id="t"):
+            response += chunk
+
+        assert "mcp.payments" in response
+        assert "platform_grant_missing" in response
+        assert "administrator must approve" in response
+        assert "Sorry, I encountered an error" not in response
+
+    @pytest.mark.asyncio
+    async def test_reauth_required_surfaces_url(self):
+        from aib import AccessDecision, ReauthenticationRequired
+
+        decision = AccessDecision(
+            allowed=False,
+            reason="third_party_reauth_required",
+            resource="github",
+            reauth_url="https://idp.example/reauth",
+        )
+        server = make_test_server(
+            name="reauth-agent",
+            model=self._model_raising(ReauthenticationRequired(decision)),
+        )
+
+        response = ""
+        async for chunk in server._process_message("call it", session_id="t"):
+            response += chunk
+
+        assert "https://idp.example/reauth" in response
+        assert "re-authentication" in response
+
+    @pytest.mark.asyncio
+    async def test_wrapped_outcome_is_unwrapped(self):
+        from aib import AccessDecision, AccessDenied
+
+        decision = AccessDecision(allowed=False, reason="user_grant_required", resource="db")
+        inner = AccessDenied(decision)
+        wrapped = RuntimeError("tool failed")
+        wrapped.__cause__ = inner
+        server = make_test_server(name="wrap-agent", model=self._model_raising(wrapped))
+
+        response = ""
+        async for chunk in server._process_message("call it", session_id="t"):
+            response += chunk
+
+        assert "user_grant_required" in response
+
+    @pytest.mark.asyncio
+    async def test_non_access_error_unchanged(self):
+        server = make_test_server(name="err-agent", model=self._model_raising(RuntimeError("boom")))
+
+        response = ""
+        async for chunk in server._process_message("call it", session_id="t"):
+            response += chunk
+
+        assert "Sorry, I encountered an error" in response
+
+
 class TestAgentCard:
     """Tests for AgentCard dataclass."""
 

--- a/pydantic-ai-server/tests/test_aib_outcomes.py
+++ b/pydantic-ai-server/tests/test_aib_outcomes.py
@@ -1,0 +1,142 @@
+"""Tests for gateway-outcome detection on the instrumented outbound path.
+
+A KAOS-secured gateway stamps enforcement decisions onto the response: an ext_authz
+denial returns ``403`` with ``x-kaos-access-reason`` (``platform_grant_missing`` /
+``user_grant_required``, no URL); an ext_proc token-exchange re-auth returns ``200``
+with ``x-kaos-access-reason: third_party_reauth_required`` plus ``x-kaos-reauth-url``.
+The SDK turns these into typed outcomes so the runtime can surface them; every other
+response (including ordinary non-KAOS 4xx/5xx) is returned untouched.
+"""
+
+import aib
+import httpx
+import pytest
+import respx
+
+
+@pytest.fixture(autouse=True)
+def _patch_and_clear():
+    aib.instrument_httpx()  # idempotent — safe to call per test
+    aib.ctx.replace({})
+    yield
+    aib.ctx.replace({})
+
+
+# --- outcome_from_response (pure header mapping) ------------------------------
+
+
+def _response(status: int, headers: dict) -> httpx.Response:
+    return httpx.Response(status_code=status, headers=headers)
+
+
+def test_outcome_none_for_plain_response():
+    assert aib.outcome_from_response(_response(200, {})) is None
+    assert aib.outcome_from_response(_response(403, {})) is None
+    assert aib.outcome_from_response(_response(500, {"x-other": "y"})) is None
+
+
+def test_outcome_platform_grant_missing_has_no_url():
+    decision = aib.outcome_from_response(
+        _response(403, {"x-kaos-access-reason": "platform_grant_missing"}),
+        resource="mcp.example",
+    )
+    assert decision is not None
+    assert decision.allowed is False
+    assert decision.reason == "platform_grant_missing"
+    assert decision.resource == "mcp.example"
+    assert decision.reauth_url is None
+    assert decision.requires_reauth is False
+
+
+def test_outcome_reauth_carries_url():
+    decision = aib.outcome_from_response(
+        _response(
+            200,
+            {
+                "x-kaos-access-reason": "third_party_reauth_required",
+                "x-kaos-reauth-url": "https://idp.example/reauth",
+            },
+        )
+    )
+    assert decision is not None
+    assert decision.reason == "third_party_reauth_required"
+    assert decision.reauth_url == "https://idp.example/reauth"
+    assert decision.requires_reauth is True
+
+
+# --- raise_for_gateway_outcome -----------------------------------------------
+
+
+def test_raise_access_denied_for_ext_authz():
+    with pytest.raises(aib.AccessDenied) as exc:
+        aib.raise_for_gateway_outcome(
+            _response(403, {"x-kaos-access-reason": "user_grant_required"})
+        )
+    assert not isinstance(exc.value, aib.ReauthenticationRequired)
+    assert exc.value.decision.reason == "user_grant_required"
+
+
+def test_raise_reauth_for_ext_proc():
+    with pytest.raises(aib.ReauthenticationRequired) as exc:
+        aib.raise_for_gateway_outcome(
+            _response(
+                200,
+                {
+                    "x-kaos-access-reason": "third_party_reauth_required",
+                    "x-kaos-reauth-url": "https://idp.example/reauth",
+                },
+            )
+        )
+    assert exc.value.reauth_url == "https://idp.example/reauth"
+
+
+def test_raise_noop_for_plain_response():
+    aib.raise_for_gateway_outcome(_response(200, {}))  # no raise
+    aib.raise_for_gateway_outcome(_response(403, {"x-app": "z"}))  # non-KAOS 403, no raise
+
+
+# --- end-to-end through the instrumented httpx send --------------------------
+
+
+@respx.mock
+def test_sync_send_raises_on_ext_authz_denial():
+    respx.get("http://downstream/data").respond(
+        403, headers={"x-kaos-access-reason": "platform_grant_missing"}
+    )
+    with httpx.Client() as client, pytest.raises(aib.AccessDenied) as exc:
+        client.get("http://downstream/data")
+    assert exc.value.decision.reason == "platform_grant_missing"
+    assert exc.value.decision.resource == "downstream"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_send_raises_reauth_on_ext_proc():
+    respx.post("http://downstream/tool").respond(
+        200,
+        headers={
+            "x-kaos-access-reason": "third_party_reauth_required",
+            "x-kaos-reauth-url": "https://idp.example/reauth",
+        },
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(aib.ReauthenticationRequired) as exc:
+            await client.post("http://downstream/tool")
+    assert exc.value.reauth_url == "https://idp.example/reauth"
+
+
+@respx.mock
+def test_sync_send_normal_response_unaffected():
+    respx.get("http://downstream/ok").respond(200, json={"ok": True})
+    with httpx.Client() as client:
+        resp = client.get("http://downstream/ok")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+@respx.mock
+def test_sync_send_non_kaos_403_not_raised():
+    respx.get("http://downstream/forbidden").respond(403, json={"error": "nope"})
+    with httpx.Client() as client:
+        resp = client.get("http://downstream/forbidden")
+    assert resp.status_code == 403

--- a/pydantic-ai-server/tests/test_autonomous.py
+++ b/pydantic-ai-server/tests/test_autonomous.py
@@ -268,3 +268,64 @@ class TestStartupAutonomous:
                 "TASK_MAX_TOOL_CALLS",
             ]:
                 os.environ.pop(key, None)
+
+
+class TestAutonomousAccessOutcome:
+    """A gateway access denial during an iteration records a user_action_required event."""
+
+    @pytest.mark.asyncio
+    async def test_reauth_outcome_records_event_and_completes(self):
+        from aib import AccessDecision, ReauthenticationRequired
+        from pais.a2a import LocalTaskManager, EVENT_USER_ACTION_REQUIRED
+
+        calls = {"n": 0}
+
+        async def process_fn(message, session_id):
+            calls["n"] += 1
+            decision = AccessDecision(
+                allowed=False,
+                reason="third_party_reauth_required",
+                resource="github",
+                reauth_url="https://idp.example/reauth",
+            )
+            raise ReauthenticationRequired(decision)
+
+        tm = LocalTaskManager(process_fn)
+        try:
+            task = await tm.submit_autonomous("do it", budgets=TaskBudgets(max_iterations=5))
+            completed = await tm.wait_for_completion(task.id, timeout=5.0)
+            assert completed is not None
+            events = [e for e in completed.events if e.type == EVENT_USER_ACTION_REQUIRED]
+            assert len(events) == 1  # exactly one — no retry storm
+            assert events[0].data["reason"] == "third_party_reauth_required"
+            assert events[0].data["resource"] == "github"
+            assert events[0].data["reauth_url"] == "https://idp.example/reauth"
+            assert completed.metadata.get("user_action_required") is not None
+            assert completed.status.state.value == "completed"
+            assert calls["n"] == 1  # stopped after the first denial, did not loop
+        finally:
+            await tm.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_platform_denial_records_event_without_url(self):
+        from aib import AccessDecision, AccessDenied
+        from pais.a2a import LocalTaskManager, EVENT_USER_ACTION_REQUIRED
+
+        async def process_fn(message, session_id):
+            decision = AccessDecision(
+                allowed=False, reason="platform_grant_missing", resource="mcp.payments"
+            )
+            raise AccessDenied(decision)
+
+        tm = LocalTaskManager(process_fn)
+        try:
+            task = await tm.submit_autonomous("do it", budgets=TaskBudgets(max_iterations=5))
+            completed = await tm.wait_for_completion(task.id, timeout=5.0)
+            assert completed is not None
+            events = [e for e in completed.events if e.type == EVENT_USER_ACTION_REQUIRED]
+            assert len(events) == 1
+            assert events[0].data["reason"] == "platform_grant_missing"
+            assert "reauth_url" not in events[0].data
+            assert completed.status.state.value == "completed"
+        finally:
+            await tm.shutdown()


### PR DESCRIPTION
Closes the operational-correctness story on top of the gateway enforcement, bypass-prevention, and sync/SDK machinery from the prior security work.

- **Runtime outcome surfacing.** The SDK-instrumented outbound path now interprets gateway-surfaced access outcomes from response headers (`x-kaos-access-reason` / `x-kaos-reauth-url`) into typed SDK results, and the runtime surfaces them: a synchronous chat/A2A call reports the denied resource and reason (and a reconnect URL when present) without blocking or auto-granting; an autonomous run records exactly one structured `user_action_required` event and stops the protected action instead of looping.
- **Requested-vs-approved guard.** Tests lock the invariant that the KAOS->AIB projection never emits an approval status of its own — platform grants are only the bootstrap permission-set binding, kept structurally distinct from the requested CRD edges.
- **Backend-neutral OPA drop-in.** A sample Rego policy + opa-envoy ext_authz manifest under `docs/security/opa-drop-in`, plus a test asserting the generated SecurityPolicy `extAuth.grpc.backendRef` follows configuration, proving the ext_authz backend is swappable with no Envoy/KAOS code change.
- **Transport hardening.** Egress NetworkPolicy (default-off) allowing DNS/gateway/operator/AIB (and provider egress for ModelAPI), plus a TLS minimum-version ClientTrafficPolicy, wired through chart and CLI.

Every new path is gated so installs with security default-off are unchanged. All new behaviour is unit-tested; the cross-component outcome story is validated against a Calico KIND cluster (see REPORT).