### PR TITLE
feat(skill): add /dependabot-fix-all orchestrator

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -116,3 +116,5 @@ Detailed instructions are in `.github/instructions/`:
 ### Skills
 - `/release-kaos`: Invoke with a version (e.g., "Use /release-kaos to release v0.5.0") — executes full release pipeline
 - `/planned-implementation`: Use for complex staged KAOS work that needs backend/UI context gathering, a written plan, task-scoped commits, PR/CI validation, and an uncommitted REPORT.md PR comment
+- `/dependabot-fix`: Invoke with a PR number (e.g., "Use /dependabot-fix 142") — diagnoses and fixes a single failing Dependabot PR autonomously, commits on the PR branch, posts a REPORT.md comment, and emits a machine-readable `RESULT:` line
+- `/dependabot-fix-all`: Invoke with no arguments — orchestrator that fixes every open Dependabot PR end-to-end on autopilot, spawning one isolated non-interactive `copilot -p` child per PR (serial), verifying each via `gh`, and recording state in the SQLite ledger

--- a/.github/skills/dependabot-fix-all/SKILL.md
+++ b/.github/skills/dependabot-fix-all/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: dependabot-fix-all
+description: Fix every open Dependabot PR end-to-end on autopilot. Use this skill when asked to run /dependabot-fix-all (no arguments). This skill acts as an orchestrator: it discovers all open Dependabot PRs once, risk-orders them, then processes them one at a time by spawning an isolated non-interactive `copilot -p` child per PR that runs the dependabot-fix skill. It verifies each PR independently via gh, applies the merge policy, records state in a durable ledger, and is bounded so it always terminates. Never pauses for user input.
+allowed-tools: shell
+---
+
+# Dependabot Fix All
+
+Orchestrate the `dependabot-fix` skill across **every open Dependabot PR**, fully autonomously. Invoked as
+`/dependabot-fix-all` (no arguments).
+
+**This session is the orchestrator.** It does not diagnose or edit PRs itself — it spawns **one isolated
+`copilot -p` child per PR** (each child runs the heavyweight `dependabot-fix` skill in a fresh context), then
+**independently verifies** the result via `gh` and moves on. This keeps the orchestrator's context lean and avoids
+cross-PR contamination.
+
+## Core principles (do not violate)
+
+- **Autopilot — never pause.** Zero `ask_user`/interactive prompts anywhere in this path. Resolve every decision
+  autonomously. If something cannot be resolved, mark the PR `blocked` and continue.
+- **Serial only.** Children share this one git working tree (each runs `gh pr checkout`). Never run children in
+  parallel. Clean tree + default branch between children.
+- **Bounded — always terminates.** Discover PRs **once** and snapshot the list. Never re-discover inside the loop.
+  Attempt each PR **at most once** (no orchestrator-level retry, no re-queue). Every child has a wall-clock timeout.
+- **Token-efficient.** **Never read a child's full stdout into context.** Use `tail`/`grep` on its log and treat `gh`
+  output as the ground truth for verification.
+- **Keep it simple.** No nesting (`dependabot-fix-all` never spawns another `dependabot-fix-all`), no extra retry
+  loops, no cleverness beyond what is written here.
+
+Durable state lives in the SQLite `todos` ledger (resumable), not in conversation memory.
+
+---
+
+## Phase 0 — Preflight & discovery (once)
+
+```bash
+mkdir -p ./tmp && touch ./tmp/null
+REPO=axsaucedo/kaos
+```
+
+**Preflight** (abort early with a clear message if any fails):
+- `gh auth status` is OK.
+- `copilot` is on `PATH` (`command -v copilot`).
+- Git working tree is clean and on the default branch:
+  ```bash
+  git rev-parse --abbrev-ref HEAD          # expect main
+  git status --porcelain                   # expect empty
+  ```
+  If dirty or on another branch, switch to `main` and confirm clean before proceeding (do not discard user work
+  silently — if the tree is dirty with unrelated changes, mark the whole run blocked and report).
+
+**Discover once** and snapshot — this is the *only* discovery; never list PRs again during the loop:
+
+```bash
+gh pr list --repo $REPO --author app/dependabot \
+  --json number,title,labels,headRefName,files --limit 100 > ./tmp/dfa-prs.json
+```
+
+**Risk-order easy → hard** (process low-risk first so the run banks wins before tackling fragile UI majors):
+
+1. `github_actions` / `docker`, and any minor/patch-only bumps
+2. `gomod` (operator) — may need `make generate manifests`
+3. `uv` / `pip` (pydantic-ai-server, kaos-cli, operator/tests)
+4. `npm` in `docs/` or root
+5. `npm` in `kaos-ui/` — **framework majors last** (highest risk; may be left open for review)
+
+Infer ecosystem/scope from the PR title, `headRefName`, and `files` (e.g. `/kaos-ui`, `/operator`, `github_actions`).
+
+**Seed the ledger** — one row per discovered PR, in processing order. Use a `dfa-pr-<number>` id convention so rows are
+unambiguous:
+
+```sql
+-- one INSERT per PR (status pending). Record ecosystem + risk in the description for traceability.
+INSERT INTO todos (id, title, description) VALUES
+  ('dfa-pr-245', 'Fixing PR #245 (github_actions)', 'ecosystem=github_actions risk=low order=1');
+```
+
+Print the ordered plan (PR number, ecosystem, risk) so the run is auditable, then proceed without pausing.
+
+---
+
+## Phase 1 — Serial loop (one PR at a time, in order)
+
+Iterate the snapshot in risk order. For each PR `<n>`:
+
+### 1. Pre-checks (orchestrator, cheap — no child yet)
+
+```bash
+gh pr view <n> --repo $REPO --json state,mergeStateStatus,labels,title
+```
+
+- If `state` is `MERGED` or `CLOSED` → ledger `done` (note "already merged/closed"), continue.
+- Confirm working tree is clean and on `main` before handing off (the previous child should have restored it; if not,
+  `git checkout main` and clean up first).
+
+Mark the ledger row `in_progress`.
+
+### 2. Spawn the child (isolated, non-interactive, with a timeout)
+
+Run **serially** and wait. The child runs the `dependabot-fix` skill in its own fresh context. **Use
+`--output-format json`** and redirect to a log file — **do not stream it into context**.
+
+> Important: plain `copilot -p` text output does **not** include the agent's reply when redirected to a file (only a
+> usage footer is captured), and `-s/--silent` can come back empty. Use `--output-format json` (JSONL): each line is a
+> JSON event, and the final assistant reply (containing the `RESULT:` line) is the last `assistant.message`, followed by
+> a `result` event carrying `exitCode`.
+
+```bash
+timeout 1800 copilot -p "Use the dependabot-fix skill to fix Dependabot PR <n> fully autonomously. \
+Do not ask any questions; run on autopilot to completion and emit the final RESULT line." \
+  --allow-all-tools --allow-all-paths --output-format json --no-color \
+  > ./tmp/pr-<n>-child.jsonl 2>&1
+echo "child exit: $?"
+```
+
+Notes:
+- `--allow-all-tools --allow-all-paths` are required for unattended execution. Run from the repo root so the project
+  skill is discoverable.
+- `timeout 1800` (30 min) guards against a hung child; a timeout is treated as `blocked` (see classification).
+
+### 3. Capture the result — token-efficiently (never load the whole JSONL)
+
+Extract **only** the final assistant message (the `RESULT:` line) and the `result` event's exit code. Do not read the
+full log — it is large.
+
+```bash
+python3 - "$PWD/tmp/pr-<n>-child.jsonl" <<'PY'
+import json, sys
+last_msg, result = None, None
+for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    line = line.strip()
+    if not line or not line.startswith("{"):
+        continue
+    try:
+        ev = json.loads(line)
+    except ValueError:
+        continue
+    if ev.get("type") == "assistant.message":
+        last_msg = ev.get("data", {}).get("content", "")
+    elif ev.get("type") == "result":
+        result = ev
+# print only the RESULT line from the final assistant message + the exit code
+for ln in (last_msg or "").splitlines():
+    if ln.startswith("RESULT:"):
+        print(ln)
+print("exitCode:", (result or {}).get("exitCode"))
+PY
+```
+
+If no `RESULT:` line is found or `exitCode` is non-zero/empty, treat the run as `blocked` and rely on the Phase 1.4
+`gh` verification to classify the real PR state.
+
+### 4. Post-checks — independent verification (gh is the ground truth)
+
+Never trust the child's prose; re-derive truth:
+
+```bash
+gh pr checks <n> --repo $REPO
+gh pr view <n> --repo $REPO --json state,mergeStateStatus,labels
+```
+
+Classify the outcome:
+- **merged** — `state=MERGED`.
+- **green-left-open** — checks green, still open, and it is a kaos-ui framework major (intentional; see merge policy).
+- **superseded** — child scope-rejected: a `dependabot.yml` split PR was opened and a comment posted; original left
+  open for the host to close.
+- **blocked** — checks failing/timeout/child error, or any state that is none of the above.
+
+### 5. Apply merge policy (auto-merge safe)
+
+If the PR is **green + mergeable + still open + NOT a kaos-ui framework major + not already merged**, merge it:
+
+```bash
+gh pr merge <n> --repo $REPO --merge
+```
+
+The child already attempts this in its own Step 9; the orchestrator only acts if the PR is verifiably green but still
+open (and not a held kaos-ui major). **Never** merge a kaos-ui framework major — leave it open for human review.
+
+### 6. Record and continue
+
+Update the ledger row to `done` (with a one-line outcome note: `merged` / `left-open` / `superseded` / `blocked
+<reason>`). Restore a clean state for the next child:
+
+```bash
+git checkout main && git reset --hard origin/main >/dev/null 2>./tmp/null
+git status --porcelain   # expect empty
+```
+
+Move to the next PR. **Do not re-discover, do not retry a blocked PR, do not re-queue.**
+
+---
+
+## Phase 2 — Termination & summary
+
+The loop is bounded by the Phase 0 snapshot; once every row is `done`, stop. There is no re-discovery and no retry, so
+the run always terminates.
+
+Print a concise summary table built from the ledger — **not** from child logs:
+
+```sql
+SELECT id, title, status, description FROM todos WHERE id LIKE 'dfa-pr-%' ORDER BY id;
+```
+
+Render as: `PR | ecosystem | outcome | note`. Each child already posted its own REPORT comment on its PR — the
+orchestrator does **not** duplicate those. Write the session summary to `./tmp/dfa-summary.md` if useful; **never commit
+it**.
+
+Close with a one-paragraph wrap-up: how many merged, how many left open for review, how many superseded, how many
+blocked (and the single-line reason for each blocked PR).
+
+---
+
+## Assessment: grouped multi-PR (`/dependabot-fix A,B`) — deferred
+
+Deliberately **not** supported. Dependabot already bundles related dependencies into single grouped PRs, so genuine
+cross-PR coupling is rare; serial single-PR runs handle ordering safely on the shared working tree. Batching two PRs
+into one child would require two `gh pr checkout`s, intertwined diagnosis, and ambiguous merge/REPORT semantics — more
+complexity than value. The orchestrator therefore always runs **one PR per child**. Revisit only if a concrete, repeated
+need emerges.
+
+---
+
+## Invariants
+
+- Discover PRs **once**; never re-list inside the loop (prevents endless growth from new bump/version PRs).
+- **Serial** children only (shared git checkout); clean tree + `main` between runs.
+- One attempt per PR; no orchestrator retry, no re-queue; every child has a `timeout`.
+- **Never** load full child output into context — extract only the final `assistant.message` `RESULT:` line + the
+  `result` exit code from the JSONL log; use `gh` as the ground truth.
+- Fully non-interactive (autopilot); never call `ask_user`.
+- Never auto-merge a kaos-ui framework major; leave it open for human review.
+- Scratch under `./tmp/` (never `/tmp/`); the SQLite `todos` ledger is the durable, resumable state.
+- This skill never spawns another `dependabot-fix-all`.

--- a/.github/skills/dependabot-fix/SKILL.md
+++ b/.github/skills/dependabot-fix/SKILL.md
@@ -115,11 +115,11 @@ Before planning a fix, check whether the PR is **in-scope** for fixing at all. A
 - A major bump on: `react`, `react-dom`, `react-router-dom`, `vite`, `vitest`, `@tanstack/react-query`, `tailwindcss`, `typescript`, `eslint`, `zod`, `zustand` (npm); `controller-runtime`, `k8s.io/*`, `pydantic`, `pydantic-ai`, `litellm` (other ecosystems) when bundled with unrelated updates
 - The PR touches > ~40 packages and the majority are routine but a minority are migrations
 
-When triggered, **do not attempt a fix**. Instead:
+When triggered, **do not attempt a fix** and **do not close the PR yourself** — leave it open for the host to close. Instead:
 1. Update `.github/dependabot.yml` to split the offending group (typically add `update-types: ["minor", "patch"]` to the `all` group so majors get individual PRs).
-2. Open that config change as a separate small PR, merge it.
-3. Close the original Dependabot PR(s) as superseded with a comment explaining that smaller PRs will replace them next cycle.
-4. Skip Phase E's "commit on Dependabot branch" flow — the PR is closed, not fixed. Post REPORT.md as a comment on each closed PR.
+2. Open that config change as a separate small PR (leave it for the host to review/merge).
+3. **Verbalise the scope-reject decision as a comment** on the original Dependabot PR(s): explain why it cannot be fixed in one pass, link the config PR, and recommend the host close it once smaller PRs replace it next cycle. Leave the PR **open** — do not pause for a decision, do not close it.
+4. Skip Phase E's "commit on Dependabot branch" flow — there is no fix. The REPORT.md content can be folded into that comment.
 
 Security-update groups (`all-security`) are usually left bundled because security majors are rare and time-sensitive — only split them if a concrete blocker (e.g. a framework major) forces it.
 
@@ -189,7 +189,7 @@ gh pr checks $PR_NUM --repo $REPO
 gh run rerun <run-id> --failed --repo $REPO  # only for known flakes
 ```
 
-Merge when green — **but** for kaos-ui framework majors, gate the merge on a host smoke confirmation (see Step 9.5):
+Merge when green — **but** for kaos-ui framework **major** bumps, leave the PR open for human review instead of merging (see Step 9.5):
 
 ```bash
 gh pr merge $PR_NUM --repo $REPO --merge
@@ -197,25 +197,24 @@ gh pr merge $PR_NUM --repo $REPO --merge
 
 **Caveats:**
 - Do not use `@dependabot rebase` after pushing fix commits — it will discard them. Let the PR merge as-is.
-- If the merge gate (Step 9.5) is unresolved, **do not merge**. Leave the PR open with the report posted; the host will merge after their visual review.
+- If Step 9.5 says leave-open (kaos-ui framework major), **do not merge**. Post the report and leave the PR open; the host merges after their own visual review.
 
-### Step 9.5 · Host smoke gate (kaos-ui framework majors only)
+### Step 9.5 · kaos-ui review gate (framework majors only)
 
-When the PR is a kaos-ui major bump on a framework package (`react`, `react-dom`, `react-router-dom`, `vite`, `vitest`, `@tanstack/react-query`, `tailwindcss`, `typescript`, `eslint`, `zod`, `zustand`), CI alone is insufficient evidence — visual regressions are invisible to Playwright assertions.
+The visual/E2E suite for kaos-ui is stringent, so **minor and patch** bumps — including framework packages — can be **merged directly** once CI is green. No human gate is needed for them.
 
-Use the **`ask_user` tool** (the built-in Copilot CLI prompt — no other mechanism) with a concrete click-through script. Example:
+For a kaos-ui **major** bump on a framework package (`react`, `react-dom`, `react-router-dom`, `vite`, `vitest`, `@tanstack/react-query`, `tailwindcss`, `typescript`, `eslint`, `zod`, `zustand`), CI alone is insufficient evidence — major-version visual regressions can slip past Playwright assertions. **Do not merge.** Instead:
 
-> Agents list → detail drawer (Overview / Logs / YAML / Events tabs) → Create dialog Dry Run → Visual Map pan/zoom/node click → MCP list + drawer → ModelAPI list + drawer → Chat drawer streaming → theme toggle. Watch DevTools console for red errors and React `Warning:` messages.
+1. Push the fix commits so CI is green.
+2. Post REPORT.md as a PR comment (Step 10), explicitly noting it is a framework **major** held for human visual review.
+3. Leave the PR open. The host reviews and merges manually.
 
-Decision matrix on the `ask_user` response:
-
-| Response | Action |
+| Bump type (kaos-ui) | Action |
 |---|---|
-| Host confirms all checks pass | Merge (Step 9 `gh pr merge`) |
-| Host reports issues | Diagnose and push more commits; re-prompt |
-| Host unavailable (autonomous-mode fallback) | **Do NOT merge.** Post the report (Step 10) and stop. |
+| Minor / patch (any package) | Merge directly when green (Step 9 `gh pr merge`) |
+| Major on framework package | **Do NOT merge.** Post report, leave open for human review |
 
-`ask_user` is the **only** sanctioned host-prompt mechanism for this skill. Do not substitute plain-text questions in the chat output, comments on the PR, or any other channel — those do not block execution and the prompt will be missed.
+Do not use the `ask_user` tool or any in-chat prompt as a merge gate — it does not reliably block execution. The gate is simply "leave the major PR open"; the human review happens on the PR itself.
 
 ### Step 10 · REPORT.md as PR comment — never commit
 
@@ -224,6 +223,23 @@ Write `REPORT.md` at the repo root (gitignored) covering: PR context, symptoms, 
 ```bash
 gh pr comment $PR_NUM --repo $REPO --body-file REPORT.md
 ```
+
+### Step 10.6 · Emit a machine-readable result line
+
+As the **final line of output**, print exactly one status line so an orchestrator (e.g. `/dependabot-fix-all`) can
+classify the outcome without parsing prose:
+
+```
+RESULT: <merged|left-open|superseded|blocked> pr=<PR_NUM> reason="<short phrase>"
+```
+
+- `merged` — fix pushed, CI green, PR merged.
+- `left-open` — CI green but intentionally not merged (kaos-ui framework major held for human review).
+- `superseded` — scope-rejected; `dependabot.yml` split PR opened + comment posted, original left open for host to close.
+- `blocked` — could not be fixed this run (record why in `reason`).
+
+This skill runs **fully non-interactive / autopilot**: never call `ask_user` or ask questions in any mode — resolve
+every decision autonomously per the policies above and emit the RESULT line.
 
 ### Step 11 · Evaluate skill currency
 
@@ -244,6 +260,7 @@ If yes — and only if the learning is non-obvious — open a small follow-up PR
 - Scratch files under `./tmp/` (never `/tmp/`); suppress output with `2>./tmp/null`
 - Conventional-commit style with Copilot co-author trailer
 - REPORT.md is **posted as a PR comment**, never committed
+- Runs fully non-interactive (autopilot); the **final output line** is the `RESULT:` status line (Step 10.6)
 
 ---
 
@@ -272,11 +289,11 @@ Common failure modes observed on bundled Dependabot PRs in this repo. Treat thes
 - For E2E deps (`operator/tests/`): `cd operator/tests && source .venv/bin/activate && make e2e-test` (requires KIND)
 
 ### `npm` in `kaos-ui/` (e.g. PR #143, #146)
-- **Scope-reject first** (see Step 6.5). React / React Router / Vite / Vitest / Zod / Zustand / Tailwind majors bundled with routine bumps = close and reconfigure, don't fix.
+- **Scope-reject first** (see Step 6.5). React / React Router / Vite / Vitest / Zod / Zustand / Tailwind majors bundled with routine bumps = reconfigure `dependabot.yml` and leave the PR open with a comment for the host to close, don't fix.
 - Risk is automatically **high** for any kaos-ui PR with a major bump on a framework package — visual regressions do not show up in CI.
 - Local reproduction: `cd kaos-ui && npm ci && npm run build && npm run lint && npm run test:unit`
 - **Playwright required**, not optional: `npm run test:e2e` against a running dev server + `kaos ui --no-browser` proxy + KIND cluster (per `kaos-ui-testing.instructions.md`). CI's E2E alone is not sufficient evidence.
-- **Host smoke before merge**: gated by Step 9.5 using the `ask_user` tool. If the host is unavailable, do not merge — leave the PR open with the report posted.
+- **Merge policy** (Step 9.5): kaos-ui **minor/patch** bumps merge directly when CI is green; framework **major** bumps are **left open for human review**, never auto-merged. No `ask_user` gate.
 - Common breakage: `vitest` majors change config shape and matcher behaviour; `react-router` majors change route definitions; `@tanstack/react-query` majors change `useQuery` signature; ESLint 9 flat-config drift when `eslint-*` plugins bump.
 - **Lockfile desync** is the dominant failure mode on routine grouped PRs — every UI check fails at `npm ci` with `Missing: <pkg> from lock file`. Fix: delete **both** `node_modules` **and** `package-lock.json`, then `npm install`. Deleting only `node_modules` can trigger a secondary `Cannot find native binding` error from `rolldown`/vitest 4.x optional deps.
 


### PR DESCRIPTION
## Overview
Adds a `/dependabot-fix-all` orchestrator skill that fixes every open Dependabot PR end-to-end on autopilot, and refines the existing `dependabot-fix` skill to support it.

## What changed
- **New skill** `.github/skills/dependabot-fix-all/SKILL.md`: discovers all open Dependabot PRs once, risk-orders them, and processes them **serially** by spawning one isolated non-interactive `copilot -p` child per PR (each running `dependabot-fix` in a fresh context). It verifies each PR independently via `gh`, applies an auto-merge-safe policy (merge green except kaos-ui framework majors), records state in the SQLite ledger, and is bounded so it always terminates.
- **Token-efficient capture**: children run with `--output-format json`; the orchestrator extracts only the final `RESULT:` line + exit code, never the full log.
- **Refined** `dependabot-fix`: dropped the no-op `ask_user` host-smoke gate (replaced with leave-open-for-review scoped to kaos-ui framework majors; minor/patch merge directly), scope-reject now leaves PRs open for the host to close, and added a machine-readable `RESULT:` final line.
- Listed both skills in `.github/copilot-instructions.md`.

## Validation
Non-destructive: discovery correctly lists and risk-orders the open PRs; confirmed headless `copilot -p` works and that `--output-format json` is required to capture the agent reply (plain redirect and `-s` lose it); verified the JSONL extractor. No real fixing child was run against a live PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>