### PR TITLE
fix(skill): repair dependabot-fix-all YAML frontmatter

### DIFF
--- a/.github/skills/dependabot-fix-all/SKILL.md
+++ b/.github/skills/dependabot-fix-all/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependabot-fix-all
-description: Fix every open Dependabot PR end-to-end on autopilot. Use this skill when asked to run /dependabot-fix-all (no arguments). This skill acts as an orchestrator: it discovers all open Dependabot PRs once, risk-orders them, then processes them one at a time by spawning an isolated non-interactive `copilot -p` child per PR that runs the dependabot-fix skill. It verifies each PR independently via gh, applies the merge policy, records state in a durable ledger, and is bounded so it always terminates. Never pauses for user input.
+description: Fix every open Dependabot PR end-to-end on autopilot. Use this skill when asked to run /dependabot-fix-all (no arguments). This skill acts as an orchestrator that discovers all open Dependabot PRs once, risk-orders them, then processes them one at a time by spawning an isolated non-interactive `copilot -p` child per PR that runs the dependabot-fix skill. It verifies each PR independently via gh, applies the merge policy, records state in a durable ledger, and is bounded so it always terminates. Never pauses for user input.
 allowed-tools: shell
 ---
 


### PR DESCRIPTION
The `dependabot-fix-all` skill failed to load (`failed to parse YAML frontmatter: mapping values are not allowed`) because its description scalar contained `orchestrator: it` — a colon-space sequence YAML interprets as a nested mapping. Rephrased to remove the colon so the frontmatter parses. Validated all four skills' frontmatter parse with PyYAML.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>