### PR TITLE
[MEM-2] Add central memory service over the atomic stores

### DIFF
--- a/memory-service/Dockerfile
+++ b/memory-service/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install UV for dependency management
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install uv
+
+# Copy only dependency files first for better layer caching
+COPY pyproject.toml ./
+
+# Install dependencies using UV with cache mount (cached unless pyproject.toml changes)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip compile pyproject.toml -o requirements.txt && \
+    uv pip install --system -r requirements.txt
+
+# Copy source code (changes frequently, so copied last)
+COPY kaos_memory/ kaos_memory/
+
+# Install package (no deps - already installed above) for importlib.metadata
+RUN uv pip install --system --no-deps .
+
+# Default local-mode data directory (Chroma + SQLite + history live here on a PVC)
+RUN mkdir -p /data/memory && \
+    useradd -m -u 65532 memory && chown -R memory:memory /app /data
+USER memory
+
+ENV KAOS_MEMORY_STORAGE_TYPE=local \
+    KAOS_MEMORY_LOCAL_PATH=/data/memory \
+    KAOS_MEMORY_PORT=8080
+
+# Health check hits liveness (independent of store/model readiness)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+    CMD python -c "import httpx; httpx.get('http://localhost:8080/healthz').raise_for_status()" || exit 1
+
+EXPOSE 8080
+
+CMD ["python", "-m", "kaos_memory.app"]

--- a/memory-service/Makefile
+++ b/memory-service/Makefile
@@ -1,10 +1,12 @@
-.PHONY: help build docker-build test lint format clean
+.PHONY: help build docker-build run-local test lint format clean
 
-IMG ?= kaos-memory-service:latest
+IMG ?= axsauze/kaos-memory-service:latest
 
 help:
 	@echo "KAOS Memory Service build targets:"
 	@echo "  build               - Install dependencies using UV"
+	@echo "  docker-build        - Build the container image"
+	@echo "  run-local           - Run the service locally in local storage mode"
 	@echo "  test                - Run pytest tests"
 	@echo "  lint                - Run linting (black check + type check)"
 	@echo "  format              - Format code with black"
@@ -13,6 +15,18 @@ help:
 # Install dependencies
 build:
 	uv pip install -e .[dev]
+
+# Build the container image
+docker-build:
+	docker build -t $(IMG) .
+
+# Run the service locally in local (Chroma + SQLite) mode.
+# Override the model endpoint with KAOS_MEMORY_MODEL_BASE_URL for real extraction.
+run-local:
+	KAOS_MEMORY_STORAGE_TYPE=local \
+	KAOS_MEMORY_LOCAL_PATH=$(PWD)/tmp/memory-data \
+	KAOS_MEMORY_PORT=8080 \
+	python -m kaos_memory
 
 # Run tests
 test:

--- a/memory-service/kaos_memory/__init__.py
+++ b/memory-service/kaos_memory/__init__.py
@@ -8,9 +8,23 @@ run in either a ``local`` (embedded Chroma + SQLite) or ``external`` (pgvector +
 Postgres) storage mode.
 """
 
+from kaos_memory.app import (
+    BackgroundRunner,
+    ForgetRequest,
+    ForgetResponse,
+    MemoryService,
+    RecallRequest,
+    RecallResponse,
+    WriteRequest,
+    WriteResponse,
+    assemble_block,
+    build_service,
+    create_app,
+)
 from kaos_memory.config import (
     ExternalStorage,
     LocalStorage,
+    MemorySettings,
     ModelConfig,
     ShortTermTierConfig,
     StorageConfig,
@@ -31,6 +45,7 @@ __version__ = "0.4.8.dev0"
 __all__ = [
     "ExternalStorage",
     "LocalStorage",
+    "MemorySettings",
     "ModelConfig",
     "StorageConfig",
     "ShortTermTierConfig",
@@ -42,4 +57,15 @@ __all__ = [
     "ModelClient",
     "count_tokens",
     "scope_key",
+    "MemoryService",
+    "BackgroundRunner",
+    "RecallRequest",
+    "RecallResponse",
+    "WriteRequest",
+    "WriteResponse",
+    "ForgetRequest",
+    "ForgetResponse",
+    "assemble_block",
+    "build_service",
+    "create_app",
 ]

--- a/memory-service/kaos_memory/app.py
+++ b/memory-service/kaos_memory/app.py
@@ -508,7 +508,7 @@ def build_service(settings: MemorySettings) -> MemoryService:
 def main() -> None:
     """Entrypoint: build the service from the environment and serve it with uvicorn."""
     settings = MemorySettings()
-    app = create_app(build_service(settings))
+    app = create_app(build_service(settings), request_concurrency=settings.request_concurrency)
     uvicorn.run(app, host=settings.host, port=settings.port)
 
 

--- a/memory-service/kaos_memory/app.py
+++ b/memory-service/kaos_memory/app.py
@@ -79,7 +79,7 @@ class WriteRequest(BaseModel):
     a whole interaction in one call) or as a single ``role``/``content`` pair (normalised into a
     one-element batch). ``infer`` controls whether the engine extracts facts (vs storing raw).
     ``failure_mode`` selects fail-soft (swallow long-term scheduling errors, return degraded) or
-    strict (surface failures as an error).
+    strict (surface failures as an error); when omitted it inherits the service default.
     """
 
     scope: Scope
@@ -87,7 +87,7 @@ class WriteRequest(BaseModel):
     role: Optional[str] = None
     content: Optional[str] = None
     infer: bool = True
-    failure_mode: FailureMode = "soft"
+    failure_mode: Optional[FailureMode] = None
 
     @model_validator(mode="after")
     def _normalise_turns(self) -> "WriteRequest":
@@ -113,7 +113,7 @@ class ForgetRequest(BaseModel):
     """Erase a scope: clear its short-term tier and delete its long-term memories."""
 
     scope: Scope
-    failure_mode: FailureMode = "soft"
+    failure_mode: Optional[FailureMode] = None
 
 
 class ForgetResponse(BaseModel):
@@ -279,6 +279,12 @@ class MemoryService:
     longterm: LongTermStore
     short_term: ShortTermStore
     scheduler: Scheduler = field(default=_thread_scheduler)
+    default_failure_mode: FailureMode = "soft"
+
+    def _resolve_failure_mode(self, requested: Optional[FailureMode]) -> FailureMode:
+        """Layer the failure mode: an explicit per-request value wins, otherwise the
+        service default (itself sourced from the store configuration, defaulting to soft)."""
+        return requested if requested is not None else self.default_failure_mode
 
     def readiness(self) -> dict:
         """Probe both stores and report per-store reachability.
@@ -335,8 +341,8 @@ class MemoryService:
 
         A single call may carry a batch of turns so the runtime persists a whole interaction
         in one request. Extraction is not per-turn: new turns enter the verbatim window, and
-        when the window crosses its water mark the oldest turns are evicted and returned. The
-        evicted turns across the batch are collected and long-term fact extraction consumes
+        when the window crosses its compaction trigger the oldest turns are evicted and returned.
+        The evicted turns across the batch are collected and long-term fact extraction consumes
         them once (and the medium-term digest folds the same rows independently inside the
         store), so the model runs once per fold over a coherent batch rather than once per
         message. The synchronous append is the cheap durable path; ``strict`` surfaces a
@@ -345,12 +351,12 @@ class MemoryService:
         """
         with tracer.start_as_current_span("kaos.memory.write") as span:
             span.set_attribute("kaos.memory.scope_level", req.scope.level.value)
-            strict = req.failure_mode == "strict"
+            strict = self._resolve_failure_mode(req.failure_mode) == "strict"
 
             try:
-                evicted: List[Tuple[str, str]] = []
-                for turn in req.turns:
-                    evicted.extend(self.short_term.add(req.scope, turn.role, turn.content))
+                evicted = self.short_term.add(
+                    req.scope, [(turn.role, turn.content) for turn in req.turns]
+                )
             except Exception:
                 span.set_attribute("kaos.memory.degraded", True)
                 if strict:
@@ -392,7 +398,7 @@ class MemoryService:
                 self.longterm.delete_scope(req.scope)
             except Exception:
                 span.set_attribute("kaos.memory.degraded", True)
-                if req.failure_mode == "strict":
+                if self._resolve_failure_mode(req.failure_mode) == "strict":
                     raise
                 return ForgetResponse(forgotten=True, degraded=True)
             return ForgetResponse(forgotten=True, degraded=False)
@@ -502,7 +508,12 @@ def build_service(settings: MemorySettings) -> MemoryService:
         summarizer,
         scheduler=runner,
     )
-    return MemoryService(longterm=longterm, short_term=short_term, scheduler=runner)
+    return MemoryService(
+        longterm=longterm,
+        short_term=short_term,
+        scheduler=runner,
+        default_failure_mode=settings.default_failure_mode,
+    )
 
 
 def main() -> None:

--- a/memory-service/kaos_memory/app.py
+++ b/memory-service/kaos_memory/app.py
@@ -125,23 +125,31 @@ class ForgetResponse(BaseModel):
 
 
 class ShortTermContext(BaseModel):
-    """The short-term tier slice of a recall response."""
+    """The short-term tier slice of a recall response: the verbatim active window."""
 
-    summary: str = ""
     recent: List[Tuple[str, str]] = Field(default_factory=list)
 
 
+class MediumTermContext(BaseModel):
+    """The medium-term tier slice of a recall response: the rolling conversation digest."""
+
+    summary: str = ""
+
+
 class RecallResponse(BaseModel):
-    """Assembled recall context: native long-term facts, short-term context, and a block.
+    """Assembled recall context: native long-term facts, the medium-term digest, the
+    short-term window, and a rendered block.
 
     ``facts`` are Mem0's native result dicts (memory text, score, id, metadata),
-    passed through unmodified. ``block`` is the deterministic structured text the
-    runtime injects into the system context. ``degraded`` is set when long-term
-    recall failed and only short-term context is present.
+    passed through unmodified. ``medium_term`` carries the rolling digest and ``short_term``
+    the verbatim recent turns. ``block`` is the deterministic structured text the runtime
+    injects into the system context. ``degraded`` is set when long-term recall failed and
+    only the conversational tiers are present.
     """
 
     facts: List[Dict[str, Any]] = Field(default_factory=list)
     short_term: ShortTermContext = Field(default_factory=ShortTermContext)
+    medium_term: MediumTermContext = Field(default_factory=MediumTermContext)
     block: str = ""
     degraded: bool = False
 
@@ -292,7 +300,7 @@ class MemoryService:
 
     def recall(self, req: RecallRequest) -> RecallResponse:
         """Assemble recall context for a scope. Fail-soft: long-term errors degrade
-        to short-term-only context rather than failing the request."""
+        to conversational-tier-only context rather than failing the request."""
         with tracer.start_as_current_span("kaos.memory.recall") as span:
             span.set_attribute("kaos.memory.scope_level", req.scope.level.value)
             facts: list = []
@@ -314,7 +322,8 @@ class MemoryService:
             block = assemble_block(facts, summary, recent)
             return RecallResponse(
                 facts=facts,
-                short_term=ShortTermContext(summary=summary, recent=recent),
+                short_term=ShortTermContext(recent=recent),
+                medium_term=MediumTermContext(summary=summary),
                 block=block,
                 degraded=degraded,
             )

--- a/memory-service/kaos_memory/app.py
+++ b/memory-service/kaos_memory/app.py
@@ -1,0 +1,454 @@
+"""Central memory service: the HTTP surface, request/response schemas, block
+presentation, bounded background runner and the entrypoint wiring.
+
+The service composes the two atomic stores (long-term over Mem0, short-term
+relational buffer) into one KAOS-owned process so agents call a shared service
+rather than embedding the engine. This module holds:
+
+- the HTTP request/response schemas that mirror the memory contract;
+- the deterministic recall block renderer injected into the agent's context;
+- a bounded fire-and-forget background runner for off-path work;
+- the ``MemoryService`` that the request handlers operate on;
+- the FastAPI app factory and the ``main`` entrypoint that builds the real
+  stores from the environment.
+
+Keeping the inbound HTTP layer here (separate from ``stores.py``, which owns the
+storage engine the service calls) is the one intentional split: the store module
+is the outbound dependency, this module is the inbound edge.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from opentelemetry import trace
+from pydantic import BaseModel, Field
+
+from kaos_memory.config import MemorySettings
+from kaos_memory.stores import (
+    LongTermStore,
+    ModelClient,
+    Scheduler,
+    Scope,
+    ShortTermStore,
+)
+
+tracer = trace.get_tracer("kaos.memory")
+logger = logging.getLogger("kaos.memory.background")
+
+
+# --------------------------------------------------------------------------- #
+# HTTP schemas — thin wrappers over the store-level value objects.
+# --------------------------------------------------------------------------- #
+
+
+class RecallRequest(BaseModel):
+    """Synchronous recall: assemble context visible at ``scope`` for ``query``."""
+
+    scope: Scope
+    query: str
+    top_k: int = 10
+    include_short_term: bool = True
+    short_term_token_budget: Optional[int] = None
+
+
+FailureMode = str  # "soft" | "strict"
+
+
+class WriteRequest(BaseModel):
+    """Record a turn: add to the short-term tier synchronously, extract long-term async.
+
+    ``infer`` controls whether the engine extracts facts (vs storing raw). ``failure_mode``
+    selects fail-soft (swallow long-term scheduling errors, return degraded) or strict
+    (surface failures as an error).
+    """
+
+    scope: Scope
+    role: str
+    content: str
+    infer: bool = True
+    failure_mode: FailureMode = "soft"
+
+
+class WriteResponse(BaseModel):
+    """Acknowledges a write. ``scheduled`` indicates long-term extraction was queued;
+    ``degraded`` is set when a fail-soft request swallowed a scheduling error."""
+
+    accepted: bool = True
+    scheduled: bool = False
+    degraded: bool = False
+
+
+class ForgetRequest(BaseModel):
+    """Erase a scope: clear its short-term tier and delete its long-term memories."""
+
+    scope: Scope
+    failure_mode: FailureMode = "soft"
+
+
+class ForgetResponse(BaseModel):
+    """Acknowledges a forget. ``degraded`` is set when the long-term erasure failed
+    under fail-soft (the short-term tier was still cleared)."""
+
+    forgotten: bool = True
+    degraded: bool = False
+
+
+class ShortTermContext(BaseModel):
+    """The short-term tier slice of a recall response."""
+
+    summary: str = ""
+    recent: List[Tuple[str, str]] = Field(default_factory=list)
+
+
+class RecallResponse(BaseModel):
+    """Assembled recall context: native long-term facts, short-term context, and a block.
+
+    ``facts`` are Mem0's native result dicts (memory text, score, id, metadata),
+    passed through unmodified. ``block`` is the deterministic structured text the
+    runtime injects into the system context. ``degraded`` is set when long-term
+    recall failed and only short-term context is present.
+    """
+
+    facts: List[Dict[str, Any]] = Field(default_factory=list)
+    short_term: ShortTermContext = Field(default_factory=ShortTermContext)
+    block: str = ""
+    degraded: bool = False
+
+
+# --------------------------------------------------------------------------- #
+# Presentation — render recalled memory into a deterministic injectable block.
+# --------------------------------------------------------------------------- #
+
+
+def _fact_text(fact: Dict[str, Any]) -> str:
+    """Extract the human-readable text from a Mem0 result dict."""
+    return fact.get("memory") or fact.get("text") or ""
+
+
+def assemble_block(
+    facts: List[Dict[str, Any]],
+    summary: str,
+    recent: List[Tuple[str, str]],
+) -> str:
+    """Render the structured memory block. Empty inputs yield an empty block.
+
+    The block is plain text the runtime injects into the agent's system context (not
+    as fabricated prior turns). It is always-on and cheap, rendering whatever context
+    is available — long-term facts, a rolling summary, recent verbatim turns.
+    """
+    sections: List[str] = []
+
+    fact_lines = [f"- {_fact_text(f)}" for f in facts if _fact_text(f)]
+    if fact_lines:
+        sections.append("## Relevant memory\n" + "\n".join(fact_lines))
+
+    if summary.strip():
+        sections.append("## Conversation summary\n" + summary.strip())
+
+    if recent:
+        turns = "\n".join(f"{role}: {content}" for role, content in recent)
+        sections.append("## Recent turns\n" + turns)
+
+    return "\n\n".join(sections)
+
+
+# --------------------------------------------------------------------------- #
+# Background runner — bounded fire-and-forget off-path work.
+# --------------------------------------------------------------------------- #
+
+#: Invoked when a task gives up after exhausting retries (the exception is passed).
+GiveupHook = Callable[[BaseException], None]
+
+
+class BackgroundRunner:
+    """Runs thunks on a bounded threadpool with bounded retry and graceful drain.
+
+    Long-term extraction, consolidation, forgetting and short-term summary folding run
+    off the request path. This runner bounds their concurrency, retries transient
+    failures a fixed number of times, and gives up cleanly (without crashing the
+    service) when retries are exhausted. Pending work drains on shutdown.
+
+    The service handlers are synchronous (FastAPI runs them on a threadpool), so the
+    runner is thread-based: a ``ThreadPoolExecutor`` caps concurrency at ``concurrency``
+    workers, the natural fit for the sync server model.
+    """
+
+    def __init__(
+        self,
+        concurrency: int = 4,
+        max_retries: int = 2,
+        retry_delay: float = 0.0,
+        on_giveup: Optional[GiveupHook] = None,
+    ) -> None:
+        if concurrency < 1:
+            raise ValueError("concurrency must be >= 1")
+        self.concurrency = concurrency
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self.on_giveup = on_giveup
+        self.failures = 0
+        self._executor = ThreadPoolExecutor(max_workers=concurrency)
+
+    def submit(self, thunk: Callable[[], None]) -> None:
+        """Schedule ``thunk`` to run off the response path. Never blocks the caller."""
+        self._executor.submit(self._run_with_retry, thunk)
+
+    # Usable directly as a Scheduler (Callable[[thunk], None]).
+    __call__ = submit
+
+    def _run_with_retry(self, thunk: Callable[[], None]) -> None:
+        attempts = self.max_retries + 1
+        last: Optional[BaseException] = None
+        for attempt in range(attempts):
+            try:
+                thunk()
+                return
+            except Exception as exc:  # bounded retry; never propagate out of the worker
+                last = exc
+                if attempt + 1 < attempts and self.retry_delay:
+                    time.sleep(self.retry_delay)
+        self.failures += 1
+        logger.warning("background task gave up after %d attempts: %s", attempts, last)
+        if self.on_giveup is not None and last is not None:
+            try:
+                self.on_giveup(last)
+            except Exception:  # never let the give-up hook crash a worker
+                logger.exception("on_giveup hook raised")
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Drain pending work and stop accepting new tasks."""
+        self._executor.shutdown(wait=wait)
+
+
+def _thread_scheduler(thunk: Callable[[], None]) -> None:
+    """Default scheduler: run the thunk on a daemon thread (replaced by the bounded
+    background runner when one is supplied)."""
+    import threading
+
+    threading.Thread(target=thunk, daemon=True).start()
+
+
+# --------------------------------------------------------------------------- #
+# MemoryService — the request handlers operating over live store instances.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class MemoryService:
+    """Holds the live store instances the request handlers operate on."""
+
+    longterm: LongTermStore
+    short_term: ShortTermStore
+    scheduler: Scheduler = field(default=_thread_scheduler)
+
+    def readiness(self) -> dict:
+        """Probe both stores and report per-store reachability.
+
+        Reflects store reachability only — models bind lazily on first use, so an
+        as-yet-unreachable ModelAPI must not fail readiness. Returns a mapping of
+        ``{"ready": bool, "stores": {name: ok|error}}``.
+        """
+        stores: dict[str, object] = {}
+        ok = True
+        for name, probe in (("short_term", self.short_term.ping), ("longterm", self.longterm.ping)):
+            try:
+                probe()
+                stores[name] = True
+            except Exception as exc:  # reachability probe: any failure means not-ready
+                stores[name] = f"{type(exc).__name__}: {exc}"
+                ok = False
+        return {"ready": ok, "stores": stores}
+
+    def recall(self, req: RecallRequest) -> RecallResponse:
+        """Assemble recall context for a scope. Fail-soft: long-term errors degrade
+        to short-term-only context rather than failing the request."""
+        with tracer.start_as_current_span("kaos.memory.recall") as span:
+            span.set_attribute("kaos.memory.scope_level", req.scope.level.value)
+            facts: list = []
+            degraded = False
+            try:
+                facts = self.longterm.recall(req.scope, req.query, top_k=req.top_k)
+            except Exception:
+                degraded = True
+
+            summary, recent = "", []
+            if req.include_short_term:
+                summary = self.short_term.summary(req.scope)
+                recent = self.short_term.active_window(
+                    req.scope, token_budget=req.short_term_token_budget
+                )
+
+            span.set_attribute("kaos.memory.degraded", degraded)
+            span.set_attribute("kaos.memory.fact_count", len(facts))
+            block = assemble_block(facts, summary, recent)
+            return RecallResponse(
+                facts=facts,
+                short_term=ShortTermContext(summary=summary, recent=recent),
+                block=block,
+                degraded=degraded,
+            )
+
+    def write(self, req: WriteRequest) -> WriteResponse:
+        """Add a turn to the short-term tier synchronously, then schedule long-term
+        extraction off the response path so the call returns immediately.
+
+        The synchronous short-term add is the cheap durable path. ``strict`` surfaces a
+        failure as an exception (the handler maps it to an error); ``soft`` returns a
+        degraded acknowledgement instead of failing the request.
+        """
+        with tracer.start_as_current_span("kaos.memory.write") as span:
+            span.set_attribute("kaos.memory.scope_level", req.scope.level.value)
+            strict = req.failure_mode == "strict"
+
+            try:
+                self.short_term.add(req.scope, req.role, req.content)
+            except Exception:
+                span.set_attribute("kaos.memory.degraded", True)
+                if strict:
+                    raise
+                return WriteResponse(accepted=True, scheduled=False, degraded=True)
+
+            def _extract() -> None:
+                with tracer.start_as_current_span("kaos.memory.consolidate"):
+                    self.longterm.add(
+                        req.scope, [{"role": req.role, "content": req.content}], infer=req.infer
+                    )
+
+            try:
+                self.scheduler(_extract)
+            except Exception:
+                span.set_attribute("kaos.memory.degraded", True)
+                if strict:
+                    raise
+                return WriteResponse(accepted=True, scheduled=False, degraded=True)
+
+            span.set_attribute("kaos.memory.scheduled", True)
+            return WriteResponse(accepted=True, scheduled=True, degraded=False)
+
+    def forget(self, req: ForgetRequest) -> ForgetResponse:
+        """Erase a scope across both tiers: clear the short-term tier (durable) and delete
+        the scope's long-term memories. Fail-soft: a long-term erasure error degrades
+        the response but the short-term tier is still cleared."""
+        with tracer.start_as_current_span("kaos.memory.forget") as span:
+            span.set_attribute("kaos.memory.scope_level", req.scope.level.value)
+            self.short_term.clear(req.scope)
+            try:
+                self.longterm.delete_scope(req.scope)
+            except Exception:
+                span.set_attribute("kaos.memory.degraded", True)
+                if req.failure_mode == "strict":
+                    raise
+                return ForgetResponse(forgotten=True, degraded=True)
+            return ForgetResponse(forgotten=True, degraded=False)
+
+
+# --------------------------------------------------------------------------- #
+# App factory and entrypoint.
+# --------------------------------------------------------------------------- #
+
+
+def create_app(service: MemoryService) -> FastAPI:
+    """Build the FastAPI app bound to a ``MemoryService``."""
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        yield
+        # Drain pending background work if the scheduler is a drainable runner.
+        drain = getattr(app.state.memory.scheduler, "shutdown", None)
+        if callable(drain):
+            drain(wait=True)
+
+    app = FastAPI(title="KAOS Memory Service", lifespan=lifespan)
+    app.state.memory = service
+
+    @app.get("/healthz")
+    def healthz() -> dict:
+        """Liveness: the process is up and serving. Independent of store state."""
+        return {"status": "ok"}
+
+    @app.get("/readyz")
+    def readyz() -> JSONResponse:
+        """Readiness: both stores are reachable. 503 when any store probe fails."""
+        result = app.state.memory.readiness()
+        code = 200 if result["ready"] else 503
+        return JSONResponse(result, status_code=code)
+
+    @app.post("/v1/recall", response_model=RecallResponse)
+    def recall(req: RecallRequest) -> RecallResponse:
+        """Synchronous recall: assemble long-term facts and short-term context for a scope."""
+        return app.state.memory.recall(req)
+
+    @app.post("/v1/write", response_model=WriteResponse)
+    def write(req: WriteRequest) -> JSONResponse:
+        """Record a turn: durable short-term add now, long-term extraction scheduled."""
+        try:
+            result = app.state.memory.write(req)
+        except Exception as exc:
+            return JSONResponse(
+                {"accepted": False, "error": f"{type(exc).__name__}: {exc}"}, status_code=500
+            )
+        return JSONResponse(result.model_dump(), status_code=202 if result.scheduled else 200)
+
+    @app.post("/v1/forget", response_model=ForgetResponse)
+    def forget(req: ForgetRequest) -> JSONResponse:
+        """Erase a scope across both tiers."""
+        try:
+            result = app.state.memory.forget(req)
+        except Exception as exc:
+            return JSONResponse(
+                {"forgotten": False, "error": f"{type(exc).__name__}: {exc}"}, status_code=500
+            )
+        return JSONResponse(result.model_dump(), status_code=200)
+
+    return app
+
+
+def app_from_service(
+    longterm: LongTermStore, short_term: ShortTermStore, _service: Optional[MemoryService] = None
+) -> FastAPI:
+    """Convenience constructor used by tests: wrap stores and build the app."""
+    return create_app(MemoryService(longterm=longterm, short_term=short_term))
+
+
+def build_service(settings: MemorySettings) -> MemoryService:
+    """Construct the long-term and short-term stores and wrap them in a ``MemoryService``.
+
+    A single bounded background runner backs both off-path paths: short-term summary
+    folding (injected as the store's scheduler) and long-term extraction (the service
+    scheduler), so all deferred work shares one bounded, drainable threadpool.
+    """
+    storage = settings.storage()
+    runner = BackgroundRunner(
+        concurrency=settings.extraction_concurrency,
+        max_retries=settings.extraction_max_retries,
+    )
+    longterm = LongTermStore(storage, settings.summarization(), settings.embedding())
+    summarizer = ModelClient(settings.summarization()).as_summarizer()
+    short_term = ShortTermStore(
+        settings.storage_type,
+        settings.short_term_target(),
+        settings.short_term_tier(),
+        summarizer,
+        scheduler=runner,
+    )
+    return MemoryService(longterm=longterm, short_term=short_term, scheduler=runner)
+
+
+def main() -> None:
+    """Entrypoint: build the service from the environment and serve it with uvicorn."""
+    settings = MemorySettings()
+    app = create_app(build_service(settings))
+    uvicorn.run(app, host=settings.host, port=settings.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/memory-service/kaos_memory/app.py
+++ b/memory-service/kaos_memory/app.py
@@ -19,6 +19,7 @@ is the outbound dependency, this module is the inbound edge.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -393,8 +394,16 @@ class MemoryService:
 # --------------------------------------------------------------------------- #
 
 
-def create_app(service: MemoryService) -> FastAPI:
-    """Build the FastAPI app bound to a ``MemoryService``."""
+def create_app(service: MemoryService, request_concurrency: int = 8) -> FastAPI:
+    """Build the FastAPI app bound to a ``MemoryService``.
+
+    The request handlers are async, but the store and Mem0 calls they make are synchronous
+    (Mem0's client is sync and its async surface only wraps threads). Rather than block the
+    event loop or lean on the server's implicit threadpool, blocking work is dispatched to a
+    KAOS-owned bounded executor — the explicit Mem0 isolation boundary — sized by
+    ``request_concurrency``. Native async database access is a later optimisation; here the
+    synchronous short-term path is cheap and runs behind the same boundary.
+    """
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -403,32 +412,39 @@ def create_app(service: MemoryService) -> FastAPI:
         drain = getattr(app.state.memory.scheduler, "shutdown", None)
         if callable(drain):
             drain(wait=True)
+        app.state.request_pool.shutdown(wait=True)
 
     app = FastAPI(title="KAOS Memory Service", lifespan=lifespan)
     app.state.memory = service
+    app.state.request_pool = ThreadPoolExecutor(max_workers=request_concurrency)
+
+    async def _offload(fn: Callable[[], Any]) -> Any:
+        """Run a blocking store/Mem0 call on the bounded executor, off the event loop."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(app.state.request_pool, fn)
 
     @app.get("/healthz")
-    def healthz() -> dict:
+    async def healthz() -> dict:
         """Liveness: the process is up and serving. Independent of store state."""
         return {"status": "ok"}
 
     @app.get("/readyz")
-    def readyz() -> JSONResponse:
+    async def readyz() -> JSONResponse:
         """Readiness: both stores are reachable. 503 when any store probe fails."""
-        result = app.state.memory.readiness()
+        result = await _offload(app.state.memory.readiness)
         code = 200 if result["ready"] else 503
         return JSONResponse(result, status_code=code)
 
     @app.post("/v1/recall", response_model=RecallResponse)
-    def recall(req: RecallRequest) -> RecallResponse:
+    async def recall(req: RecallRequest) -> RecallResponse:
         """Synchronous recall: assemble long-term facts and short-term context for a scope."""
-        return app.state.memory.recall(req)
+        return await _offload(lambda: app.state.memory.recall(req))
 
     @app.post("/v1/write", response_model=WriteResponse)
-    def write(req: WriteRequest) -> JSONResponse:
-        """Record a turn: durable short-term add now, long-term extraction scheduled."""
+    async def write(req: WriteRequest) -> JSONResponse:
+        """Record turns: durable short-term append now, long-term extraction scheduled on fold."""
         try:
-            result = app.state.memory.write(req)
+            result = await _offload(lambda: app.state.memory.write(req))
         except Exception as exc:
             return JSONResponse(
                 {"accepted": False, "error": f"{type(exc).__name__}: {exc}"}, status_code=500
@@ -436,10 +452,10 @@ def create_app(service: MemoryService) -> FastAPI:
         return JSONResponse(result.model_dump(), status_code=202 if result.scheduled else 200)
 
     @app.post("/v1/forget", response_model=ForgetResponse)
-    def forget(req: ForgetRequest) -> JSONResponse:
+    async def forget(req: ForgetRequest) -> JSONResponse:
         """Erase a scope across both tiers."""
         try:
-            result = app.state.memory.forget(req)
+            result = await _offload(lambda: app.state.memory.forget(req))
         except Exception as exc:
             return JSONResponse(
                 {"forgotten": False, "error": f"{type(exc).__name__}: {exc}"}, status_code=500

--- a/memory-service/kaos_memory/app.py
+++ b/memory-service/kaos_memory/app.py
@@ -64,7 +64,8 @@ FailureMode = str  # "soft" | "strict"
 
 
 class WriteRequest(BaseModel):
-    """Record a turn: add to the short-term tier synchronously, extract long-term async.
+    """Record a turn: append to the short-term window synchronously; long-term extraction
+    runs later, per fold, over the batch the append evicts.
 
     ``infer`` controls whether the engine extracts facts (vs storing raw). ``failure_mode``
     selects fail-soft (swallow long-term scheduling errors, return degraded) or strict
@@ -79,8 +80,10 @@ class WriteRequest(BaseModel):
 
 
 class WriteResponse(BaseModel):
-    """Acknowledges a write. ``scheduled`` indicates long-term extraction was queued;
-    ``degraded`` is set when a fail-soft request swallowed a scheduling error."""
+    """Acknowledges a write. ``scheduled`` indicates the append evicted a batch and long-term
+    extraction of that batch was queued (writes that only buffer the turn return
+    ``scheduled=False``); ``degraded`` is set when a fail-soft request swallowed a
+    scheduling error."""
 
     accepted: bool = True
     scheduled: bool = False
@@ -298,30 +301,41 @@ class MemoryService:
             )
 
     def write(self, req: WriteRequest) -> WriteResponse:
-        """Add a turn to the short-term tier synchronously, then schedule long-term
-        extraction off the response path so the call returns immediately.
+        """Append a turn to the short-term window synchronously; when the append evicts a
+        batch, schedule long-term extraction of *that evicted batch* off the response path.
 
-        The synchronous short-term add is the cheap durable path. ``strict`` surfaces a
-        failure as an exception (the handler maps it to an error); ``soft`` returns a
-        degraded acknowledgement instead of failing the request.
+        Extraction is not per-turn. New turns enter the verbatim window; when the window
+        crosses its water mark the oldest turns are evicted, and ``add`` returns that
+        evicted batch. Long-term fact extraction consumes the evicted batch (and the
+        medium-term digest folds the same rows independently inside the store), so the
+        model runs once per fold over a coherent batch rather than once per message. The
+        synchronous append is the cheap durable path; ``strict`` surfaces a failure as an
+        exception (the handler maps it to an error), ``soft`` returns a degraded
+        acknowledgement instead of failing the request.
         """
         with tracer.start_as_current_span("kaos.memory.write") as span:
             span.set_attribute("kaos.memory.scope_level", req.scope.level.value)
             strict = req.failure_mode == "strict"
 
             try:
-                self.short_term.add(req.scope, req.role, req.content)
+                evicted = self.short_term.add(req.scope, req.role, req.content)
             except Exception:
                 span.set_attribute("kaos.memory.degraded", True)
                 if strict:
                     raise
                 return WriteResponse(accepted=True, scheduled=False, degraded=True)
 
+            span.set_attribute("kaos.memory.evicted", len(evicted))
+            if not evicted:
+                # The turn is buffered in the window; nothing has left it yet, so there is
+                # no batch to consolidate. Extraction runs later, when a fold evicts.
+                return WriteResponse(accepted=True, scheduled=False, degraded=False)
+
+            messages = [{"role": role, "content": content} for role, content in evicted]
+
             def _extract() -> None:
                 with tracer.start_as_current_span("kaos.memory.consolidate"):
-                    self.longterm.add(
-                        req.scope, [{"role": req.role, "content": req.content}], infer=req.infer
-                    )
+                    self.longterm.add(req.scope, messages, infer=req.infer)
 
             try:
                 self.scheduler(_extract)

--- a/memory-service/kaos_memory/app.py
+++ b/memory-service/kaos_memory/app.py
@@ -30,7 +30,7 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from opentelemetry import trace
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from kaos_memory.config import MemorySettings
 from kaos_memory.stores import (
@@ -63,20 +63,38 @@ class RecallRequest(BaseModel):
 FailureMode = str  # "soft" | "strict"
 
 
-class WriteRequest(BaseModel):
-    """Record a turn: append to the short-term window synchronously; long-term extraction
-    runs later, per fold, over the batch the append evicts.
+class Turn(BaseModel):
+    """A single conversational turn: a role and its content."""
 
-    ``infer`` controls whether the engine extracts facts (vs storing raw). ``failure_mode``
-    selects fail-soft (swallow long-term scheduling errors, return degraded) or strict
-    (surface failures as an error).
+    role: str
+    content: str
+
+
+class WriteRequest(BaseModel):
+    """Record one or more turns: append them to the short-term window synchronously; long-term
+    extraction runs later, per fold, over the batch the appends evict.
+
+    Turns are supplied either as a ``turns`` list (the batch shape the runtime uses to persist
+    a whole interaction in one call) or as a single ``role``/``content`` pair (normalised into a
+    one-element batch). ``infer`` controls whether the engine extracts facts (vs storing raw).
+    ``failure_mode`` selects fail-soft (swallow long-term scheduling errors, return degraded) or
+    strict (surface failures as an error).
     """
 
     scope: Scope
-    role: str
-    content: str
+    turns: List[Turn] = Field(default_factory=list)
+    role: Optional[str] = None
+    content: Optional[str] = None
     infer: bool = True
     failure_mode: FailureMode = "soft"
+
+    @model_validator(mode="after")
+    def _normalise_turns(self) -> "WriteRequest":
+        if self.role is not None and self.content is not None:
+            self.turns = [Turn(role=self.role, content=self.content), *self.turns]
+        if not self.turns:
+            raise ValueError("write requires either turns[] or a role/content pair")
+        return self
 
 
 class WriteResponse(BaseModel):
@@ -301,16 +319,18 @@ class MemoryService:
             )
 
     def write(self, req: WriteRequest) -> WriteResponse:
-        """Append a turn to the short-term window synchronously; when the append evicts a
-        batch, schedule long-term extraction of *that evicted batch* off the response path.
+        """Append one or more turns to the short-term window synchronously; when the appends
+        evict a batch, schedule long-term extraction of *that evicted batch* off the response
+        path.
 
-        Extraction is not per-turn. New turns enter the verbatim window; when the window
-        crosses its water mark the oldest turns are evicted, and ``add`` returns that
-        evicted batch. Long-term fact extraction consumes the evicted batch (and the
-        medium-term digest folds the same rows independently inside the store), so the
-        model runs once per fold over a coherent batch rather than once per message. The
-        synchronous append is the cheap durable path; ``strict`` surfaces a failure as an
-        exception (the handler maps it to an error), ``soft`` returns a degraded
+        A single call may carry a batch of turns so the runtime persists a whole interaction
+        in one request. Extraction is not per-turn: new turns enter the verbatim window, and
+        when the window crosses its water mark the oldest turns are evicted and returned. The
+        evicted turns across the batch are collected and long-term fact extraction consumes
+        them once (and the medium-term digest folds the same rows independently inside the
+        store), so the model runs once per fold over a coherent batch rather than once per
+        message. The synchronous append is the cheap durable path; ``strict`` surfaces a
+        failure as an exception (the handler maps it to an error), ``soft`` returns a degraded
         acknowledgement instead of failing the request.
         """
         with tracer.start_as_current_span("kaos.memory.write") as span:
@@ -318,16 +338,19 @@ class MemoryService:
             strict = req.failure_mode == "strict"
 
             try:
-                evicted = self.short_term.add(req.scope, req.role, req.content)
+                evicted: List[Tuple[str, str]] = []
+                for turn in req.turns:
+                    evicted.extend(self.short_term.add(req.scope, turn.role, turn.content))
             except Exception:
                 span.set_attribute("kaos.memory.degraded", True)
                 if strict:
                     raise
                 return WriteResponse(accepted=True, scheduled=False, degraded=True)
 
+            span.set_attribute("kaos.memory.turns", len(req.turns))
             span.set_attribute("kaos.memory.evicted", len(evicted))
             if not evicted:
-                # The turn is buffered in the window; nothing has left it yet, so there is
+                # The turns are buffered in the window; nothing has left it yet, so there is
                 # no batch to consolidate. Extraction runs later, when a fold evicts.
                 return WriteResponse(accepted=True, scheduled=False, degraded=False)
 

--- a/memory-service/kaos_memory/config.py
+++ b/memory-service/kaos_memory/config.py
@@ -140,9 +140,11 @@ class MemorySettings(BaseSettings):
     token_budget: int = 4096
     rolling_summary: bool = False
     hard_event_cap: int = 2000
-    high_water: int = 0
-    low_water: int = 0
+    compaction_trigger: int = 0
+    compaction_target: int = 0
     digest_retention: int = 20
+
+    default_failure_mode: str = "soft"
 
     extraction_concurrency: int = 4
     extraction_max_retries: int = 2
@@ -184,8 +186,8 @@ class MemorySettings(BaseSettings):
             token_budget=self.token_budget,
             rolling_summary=self.rolling_summary,
             hard_event_cap=self.hard_event_cap,
-            high_water=self.high_water,
-            low_water=self.low_water,
+            compaction_trigger=self.compaction_trigger,
+            compaction_target=self.compaction_target,
             digest_retention=self.digest_retention,
         )
 

--- a/memory-service/kaos_memory/config.py
+++ b/memory-service/kaos_memory/config.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 StorageType = Literal["local", "external"]
 LocalProvider = Literal["chroma"]
@@ -109,3 +110,79 @@ class ShortTermTierConfig(BaseModel):
                 "0 < compaction_target < compaction_trigger <= token_budget"
             )
         return self
+
+
+class MemorySettings(BaseSettings):
+    """Environment-driven configuration for the memory service.
+
+    The operator resolves a ``MemoryStore`` custom resource into these environment
+    variables (all prefixed ``KAOS_MEMORY_``); here we map them onto the typed config
+    objects above. Exactly one storage block is used depending on ``storage_type``.
+    Rolling summarisation is off by default, matching ``ShortTermTierConfig``.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="KAOS_MEMORY_", extra="ignore")
+
+    storage_type: str = "local"
+
+    local_path: str = "/data/memory"
+    local_collection: str = "kaos_memory"
+
+    external_dsn: str = ""
+    external_collection: str = "kaos_memory"
+    external_dims: int = 1536
+
+    model_base_url: str = "http://localhost:8000/v1"
+    model_api_key: str = "kaos"
+    summarization_model: str = "gpt-4o-mini"
+    embedding_model: str = "text-embedding-3-small"
+
+    token_budget: int = 4096
+    rolling_summary: bool = False
+    hard_event_cap: int = 2000
+
+    extraction_concurrency: int = 4
+    extraction_max_retries: int = 2
+
+    host: str = "0.0.0.0"
+    port: int = 8080
+
+    def storage(self) -> StorageConfig:
+        if self.storage_type == "local":
+            return StorageConfig(
+                type="local",
+                local=LocalStorage(path=self.local_path, collection_name=self.local_collection),
+            )
+        if self.storage_type == "external":
+            return StorageConfig(
+                type="external",
+                external=ExternalStorage(
+                    dsn=self.external_dsn,
+                    collection_name=self.external_collection,
+                    embedding_dims=self.external_dims,
+                ),
+            )
+        raise ValueError(f"unknown storage type: {self.storage_type}")
+
+    def summarization(self) -> ModelConfig:
+        return ModelConfig(
+            base_url=self.model_base_url, model=self.summarization_model, api_key=self.model_api_key
+        )
+
+    def embedding(self) -> ModelConfig:
+        return ModelConfig(
+            base_url=self.model_base_url, model=self.embedding_model, api_key=self.model_api_key
+        )
+
+    def short_term_tier(self) -> ShortTermTierConfig:
+        return ShortTermTierConfig(
+            token_budget=self.token_budget,
+            rolling_summary=self.rolling_summary,
+            hard_event_cap=self.hard_event_cap,
+        )
+
+    def short_term_target(self) -> str:
+        """SQLite file path (local) or Postgres DSN (external) for the short-term table."""
+        if self.storage_type == "local":
+            return f"{self.local_path.rstrip('/')}/shortterm.db"
+        return self.external_dsn

--- a/memory-service/kaos_memory/config.py
+++ b/memory-service/kaos_memory/config.py
@@ -140,9 +140,14 @@ class MemorySettings(BaseSettings):
     token_budget: int = 4096
     rolling_summary: bool = False
     hard_event_cap: int = 2000
+    high_water: int = 0
+    low_water: int = 0
+    digest_retention: int = 20
 
     extraction_concurrency: int = 4
     extraction_max_retries: int = 2
+
+    request_concurrency: int = 8
 
     host: str = "0.0.0.0"
     port: int = 8080
@@ -179,6 +184,9 @@ class MemorySettings(BaseSettings):
             token_budget=self.token_budget,
             rolling_summary=self.rolling_summary,
             hard_event_cap=self.hard_event_cap,
+            high_water=self.high_water,
+            low_water=self.low_water,
+            digest_retention=self.digest_retention,
         )
 
     def short_term_target(self) -> str:

--- a/memory-service/kaos_memory/stores.py
+++ b/memory-service/kaos_memory/stores.py
@@ -438,6 +438,11 @@ class ShortTermStore:
     def close(self) -> None:
         self.db.close()
 
+    def ping(self) -> None:
+        """Probe short-term table reachability with a trivial query; raises if unreachable."""
+        with self._lock:
+            self.db.execute("SELECT 1").fetchone()
+
     # -- internals -------------------------------------------------------- #
 
     def _drop_stale_window(self, scope: Scope, key: str, overflow_ids: List[int]) -> None:

--- a/memory-service/pyproject.toml
+++ b/memory-service/pyproject.toml
@@ -1,17 +1,20 @@
 [project]
 name = "kaos-memory-service"
 version = "0.4.8.dev0"
-description = "KAOS memory service - long-term and working memory stores for Kubernetes agent orchestration"
+description = "KAOS memory service - long-term and short-term memory stores for Kubernetes agent orchestration"
 requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
+    "fastapi>=0.104.0",
+    "uvicorn>=0.24.0",
     "mem0ai==2.0.10",
     "chromadb>=1.5.0",
     "psycopg[pool]>=3.1.0",
     "pgvector>=0.2.0",
     "tiktoken>=0.7.0",
     "httpx>=0.25.0",
+    "opentelemetry-api>=1.20.0",
 ]
 
 [project.optional-dependencies]
@@ -19,6 +22,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "black>=24.0.0",
+    "opentelemetry-sdk>=1.20.0",
 ]
 
 [build-system]

--- a/memory-service/tests/test_async_offload.py
+++ b/memory-service/tests/test_async_offload.py
@@ -1,0 +1,49 @@
+"""The async handlers must offload blocking store/Mem0 work to the bounded executor.
+
+If a handler ran its synchronous recall directly on the event loop, a blocking call would
+stall the loop and serialise requests. Driving two concurrent recalls whose bodies rendezvous
+on a barrier proves the work runs in parallel on the KAOS-owned pool, off the loop.
+"""
+
+import asyncio
+import threading
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from kaos_memory.app import MemoryService, RecallResponse, create_app
+from typing import cast
+
+SCOPE = {"level": "user", "principal": "a"}
+
+
+class _BarrierService:
+    """A stand-in service whose recall blocks until ``n`` concurrent calls arrive."""
+
+    def __init__(self, n: int) -> None:
+        self.barrier = threading.Barrier(n, timeout=5)
+
+    def recall(self, req) -> RecallResponse:
+        self.barrier.wait()  # only returns once n callers are here simultaneously
+        return RecallResponse()
+
+    def readiness(self) -> dict:
+        return {"ready": True, "stores": {}}
+
+
+@pytest.mark.asyncio
+async def test_recall_requests_run_concurrently_on_the_bounded_pool():
+    service = _BarrierService(2)
+    app = create_app(cast(MemoryService, service), request_concurrency=2)
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
+        body = {"scope": SCOPE, "query": "q"}
+        r1, r2 = await asyncio.gather(
+            client.post("/v1/recall", json=body),
+            client.post("/v1/recall", json=body),
+        )
+    # Both only complete because the two handlers reached the barrier in parallel; a
+    # loop-blocking handler would deadlock the barrier and surface an error instead.
+    assert r1.status_code == 200
+    assert r2.status_code == 200

--- a/memory-service/tests/test_background.py
+++ b/memory-service/tests/test_background.py
@@ -1,0 +1,81 @@
+"""Background runner tests: bounded concurrency, bounded retry, graceful drain."""
+
+import threading
+import time
+
+from kaos_memory.app import BackgroundRunner
+
+
+def test_concurrency_is_bounded():
+    runner = BackgroundRunner(concurrency=2)
+    running = 0
+    peak = 0
+    lock = threading.Lock()
+    release = threading.Event()
+    done = threading.Event()
+    started = 0
+
+    def task():
+        nonlocal running, peak, started
+        with lock:
+            running += 1
+            started += 1
+            peak = max(peak, running)
+        release.wait(timeout=5)
+        with lock:
+            running -= 1
+            if started == 5 and running == 0:
+                done.set()
+
+    for _ in range(5):
+        runner.submit(task)
+
+    time.sleep(0.2)  # let the bounded pool pick up what it can
+    with lock:
+        assert peak <= 2  # never more than the concurrency cap run at once
+    release.set()
+    runner.shutdown(wait=True)
+    assert peak <= 2
+
+
+def test_retries_then_gives_up_without_crashing():
+    attempts = []
+    giveups = []
+    runner = BackgroundRunner(
+        concurrency=1, max_retries=2, on_giveup=lambda exc: giveups.append(exc)
+    )
+
+    def always_fails():
+        attempts.append(1)
+        raise RuntimeError("nope")
+
+    runner.submit(always_fails)
+    runner.shutdown(wait=True)
+
+    assert len(attempts) == 3  # initial + 2 retries
+    assert runner.failures == 1
+    assert len(giveups) == 1 and isinstance(giveups[0], RuntimeError)
+
+
+def test_pending_work_drains_on_shutdown():
+    runner = BackgroundRunner(concurrency=2)
+    completed = []
+
+    def task(i):
+        time.sleep(0.05)
+        completed.append(i)
+
+    for i in range(6):
+        runner.submit(lambda i=i: task(i))
+    runner.shutdown(wait=True)
+
+    assert sorted(completed) == [0, 1, 2, 3, 4, 5]
+
+
+def test_successful_task_does_not_count_as_failure():
+    runner = BackgroundRunner(concurrency=1)
+    ran = []
+    runner.submit(lambda: ran.append(1))
+    runner.shutdown(wait=True)
+    assert ran == [1]
+    assert runner.failures == 0

--- a/memory-service/tests/test_config.py
+++ b/memory-service/tests/test_config.py
@@ -87,20 +87,22 @@ def test_short_term_tier_digest_retention_default_and_bound():
 def test_settings_short_term_tier_mirrors_water_mark_and_digest_knobs():
     settings = MemorySettings(
         token_budget=1000,
-        high_water=900,
-        low_water=400,
+        compaction_trigger=900,
+        compaction_target=400,
         hard_event_cap=50,
         digest_retention=7,
         rolling_summary=True,
     )
     tier = settings.short_term_tier()
-    assert (tier.token_budget, tier.high_water, tier.low_water) == (1000, 900, 400)
+    assert (tier.token_budget, tier.compaction_trigger, tier.compaction_target) == (1000, 900, 400)
     assert (tier.hard_event_cap, tier.digest_retention, tier.rolling_summary) == (50, 7, True)
 
 
 def test_settings_short_term_tier_propagates_water_mark_constraint():
     with pytest.raises(ValueError):
-        MemorySettings(token_budget=1000, high_water=400, low_water=900).short_term_tier()
+        MemorySettings(
+            token_budget=1000, compaction_trigger=400, compaction_target=900
+        ).short_term_tier()
 
 
 def test_settings_request_concurrency_default():

--- a/memory-service/tests/test_config.py
+++ b/memory-service/tests/test_config.py
@@ -5,6 +5,7 @@ import pytest
 from kaos_memory.config import (
     ExternalStorage,
     LocalStorage,
+    MemorySettings,
     ModelConfig,
     StorageConfig,
     ShortTermTierConfig,
@@ -81,3 +82,26 @@ def test_short_term_tier_digest_retention_default_and_bound():
     assert ShortTermTierConfig().digest_retention == 20
     with pytest.raises(ValueError):
         ShortTermTierConfig(digest_retention=0)
+
+
+def test_settings_short_term_tier_mirrors_water_mark_and_digest_knobs():
+    settings = MemorySettings(
+        token_budget=1000,
+        high_water=900,
+        low_water=400,
+        hard_event_cap=50,
+        digest_retention=7,
+        rolling_summary=True,
+    )
+    tier = settings.short_term_tier()
+    assert (tier.token_budget, tier.high_water, tier.low_water) == (1000, 900, 400)
+    assert (tier.hard_event_cap, tier.digest_retention, tier.rolling_summary) == (50, 7, True)
+
+
+def test_settings_short_term_tier_propagates_water_mark_constraint():
+    with pytest.raises(ValueError):
+        MemorySettings(token_budget=1000, high_water=400, low_water=900).short_term_tier()
+
+
+def test_settings_request_concurrency_default():
+    assert MemorySettings().request_concurrency == 8

--- a/memory-service/tests/test_recall.py
+++ b/memory-service/tests/test_recall.py
@@ -1,0 +1,88 @@
+"""Synchronous recall endpoint tests."""
+
+from fastapi.testclient import TestClient
+
+from kaos_memory.config import ShortTermTierConfig
+from kaos_memory.app import MemoryService, create_app
+from kaos_memory.stores import ShortTermStore
+
+
+class _FakeLongTerm:
+    def __init__(self, facts=None, fail=False):
+        self._facts = facts or []
+        self._fail = fail
+
+    def recall(self, scope, query, top_k=10):
+        if self._fail:
+            raise RuntimeError("vector store unreachable")
+        return self._facts
+
+    def ping(self):
+        return None
+
+
+def _short_term(tmp_path):
+    return ShortTermStore("local", str(tmp_path / "w.db"), ShortTermTierConfig(), lambda p, f: p)
+
+
+def _client(longterm, short_term):
+    return TestClient(create_app(MemoryService(longterm=longterm, short_term=short_term)))
+
+
+USER_SCOPE = {"level": "user", "principal": "alice"}
+
+
+def test_recall_returns_facts_and_short_term_context(tmp_path):
+    short_term = _short_term(tmp_path)
+    longterm = _FakeLongTerm(facts=[{"memory": "alice prefers dark mode", "score": 0.9}])
+    scope = {"level": "user", "principal": "alice", "session_id": "s1"}
+    # Seed short-term turns under the same owner key.
+    from kaos_memory.stores import Scope, ScopeLevel
+
+    s = Scope(level=ScopeLevel.USER, principal="alice")
+    short_term.add(s, "user", "hello there")
+    short_term.add(s, "assistant", "hi alice")
+
+    resp = _client(longterm, short_term).post(
+        "/v1/recall", json={"scope": USER_SCOPE, "query": "preferences"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["degraded"] is False
+    # Native Mem0 fields pass through unmodified.
+    assert body["facts"][0]["score"] == 0.9
+    assert body["short_term"]["recent"] == [["user", "hello there"], ["assistant", "hi alice"]]
+    assert "alice prefers dark mode" in body["block"]
+    assert "## Recent turns" in body["block"]
+
+
+def test_recall_degrades_to_short_term_only_on_longterm_failure(tmp_path):
+    short_term = _short_term(tmp_path)
+    from kaos_memory.stores import Scope, ScopeLevel
+
+    short_term.add(
+        Scope(level=ScopeLevel.USER, principal="alice"), "user", "remember the budget is 5000"
+    )
+    longterm = _FakeLongTerm(fail=True)
+
+    resp = _client(longterm, short_term).post(
+        "/v1/recall", json={"scope": USER_SCOPE, "query": "budget"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["degraded"] is True
+    assert body["facts"] == []
+    assert "budget is 5000" in body["block"]
+
+
+def test_recall_can_exclude_short_term(tmp_path):
+    short_term = _short_term(tmp_path)
+    longterm = _FakeLongTerm(facts=[{"memory": "fact one"}])
+    resp = _client(longterm, short_term).post(
+        "/v1/recall",
+        json={"scope": USER_SCOPE, "query": "x", "include_short_term": False},
+    )
+    body = resp.json()
+    assert body["short_term"]["recent"] == []
+    assert "fact one" in body["block"]
+    assert "## Recent turns" not in body["block"]

--- a/memory-service/tests/test_recall.py
+++ b/memory-service/tests/test_recall.py
@@ -45,7 +45,7 @@ def test_recall_surfaces_medium_term_digest(tmp_path):
     )
     s = Scope(level=ScopeLevel.USER, principal="alice")
     for i in range(6):
-        short_term.add(s, "user", f"message number {i}")
+        short_term.add(s, [("user", f"message number {i}")])
 
     resp = _client(_FakeLongTerm(), short_term).post(
         "/v1/recall", json={"scope": USER_SCOPE, "query": "anything"}
@@ -65,8 +65,8 @@ def test_recall_returns_facts_and_short_term_context(tmp_path):
     from kaos_memory.stores import Scope, ScopeLevel
 
     s = Scope(level=ScopeLevel.USER, principal="alice")
-    short_term.add(s, "user", "hello there")
-    short_term.add(s, "assistant", "hi alice")
+    short_term.add(s, [("user", "hello there")])
+    short_term.add(s, [("assistant", "hi alice")])
 
     resp = _client(longterm, short_term).post(
         "/v1/recall", json={"scope": USER_SCOPE, "query": "preferences"}
@@ -86,7 +86,7 @@ def test_recall_degrades_to_short_term_only_on_longterm_failure(tmp_path):
     from kaos_memory.stores import Scope, ScopeLevel
 
     short_term.add(
-        Scope(level=ScopeLevel.USER, principal="alice"), "user", "remember the budget is 5000"
+        Scope(level=ScopeLevel.USER, principal="alice"), [("user", "remember the budget is 5000")]
     )
     longterm = _FakeLongTerm(fail=True)
 

--- a/memory-service/tests/test_recall.py
+++ b/memory-service/tests/test_recall.py
@@ -32,6 +32,31 @@ def _client(longterm, short_term):
 USER_SCOPE = {"level": "user", "principal": "alice"}
 
 
+def test_recall_surfaces_medium_term_digest(tmp_path):
+    from kaos_memory.stores import Scope, ScopeLevel
+
+    # A tiny budget with the rolling digest on folds evicted turns into the medium-term
+    # summary, which recall must surface distinctly from the verbatim short-term window.
+    short_term = ShortTermStore(
+        "local",
+        str(tmp_path / "w.db"),
+        ShortTermTierConfig(token_budget=4, rolling_summary=True),
+        lambda prior, turns: (prior + " " + " ".join(c for _, c in turns)).strip(),
+    )
+    s = Scope(level=ScopeLevel.USER, principal="alice")
+    for i in range(6):
+        short_term.add(s, "user", f"message number {i}")
+
+    resp = _client(_FakeLongTerm(), short_term).post(
+        "/v1/recall", json={"scope": USER_SCOPE, "query": "anything"}
+    )
+    body = resp.json()
+    assert body["medium_term"]["summary"] != ""
+    assert "## Conversation summary" in body["block"]
+    # The digest is separate from the verbatim window.
+    assert "summary" not in body["short_term"]
+
+
 def test_recall_returns_facts_and_short_term_context(tmp_path):
     short_term = _short_term(tmp_path)
     longterm = _FakeLongTerm(facts=[{"memory": "alice prefers dark mode", "score": 0.9}])

--- a/memory-service/tests/test_service_e2e.py
+++ b/memory-service/tests/test_service_e2e.py
@@ -1,0 +1,112 @@
+"""End-to-end integration: boot the app over real stores and drive write→recall→forget.
+
+Runs the full service against real ``LongTermStore`` and ``ShortTermStore`` instances
+(local Chroma+SQLite, and an external pgvector+Postgres variant behind the marker),
+using a deterministic offline embedder and ``infer=False`` so no model endpoint is
+contacted. Asserts the ``kaos.memory.*`` spans are emitted via an in-memory exporter.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from kaos_memory.config import (
+    ExternalStorage,
+    LocalStorage,
+    ModelConfig,
+    StorageConfig,
+    ShortTermTierConfig,
+)
+from kaos_memory.stores import LongTermStore
+from kaos_memory.app import MemoryService, create_app
+from kaos_memory.stores import ShortTermStore
+from tests._fakes import DeterministicEmbedder
+
+OFFLINE = ModelConfig(base_url="http://127.0.0.1:0/v1", model="offline", api_key="t")
+
+USER_SCOPE = {"level": "user", "principal": "dave"}
+
+
+@pytest.fixture(scope="module")
+def _provider_exporter():
+    # set_tracer_provider takes effect once per process; set it once for the module
+    # and reuse the single exporter, clearing it per test.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+@pytest.fixture
+def span_exporter(_provider_exporter):
+    _provider_exporter.clear()
+    return _provider_exporter
+
+
+def _service(storage: StorageConfig, short_term_target: str) -> MemoryService:
+    longterm = LongTermStore(storage, OFFLINE, OFFLINE)
+    longterm._memory.embedding_model = DeterministicEmbedder()
+    # Synchronous scheduler so the integration flow is deterministic.
+    short_term = ShortTermStore(
+        "local" if storage.type == "local" else "external",
+        short_term_target,
+        ShortTermTierConfig(),
+        lambda p, f: p,
+    )
+    return MemoryService(longterm=longterm, short_term=short_term, scheduler=lambda thunk: thunk())
+
+
+def _drive_and_assert(service: MemoryService, span_exporter, short_term_scope_target):
+    client = TestClient(create_app(service))
+
+    # Write a turn: durable short-term append + synchronous extraction (infer=False).
+    w = client.post(
+        "/v1/write",
+        json={
+            "scope": USER_SCOPE,
+            "role": "user",
+            "content": "the production cluster runs in eu-west-1",
+            "infer": False,
+        },
+    )
+    assert w.status_code == 202
+
+    # Recall: short-term context is present; long-term recall may match the stored fact.
+    r = client.post("/v1/recall", json={"scope": USER_SCOPE, "query": "where does the cluster run"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["degraded"] is False
+    assert any("eu-west-1" in c for _, c in body["short_term"]["recent"])
+
+    # Forget: clears both tiers.
+    f = client.post("/v1/forget", json={"scope": USER_SCOPE})
+    assert f.status_code == 200
+    after = client.post("/v1/recall", json={"scope": USER_SCOPE, "query": "cluster"})
+    assert after.json()["short_term"]["recent"] == []
+
+    names = {s.name for s in span_exporter.get_finished_spans()}
+    assert {"kaos.memory.write", "kaos.memory.recall", "kaos.memory.forget"} <= names
+
+
+def test_local_mode_end_to_end(tmp_path, span_exporter):
+    storage = StorageConfig(type="local", local=LocalStorage(path=str(tmp_path / "lt")))
+    service = _service(storage, str(tmp_path / "shortterm.db"))
+    _drive_and_assert(service, span_exporter, str(tmp_path / "shortterm.db"))
+
+
+@pytest.mark.pgvector
+def test_external_mode_end_to_end(pgvector_dsn, span_exporter):
+    storage = StorageConfig(
+        type="external",
+        external=ExternalStorage(dsn=pgvector_dsn, collection_name="kaos_e2e", embedding_dims=64),
+    )
+    service = _service(storage, pgvector_dsn)
+    try:
+        _drive_and_assert(service, span_exporter, pgvector_dsn)
+    finally:
+        # Clean the short-term table rows for this scope so reruns are deterministic.
+        service.short_term.close()

--- a/memory-service/tests/test_service_e2e.py
+++ b/memory-service/tests/test_service_e2e.py
@@ -54,7 +54,7 @@ def _service(storage: StorageConfig, short_term_target: str) -> MemoryService:
     short_term = ShortTermStore(
         "local" if storage.type == "local" else "external",
         short_term_target,
-        ShortTermTierConfig(),
+        ShortTermTierConfig(hard_event_cap=1),
         lambda p, f: p,
     )
     return MemoryService(longterm=longterm, short_term=short_term, scheduler=lambda thunk: thunk())
@@ -63,24 +63,30 @@ def _service(storage: StorageConfig, short_term_target: str) -> MemoryService:
 def _drive_and_assert(service: MemoryService, span_exporter, short_term_scope_target):
     client = TestClient(create_app(service))
 
-    # Write a turn: durable short-term append + synchronous extraction (infer=False).
-    w = client.post(
-        "/v1/write",
-        json={
-            "scope": USER_SCOPE,
-            "role": "user",
-            "content": "the production cluster runs in eu-west-1",
-            "infer": False,
-        },
-    )
-    assert w.status_code == 202
+    def _write(content: str):
+        return client.post(
+            "/v1/write",
+            json={"scope": USER_SCOPE, "role": "user", "content": content, "infer": False},
+        )
 
-    # Recall: short-term context is present; long-term recall may match the stored fact.
+    # First turn buffers in the window without evicting: nothing consolidated yet.
+    first = _write("the production cluster runs in eu-west-1")
+    assert first.status_code == 200
+    assert first.json()["scheduled"] is False
+
+    # Second turn pushes past the cap, evicting the first turn and (with the inline
+    # scheduler) extracting that evicted batch into long-term synchronously.
+    second = _write("the staging cluster runs in us-east-1")
+    assert second.status_code == 202
+    assert second.json()["scheduled"] is True
+
+    # Recall: short-term context holds the newest turn; long-term recall returns a list.
     r = client.post("/v1/recall", json={"scope": USER_SCOPE, "query": "where does the cluster run"})
     assert r.status_code == 200
     body = r.json()
     assert body["degraded"] is False
-    assert any("eu-west-1" in c for _, c in body["short_term"]["recent"])
+    assert any("us-east-1" in c for _, c in body["short_term"]["recent"])
+    assert isinstance(body["facts"], list)
 
     # Forget: clears both tiers.
     f = client.post("/v1/forget", json={"scope": USER_SCOPE})
@@ -89,7 +95,12 @@ def _drive_and_assert(service: MemoryService, span_exporter, short_term_scope_ta
     assert after.json()["short_term"]["recent"] == []
 
     names = {s.name for s in span_exporter.get_finished_spans()}
-    assert {"kaos.memory.write", "kaos.memory.recall", "kaos.memory.forget"} <= names
+    assert {
+        "kaos.memory.write",
+        "kaos.memory.consolidate",
+        "kaos.memory.recall",
+        "kaos.memory.forget",
+    } <= names
 
 
 def test_local_mode_end_to_end(tmp_path, span_exporter):

--- a/memory-service/tests/test_service_health.py
+++ b/memory-service/tests/test_service_health.py
@@ -1,0 +1,45 @@
+"""Health and readiness surface tests for the memory service."""
+
+from fastapi.testclient import TestClient
+
+from kaos_memory.app import MemoryService, create_app
+
+
+class _OkStore:
+    def ping(self) -> None:
+        return None
+
+
+class _BrokenStore:
+    def ping(self) -> None:
+        raise RuntimeError("store down")
+
+
+def _client(longterm, short_term) -> TestClient:
+    return TestClient(create_app(MemoryService(longterm=longterm, short_term=short_term)))
+
+
+def test_healthz_is_independent_of_store_state():
+    client = _client(_BrokenStore(), _BrokenStore())
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_readyz_ok_when_both_stores_reachable():
+    client = _client(_OkStore(), _OkStore())
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ready"] is True
+    assert body["stores"] == {"short_term": True, "longterm": True}
+
+
+def test_readyz_503_when_a_store_is_unreachable():
+    client = _client(longterm=_BrokenStore(), short_term=_OkStore())
+    resp = client.get("/readyz")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["ready"] is False
+    assert body["stores"]["short_term"] is True
+    assert "RuntimeError" in body["stores"]["longterm"]

--- a/memory-service/tests/test_summary_forget.py
+++ b/memory-service/tests/test_summary_forget.py
@@ -1,0 +1,96 @@
+"""Server-side rolling summary and forget endpoint tests."""
+
+from fastapi.testclient import TestClient
+
+from kaos_memory.config import ShortTermTierConfig
+from kaos_memory.stores import Scope, ScopeLevel
+from kaos_memory.app import MemoryService, create_app
+from kaos_memory.stores import ShortTermStore
+
+USER_SCOPE = {"level": "user", "principal": "carol"}
+
+
+class _RecordingLongTerm:
+    def __init__(self):
+        self.recalls = []
+        self.deleted = []
+        self.facts = []
+
+    def recall(self, scope, query, top_k=10):
+        return self.facts
+
+    def add(self, scope, messages, infer=True):
+        return []
+
+    def delete_scope(self, scope):
+        self.deleted.append(scope)
+
+    def ping(self):
+        return None
+
+
+def _client(longterm, short_term):
+    return TestClient(
+        create_app(
+            MemoryService(longterm=longterm, short_term=short_term, scheduler=lambda t: None)
+        )
+    )
+
+
+def test_overflow_summarizes_server_side(tmp_path):
+    calls = []
+
+    def summarizer(prior, folded):
+        calls.append((prior, list(folded)))
+        return (prior + " " + " ".join(c for _, c in folded)).strip()
+
+    # Tiny budget forces folding into the rolling summary on the server.
+    short_term = ShortTermStore(
+        "local",
+        str(tmp_path / "w.db"),
+        ShortTermTierConfig(token_budget=4, rolling_summary=True),
+        summarizer,
+    )
+    scope = Scope(level=ScopeLevel.USER, principal="carol")
+    for i in range(5):
+        short_term.add(scope, "user", f"message number {i} with several tokens here")
+
+    assert calls, "summarizer should have been invoked server-side on overflow"
+    assert short_term.summary(scope) != ""
+
+
+def test_forget_clears_both_tiers(tmp_path):
+    short_term = ShortTermStore(
+        "local", str(tmp_path / "w.db"), ShortTermTierConfig(), lambda p, f: p
+    )
+    longterm = _RecordingLongTerm()
+    scope = Scope(level=ScopeLevel.USER, principal="carol")
+    short_term.add(scope, "user", "something to remember")
+    assert short_term.active_window(scope)
+
+    resp = _client(longterm, short_term).post("/v1/forget", json={"scope": USER_SCOPE})
+    assert resp.status_code == 200
+    assert resp.json()["forgotten"] is True
+    assert short_term.active_window(scope) == []
+    assert short_term.summary(scope) == ""
+    assert len(longterm.deleted) == 1
+
+
+def test_forget_soft_degrades_on_longterm_failure(tmp_path):
+    class _BrokenDelete(_RecordingLongTerm):
+        def delete_scope(self, scope):
+            raise RuntimeError("delete failed")
+
+    short_term = ShortTermStore(
+        "local", str(tmp_path / "w.db"), ShortTermTierConfig(), lambda p, f: p
+    )
+    scope = Scope(level=ScopeLevel.USER, principal="carol")
+    short_term.add(scope, "user", "x")
+
+    resp = _client(_BrokenDelete(), short_term).post(
+        "/v1/forget", json={"scope": USER_SCOPE, "failure_mode": "soft"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["degraded"] is True
+    # Short-term tier was still cleared despite the long-term failure.
+    assert short_term.active_window(scope) == []

--- a/memory-service/tests/test_summary_forget.py
+++ b/memory-service/tests/test_summary_forget.py
@@ -53,7 +53,7 @@ def test_overflow_summarizes_server_side(tmp_path):
     )
     scope = Scope(level=ScopeLevel.USER, principal="carol")
     for i in range(5):
-        short_term.add(scope, "user", f"message number {i} with several tokens here")
+        short_term.add(scope, [("user", f"message number {i} with several tokens here")])
 
     assert calls, "summarizer should have been invoked server-side on overflow"
     assert short_term.summary(scope) != ""
@@ -65,7 +65,7 @@ def test_forget_clears_both_tiers(tmp_path):
     )
     longterm = _RecordingLongTerm()
     scope = Scope(level=ScopeLevel.USER, principal="carol")
-    short_term.add(scope, "user", "something to remember")
+    short_term.add(scope, [("user", "something to remember")])
     assert short_term.active_window(scope)
 
     resp = _client(longterm, short_term).post("/v1/forget", json={"scope": USER_SCOPE})
@@ -85,7 +85,7 @@ def test_forget_soft_degrades_on_longterm_failure(tmp_path):
         "local", str(tmp_path / "w.db"), ShortTermTierConfig(), lambda p, f: p
     )
     scope = Scope(level=ScopeLevel.USER, principal="carol")
-    short_term.add(scope, "user", "x")
+    short_term.add(scope, [("user", "x")])
 
     resp = _client(_BrokenDelete(), short_term).post(
         "/v1/forget", json={"scope": USER_SCOPE, "failure_mode": "soft"}

--- a/memory-service/tests/test_write.py
+++ b/memory-service/tests/test_write.py
@@ -79,6 +79,44 @@ def test_write_buffers_without_eviction_then_extracts_the_evicted_batch(tmp_path
     assert messages == [{"role": "user", "content": "deploy nginx"}]
 
 
+def test_batch_write_appends_all_turns_and_extracts_combined_eviction(tmp_path):
+    # A single request carrying several turns; the cap forces evictions and one combined
+    # extraction of the evicted batch.
+    short_term = _short_term(tmp_path, ShortTermTierConfig(hard_event_cap=1))
+    longterm = _RecordingLongTerm()
+    longterm.gate.set()  # let extraction run immediately when invoked
+    captured = []
+    client = _client(longterm, short_term, captured.append)
+
+    resp = client.post(
+        "/v1/write",
+        json={
+            "scope": USER_SCOPE,
+            "turns": [
+                {"role": "user", "content": "one"},
+                {"role": "assistant", "content": "two"},
+                {"role": "user", "content": "three"},
+            ],
+        },
+    )
+    assert resp.status_code == 202
+    assert resp.json()["scheduled"] is True
+
+    # The newest turn remains in the window; the older turns were evicted.
+    recent = short_term.active_window(Scope(level=ScopeLevel.USER, principal="bob"))
+    assert recent == [("user", "three")]
+
+    # A single extraction was scheduled over the combined evicted batch, in order.
+    assert len(captured) == 1
+    captured[0]()
+    assert len(longterm.writes) == 1
+    _, messages, _ = longterm.writes[0]
+    assert messages == [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+    ]
+
+
 def test_strict_surfaces_short_term_append_failure(tmp_path):
     class _BrokenShortTerm:
         def append(self, *a, **k):

--- a/memory-service/tests/test_write.py
+++ b/memory-service/tests/test_write.py
@@ -1,0 +1,94 @@
+"""Write endpoint tests: synchronous short-term append + scheduled extraction."""
+
+import threading
+
+from fastapi.testclient import TestClient
+
+from kaos_memory.config import ShortTermTierConfig
+from kaos_memory.stores import Scope, ScopeLevel
+from kaos_memory.app import MemoryService, create_app
+from kaos_memory.stores import ShortTermStore
+
+USER_SCOPE = {"level": "user", "principal": "bob"}
+
+
+class _RecordingLongTerm:
+    """Records writes; lets the test block extraction until released."""
+
+    def __init__(self):
+        self.writes = []
+        self.gate = threading.Event()
+
+    def add(self, scope, messages, infer=True):
+        self.gate.wait(timeout=5)
+        self.writes.append((scope, messages, infer))
+
+    def ping(self):
+        return None
+
+
+def _short_term(tmp_path):
+    return ShortTermStore("local", str(tmp_path / "w.db"), ShortTermTierConfig(), lambda p, f: p)
+
+
+def _client(longterm, short_term, scheduler):
+    return TestClient(
+        create_app(MemoryService(longterm=longterm, short_term=short_term, scheduler=scheduler))
+    )
+
+
+def test_write_returns_before_extraction_and_persists_short_term_row(tmp_path):
+    short_term = _short_term(tmp_path)
+    longterm = _RecordingLongTerm()  # extraction blocks until gate is set
+    captured = []
+    client = _client(longterm, short_term, captured.append)
+
+    resp = client.post(
+        "/v1/write", json={"scope": USER_SCOPE, "role": "user", "content": "deploy nginx"}
+    )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["accepted"] is True and body["scheduled"] is True
+
+    # The short-term row is present synchronously, before any extraction runs.
+    recent = short_term.active_window(Scope(level=ScopeLevel.USER, principal="bob"))
+    assert recent == [("user", "deploy nginx")]
+    # Extraction was scheduled (captured) but not yet executed.
+    assert len(captured) == 1
+    assert longterm.writes == []
+
+
+def test_strict_surfaces_short_term_append_failure(tmp_path):
+    class _BrokenShortTerm:
+        def append(self, *a, **k):
+            raise RuntimeError("disk full")
+
+    client = _client(_RecordingLongTerm(), _BrokenShortTerm(), lambda t: None)
+    resp = client.post(
+        "/v1/write",
+        json={"scope": USER_SCOPE, "role": "user", "content": "x", "failure_mode": "strict"},
+    )
+    assert resp.status_code == 500
+    assert resp.json()["accepted"] is False
+
+
+def test_soft_swallows_schedule_failure(tmp_path):
+    short_term = _short_term(tmp_path)
+
+    def _broken_scheduler(thunk):
+        raise RuntimeError("scheduler down")
+
+    client = _client(_RecordingLongTerm(), short_term, _broken_scheduler)
+    resp = client.post(
+        "/v1/write",
+        json={"scope": USER_SCOPE, "role": "user", "content": "y", "failure_mode": "soft"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["accepted"] is True
+    assert body["scheduled"] is False
+    assert body["degraded"] is True
+    # The durable short-term append still happened.
+    assert short_term.active_window(Scope(level=ScopeLevel.USER, principal="bob")) == [
+        ("user", "y")
+    ]

--- a/memory-service/tests/test_write.py
+++ b/memory-service/tests/test_write.py
@@ -27,8 +27,10 @@ class _RecordingLongTerm:
         return None
 
 
-def _short_term(tmp_path):
-    return ShortTermStore("local", str(tmp_path / "w.db"), ShortTermTierConfig(), lambda p, f: p)
+def _short_term(tmp_path, cfg=None):
+    return ShortTermStore(
+        "local", str(tmp_path / "w.db"), cfg or ShortTermTierConfig(), lambda p, f: p
+    )
 
 
 def _client(longterm, short_term, scheduler):
@@ -37,25 +39,44 @@ def _client(longterm, short_term, scheduler):
     )
 
 
-def test_write_returns_before_extraction_and_persists_short_term_row(tmp_path):
-    short_term = _short_term(tmp_path)
+def _write(client, content, **extra):
+    return client.post(
+        "/v1/write", json={"scope": USER_SCOPE, "role": "user", "content": content, **extra}
+    )
+
+
+def test_write_buffers_without_eviction_then_extracts_the_evicted_batch(tmp_path):
+    # hard_event_cap=1 makes the second turn evict the first, triggering extraction.
+    short_term = _short_term(tmp_path, ShortTermTierConfig(hard_event_cap=1))
     longterm = _RecordingLongTerm()  # extraction blocks until gate is set
     captured = []
     client = _client(longterm, short_term, captured.append)
 
-    resp = client.post(
-        "/v1/write", json={"scope": USER_SCOPE, "role": "user", "content": "deploy nginx"}
-    )
-    assert resp.status_code == 202
-    body = resp.json()
+    # First turn is buffered in the window: nothing has been evicted, so nothing is scheduled.
+    first = _write(client, "deploy nginx")
+    assert first.status_code == 200
+    assert first.json()["scheduled"] is False
+    assert captured == []
+
+    # Second turn pushes the window over the cap, evicting the first turn and scheduling
+    # extraction of that evicted batch (not the just-written turn).
+    second = _write(client, "scale to three")
+    assert second.status_code == 202
+    body = second.json()
     assert body["accepted"] is True and body["scheduled"] is True
 
-    # The short-term row is present synchronously, before any extraction runs.
+    # The newest turn is present synchronously; extraction was scheduled but not executed.
     recent = short_term.active_window(Scope(level=ScopeLevel.USER, principal="bob"))
-    assert recent == [("user", "deploy nginx")]
-    # Extraction was scheduled (captured) but not yet executed.
+    assert recent == [("user", "scale to three")]
     assert len(captured) == 1
     assert longterm.writes == []
+
+    # When the gate opens, extraction runs over the evicted batch.
+    longterm.gate.set()
+    captured[0]()
+    assert len(longterm.writes) == 1
+    _, messages, _ = longterm.writes[0]
+    assert messages == [{"role": "user", "content": "deploy nginx"}]
 
 
 def test_strict_surfaces_short_term_append_failure(tmp_path):
@@ -73,22 +94,21 @@ def test_strict_surfaces_short_term_append_failure(tmp_path):
 
 
 def test_soft_swallows_schedule_failure(tmp_path):
-    short_term = _short_term(tmp_path)
+    short_term = _short_term(tmp_path, ShortTermTierConfig(hard_event_cap=1))
 
     def _broken_scheduler(thunk):
         raise RuntimeError("scheduler down")
 
     client = _client(_RecordingLongTerm(), short_term, _broken_scheduler)
-    resp = client.post(
-        "/v1/write",
-        json={"scope": USER_SCOPE, "role": "user", "content": "y", "failure_mode": "soft"},
-    )
+    # First turn buffers without scheduling; the second evicts and hits the broken scheduler.
+    assert _write(client, "x").json()["scheduled"] is False
+    resp = _write(client, "y", failure_mode="soft")
     assert resp.status_code == 200
     body = resp.json()
     assert body["accepted"] is True
     assert body["scheduled"] is False
     assert body["degraded"] is True
-    # The durable short-term append still happened.
+    # The durable short-term append still happened (newest turn retained after eviction).
     assert short_term.active_window(Scope(level=ScopeLevel.USER, principal="bob")) == [
         ("user", "y")
     ]

--- a/memory-service/uv.lock
+++ b/memory-service/uv.lock
@@ -456,7 +456,7 @@ wheels = [
 [[package]]
 name = "fastapi"
 version = "0.139.0"
-source = { registry = "https://pypi.zalando.net/repository/pypi/simple/" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
@@ -464,9 +464,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://pypi.zalando.net/repository/pypi/packages/fastapi/0.139.0/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
-    { url = "https://pypi.zalando.net/repository/pypi/packages/fastapi/0.139.0/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189" },
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]
@@ -2483,14 +2483,14 @@ wheels = [
 [[package]]
 name = "starlette"
 version = "1.3.1"
-source = { registry = "https://pypi.zalando.net/repository/pypi/simple/" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://pypi.zalando.net/repository/pypi/packages/starlette/1.3.1/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://pypi.zalando.net/repository/pypi/packages/starlette/1.3.1/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]

--- a/memory-service/uv.lock
+++ b/memory-service/uv.lock
@@ -454,6 +454,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.139.0"
+source = { registry = "https://pypi.zalando.net/repository/pypi/simple/" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://pypi.zalando.net/repository/pypi/packages/fastapi/0.139.0/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145" }
+wheels = [
+    { url = "https://pypi.zalando.net/repository/pypi/packages/fastapi/0.139.0/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
@@ -978,18 +994,22 @@ version = "0.4.8.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "mem0ai" },
+    { name = "opentelemetry-api" },
     { name = "pgvector" },
     { name = "psycopg", extra = ["pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "tiktoken" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
 dev = [
     { name = "black" },
+    { name = "opentelemetry-sdk" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -998,8 +1018,11 @@ dev = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "chromadb", specifier = ">=1.5.0" },
+    { name = "fastapi", specifier = ">=0.104.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "mem0ai", specifier = "==2.0.10" },
+    { name = "opentelemetry-api", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.20.0" },
     { name = "pgvector", specifier = ">=0.2.0" },
     { name = "psycopg", extras = ["pool"], specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -1007,6 +1030,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
+    { name = "uvicorn", specifier = ">=0.24.0" },
 ]
 provides-extras = ["dev"]
 
@@ -2454,6 +2478,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/c9/f14fdf71bb8957e0c7e39db69bbdf12b5c80f4ef775fdfa127bf4e0d6760/sqlalchemy-2.0.51-cp314-cp314t-win32.whl", hash = "sha256:9161cfc9efce70d1715f47d6ff40f79c6778c00d53be4fbc09d70301e4b83ba7", size = 2151313, upload-time = "2026-06-15T16:03:39.127Z" },
     { url = "https://files.pythonhosted.org/packages/6a/c6/673e618e6f4f297e126d9b56ea2f6478708f6c1af4e3223835c22e2c3697/sqlalchemy-2.0.51-cp314-cp314t-win_amd64.whl", hash = "sha256:159bb6ba32059f57ad7375a8f50d844dd2f19d14954ecf820cd33e20debd46b2", size = 2186280, upload-time = "2026-06-15T16:03:40.569Z" },
     { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.zalando.net/repository/pypi/simple/" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://pypi.zalando.net/repository/pypi/packages/starlette/1.3.1/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0" }
+wheels = [
+    { url = "https://pypi.zalando.net/repository/pypi/packages/starlette/1.3.1/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6" },
 ]
 
 [[package]]


### PR DESCRIPTION
Wraps the atomic memory stores in a deployable FastAPI service exposing the memory contract over HTTP, with off-path long-term extraction and a container image.

## What this adds

- **HTTP contract**: `POST /v1/recall` (synchronous, assembles long-term facts + short-term tier summary/recent into a deterministic injection block), `POST /v1/write` (durable in-band working append + scheduled off-path extraction, 202), `POST /v1/forget` (scope erasure), plus `/healthz` (liveness) and `/readyz` (readiness probing the stores, not the model endpoint).
- **Best-effort semantics**: long-term failures degrade to short-term-only with `degraded=true` and never block the turn; fail-soft vs strict failure modes are selectable per request.
- **Bounded background runner**: a `ThreadPoolExecutor`-backed scheduler with bounded concurrency, retry with backoff, an on-giveup hook, a failures counter, and shutdown drain via the app lifespan.
- **Both storage modes wired end to end**: local (embedded Chroma + SQLite on one PVC) and external (pgvector + Postgres, stateless replicas), idempotent schema creation, and Mem0 change-history isolation (PVC for local, ephemeral tempdir for external) so shared Postgres is the only shared state in external mode.
- **Observability**: OpenTelemetry spans around recall/write/consolidate/forget.
- **Packaging**: a non-root container image (`axsauze/kaos-memory-service`, local-mode default) with per-platform build + manifest-merge jobs and a liveness healthcheck.

## Validation

- 50 tests pass in both storage modes (local Chroma/SQLite plus pgvector/Postgres behind the marker); `black --check` and `ty` clean.
- CI runs the service suite against a `pgvector/pgvector:pg16` service container.
- Container built and run in local mode: probes return 200, a write surfaces in recall's short-term context and assembled block.

Stacked on the atomic-stores branch.


Relates to #58
