### PR TITLE
P14: Authorization modes and enablement — flag-gated policy projection, CLI, verification

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,9 +86,14 @@ tmp/                       # Local work files (gitignored)
 - **MCPServer**: MCP tool server with runtime-based architecture (python-string, fastmcp-codemode, pctx-codemode, kubernetes, slack, custom)
 - **ModelAPI**: LLM proxy (LiteLLM) or hosted (Ollama) mode
 
+## Authorization (optional, off by default)
+Enforced at the gateway by an OPA policy in the Envoy `ext_proc` filter. `AuthzProjectionReconciler` projects a policy ConfigMap (`policy.rego` + `data.json`) from CRDs. Provider `kaos` (KAOS-owned grants) or `aib` (broker permission sets); modes automated / bring-your-own ConfigMap / operator-rego+admin-data / broker external off-switch; verification `verified` (inject JWKS, verify actor token) or `skip` (demo, non-production). `data.kaos.grants`/`data.kaos.jwks` is a published contract. Enable via `kaos system install --auth-enabled --authz-provider ...`. See `docs/security/authorization.md`.
+
 ## Key Files
 - `operator/api/v1alpha1/*_types.go`: CRD schemas
 - `operator/controllers/*_controller.go`: Reconciliation logic
+- `operator/controllers/authz_projection_controller.go`: Authorization policy ConfigMap + identity projection
+- `operator/internal/authz/`: Static policy rego, data document builder, JWKS fetch, published `data-schema.md`
 - `operator/chart/`: Helm chart (generated from kustomize)
 - `pydantic-ai-server/pais/server.py`: AgentServer, create_agent_server, routes, _run_autonomous
 - `pydantic-ai-server/pais/serverutils.py`: AgentDeps, AgentCard (Pydantic BaseModel, A2A-compliant), RemoteAgent (A2A + chat delegation), AgentServerSettings

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -87,7 +87,7 @@ tmp/                       # Local work files (gitignored)
 - **ModelAPI**: LLM proxy (LiteLLM) or hosted (Ollama) mode
 
 ## Authorization (optional, off by default)
-Enforced at the gateway by an OPA policy in the Envoy `ext_proc` filter. `AuthzProjectionReconciler` projects a policy ConfigMap (`policy.rego` + `data.json`) from CRDs. Provider `kaos` (KAOS-owned grants) or `aib` (broker permission sets); modes automated / bring-your-own ConfigMap / operator-rego+admin-data / broker external off-switch; verification `verified` (inject JWKS, verify actor token) or `skip` (demo, non-production). `data.kaos.grants`/`data.kaos.jwks` is a published contract. Enable via `kaos system install --auth-enabled --authz-provider ...`. See `docs/security/authorization.md`.
+Enforced at the gateway by an OPA policy in the Envoy `ext_proc` filter. `AuthzProjectionReconciler` projects a policy ConfigMap (`policy.rego` + `data.json`) from CRDs. Provider `kaos` (KAOS-owned grants) or `aib` (broker permission sets); modes automated / bring-your-own ConfigMap / operator-rego+admin-data / broker external off-switch; verification `verified` (inject JWKS, verify actor token) or `skip` (demo, non-production). `data.kaos.grants`/`data.kaos.jwks` is a published contract. Enable via `kaos system install --auth-enabled <preset>` (presets: `aib-keycloak`, `aib-only`, `kaos-internal`). See `docs/security/authorization.md`.
 
 ## Key Files
 - `operator/api/v1alpha1/*_types.go`: CRD schemas

--- a/.github/instructions/operator.instructions.md
+++ b/.github/instructions/operator.instructions.md
@@ -34,6 +34,10 @@ View each respective file in case of making modifications to the respective modu
 
 If any changes are introduced, this documentation must be updated accordingly.
 
+## Authorization
+
+Agent authorization is optional (off by default) and enforced at the gateway by an OPA policy inside the Envoy `ext_proc` filter. `AuthzProjectionReconciler` (`operator/controllers/authz_projection_controller.go`) projects a policy ConfigMap (`policy.rego` + `data.json`) from CRDs. Provider is `kaos` (KAOS-owned grants) or `aib` (broker permission sets). Modes: automated (project `policy.rego` + grants), bring-your-own ConfigMap (write nothing), operator-rego + admin data (`policy.rego` only), and broker external off-switch (identity only, no grants, prune forced off). Verification is `verified` (inject IdP JWKS at `data.kaos.jwks`, verify actor token) or `skip` (demo, spoofable, non-production). The `data.kaos.grants`/`data.kaos.jwks` schema is a published contract — see `operator/internal/authz/data-schema.md` and `docs/security/authorization.md`. Never write or prune policy data KAOS does not own.
+
 ## Key Commands
 ```bash
 # After changing *_types.go files:

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -32,6 +32,12 @@ jobs:
           go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
           go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24
 
+      - name: Install OPA
+        run: |
+          curl -sSL -o /usr/local/bin/opa https://openpolicyagent.org/downloads/v1.18.2/opa_linux_amd64_static
+          chmod +x /usr/local/bin/opa
+          opa version
+
       - name: Run Go tests
         working-directory: operator
         run: make test-unit

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -118,7 +118,8 @@ export default withMermaid(defineConfig({
         items: [
           { text: 'Overview', link: '/security/overview' },
           { text: 'Authorization', link: '/security/authorization' },
-          { text: 'End-to-end Walkthrough', link: '/security/walkthrough' }
+          { text: 'Walkthrough: kaos-internal', link: '/security/walkthrough-kaos' },
+          { text: 'Walkthrough: aib-keycloak', link: '/security/walkthrough-aib' }
         ]
       },
       {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -114,6 +114,12 @@ export default withMermaid(defineConfig({
         ]
       },
       {
+        text: 'Security',
+        items: [
+          { text: 'Authorization', link: '/security/authorization' }
+        ]
+      },
+      {
         text: 'Python Framework',
         items: [
           { text: 'Overview', link: '/python-framework/overview' },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -116,6 +116,7 @@ export default withMermaid(defineConfig({
       {
         text: 'Security',
         items: [
+          { text: 'Overview', link: '/security/overview' },
           { text: 'Authorization', link: '/security/authorization' }
         ]
       },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -117,7 +117,8 @@ export default withMermaid(defineConfig({
         text: 'Security',
         items: [
           { text: 'Overview', link: '/security/overview' },
-          { text: 'Authorization', link: '/security/authorization' }
+          { text: 'Authorization', link: '/security/authorization' },
+          { text: 'End-to-end Walkthrough', link: '/security/walkthrough' }
         ]
       },
       {

--- a/docs/operator/gateway-api.md
+++ b/docs/operator/gateway-api.md
@@ -270,3 +270,30 @@ kubectl get clusterrole kaos-operator-kaos-operator -o yaml | grep -A10 gateway
 ## Internal Routing (Future)
 
 When Gateway API is enabled, agents can optionally use Gateway URLs for inter-agent communication instead of direct service DNS. This feature is planned for future releases.
+
+## Strict Gateway-Only Traffic
+
+By default agents reach other KAOS resources (MCP servers, model APIs, peer agents) directly over their in-cluster Service DNS. Strict gateway-only traffic makes the Envoy Gateway the single application path between workloads: it generates a `NetworkPolicy` for each protected workload that denies direct workload-to-workload traffic, and injects gateway-routed URLs into agents so their internal calls flow through the gateway (where JWT authentication, authorization, and TLS apply).
+
+This is a defence-in-depth posture that is useful on its own — it does **not** require any authorization backend (ext_authz or ext_proc). Enable it with a single switch:
+
+```bash
+kaos system install --gateway-enabled --gateway-api-strict
+```
+
+Or via Helm:
+
+```bash
+helm upgrade kaos kaos/kaos-operator \
+  --set security.strictGatewayApi.enabled=true
+```
+
+The switch bundles NetworkPolicy isolation and gateway routing together because they are only useful as a pair: isolation without routing breaks connectivity, and routing without isolation is trivially bypassed. When it is on, it overrides the `security.networkPolicy.enabled` disable hatch.
+
+::: warning CNI requirement
+`NetworkPolicy` is only enforced by CNIs that implement it. The default KIND CNI (kindnet) does **not** enforce NetworkPolicy, so the generated policies are inert there and direct traffic is not actually blocked. To validate strict enforcement, use a NetworkPolicy-enforcing CNI such as Calico.
+:::
+
+::: warning Direct workload access
+Under strict gateway-only traffic, anything that reached workloads directly (for example a UI that talks to a workload Service rather than through the gateway) must move onto the gateway path first, or it will lose connectivity.
+:::

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -1,0 +1,128 @@
+# Authorization
+
+KAOS enforces agent authorization at the gateway: every request an agent makes to another KAOS resource (an MCP server, a model API, or another agent) can be checked before it is forwarded. Enforcement runs as an Open Policy Agent (OPA) policy inside the Envoy `ext_proc` filter, so a denied request never reaches the target workload.
+
+Authorization is optional and off by default. You turn it on at install time and pick who authors the policy data.
+
+## Concepts
+
+- **Actor identity** — the agent making the call. It is the `sub` claim of the agent (actor) token carried in the `x-agent-authorization` header, and equals the agent logical identity `kaos://agent/<namespace>/<name>`.
+- **Resource identity** — the target being called. It is the logical identity `kaos://<slug>/<namespace>/<name>` (`slug` is `mcpserver`, `modelapi`, or `agent`), matched against the `x-kaos-target-resource` header the gateway stamps onto the request.
+- **Grant** — a decision fact stating that an actor may reach a resource. Grants live in `data.kaos.grants`, a published contract (see [Policy data schema](#policy-data-schema)).
+- **Provider** — who owns the authorization decision data: `kaos` (KAOS projects grants from your CRDs) or `aib` (an external identity broker owns permission sets).
+
+## Providers
+
+### `kaos` — KAOS-owned policy data
+
+The operator derives the grant graph from your `Agent`, `MCPServer`, and `ModelAPI` resources (their `mcpServers`, `agentNetwork.access`, and model references) and writes it, together with a static policy, into a single policy ConfigMap that the enforcement engine mounts. No external broker is required. This is the recommended starting point and works in autonomous mode because the actor token is always present.
+
+### `aib` — broker permission sets
+
+The operator registers agents with an external identity broker and enforcement reads the broker's `granted_permission_sets` returned from token exchange. Use this when the broker is your source of truth for authorization.
+
+## Modes
+
+Select a mode with `kaos system install` flags. All modes are safe by construction: KAOS never overwrites or prunes policy data that it does not own.
+
+| Mode | Provider | `--policy-data-source` | KAOS writes | Use when |
+|------|----------|------------------------|-------------|----------|
+| Automated (default) | `kaos` | `automated` | `policy.rego` + `data.json` grants | KAOS should project grants from CRDs |
+| Bring-your-own ConfigMap | `kaos` | `manual` | nothing | You author both the rego and the data in your own ConfigMap |
+| Operator-rego + admin data | `kaos` | `manual` (with `--policy-rego-override`) | `policy.rego` only | KAOS owns the policy, you author `data.kaos.grants` |
+| Broker external off-switch | `aib` | `external` | identity only (no grants, no prune) | The broker owns authorization; KAOS only registers identity |
+
+### Automated (default)
+
+KAOS projects grants from your resources and keeps them in sync as agents are added or removed.
+
+```bash
+kaos system install \
+  --auth-enabled \
+  --authz-provider kaos \
+  --policy-data-source automated \
+  --agent-jwt-verification verified \
+  --policy-configmap-name kaos-authz-policy \
+  --policy-configmap-namespace kaos-system
+```
+
+### Bring-your-own ConfigMap
+
+KAOS points the enforcement engine at a ConfigMap you fully own and never modifies it. Author both `policy.rego` and `data.json` yourself.
+
+```bash
+kaos system install \
+  --auth-enabled \
+  --authz-provider kaos \
+  --policy-data-source manual \
+  --policy-configmap-name my-policy \
+  --policy-configmap-namespace kaos-system
+```
+
+### Operator-rego + admin data
+
+KAOS owns only the `policy.rego` key (via server-side-apply field ownership) and never writes `data.kaos.grants`, so you can author grants directly while still getting policy updates from KAOS.
+
+```bash
+kaos system install \
+  --auth-enabled \
+  --authz-provider kaos \
+  --policy-data-source manual \
+  --policy-rego-override \
+  --policy-configmap-name kaos-authz-policy \
+  --policy-configmap-namespace kaos-system
+```
+
+### Broker external off-switch
+
+KAOS keeps registering agent identities and minting per-agent credential Secrets, but disables authorization projection and forces prune off. The broker is authoritative; enforcement reads it live.
+
+```bash
+kaos system install \
+  --auth-enabled \
+  --authz-provider aib \
+  --policy-data-source external \
+  --admin-url http://aib.aib-system:8000/api
+```
+
+## Verification modes
+
+The subject (user) token is always verified by the gateway's JWT authentication. The actor token needs the same treatment for a production posture, controlled by `--agent-jwt-verification`:
+
+- `verified` — the operator injects the IdP JWKS at `data.kaos.jwks` and the policy verifies the actor token signature, issuer, and expiry before trusting its `sub`. This is the real posture.
+- `skip` — **demo mode, non-production.** The policy decodes the actor token without verifying its signature, so the `x-agent-authorization` header is spoofable. Use it only to try route- and agent-level authorization without an identity provider. Move to `verified` before any real deployment.
+
+::: warning
+Demo mode (`--agent-jwt-verification skip`) trusts an unverified header and is spoofable. It exists to explore authorization without an IdP and must never be used in production.
+:::
+
+## Policy data schema
+
+The enforcement policy reads one OPA data document from the policy ConfigMap key `data.json`. This shape is a published contract: the operator projects it in automated mode, and you author it directly in operator-rego and bring-your-own modes.
+
+```json
+{
+  "kaos": {
+    "grants": {
+      "kaos://agent/<namespace>/<name>": [
+        "kaos://mcpserver/<namespace>/<name>",
+        "kaos://agent/<namespace>/<name>"
+      ]
+    },
+    "jwks": {
+      "keys": [ { "kty": "RSA", "kid": "...", "n": "...", "e": "AQAB" } ]
+    }
+  }
+}
+```
+
+### `kaos.grants` (required)
+
+Maps an actor identity to the sorted, de-duplicated set of resource identities it may reach. A request is allowed only when its resource id is present in the granting array for its actor id.
+
+- **Actor id** — `kaos://agent/<namespace>/<name>`, the `sub` of the agent token in `x-agent-authorization`.
+- **Resource id** — `kaos://<slug>/<namespace>/<name>` (`slug` is `mcpserver`, `modelapi`, or `agent`), matched against the `x-kaos-target-resource` header.
+
+### `kaos.jwks` (optional)
+
+The IdP JSON Web Key Set used to verify the actor token signature. Its presence switches the policy from demo mode (decode only) to verified mode (`io.jwt.decode_verify` against these keys). Omit it only in demo installs.

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -25,75 +25,58 @@ The operator registers agents with an external identity broker and enforcement r
 
 Select a mode with `kaos system install` flags. All modes are safe by construction: KAOS never overwrites or prunes policy data that it does not own.
 
-| Mode | Provider | `--policy-data-source` | KAOS writes | Use when |
-|------|----------|------------------------|-------------|----------|
+## Installing
+
+The `kaos system install` command exposes two curated end-to-end postures through the single `--full-auth-enabled` flag. Both enable OPA-in-`ext_proc` authorization, route internal traffic through the gateway, and generate bypass-prevention NetworkPolicies.
+
+### Demo posture (no identity provider)
+
+`kaos-internal-demo` uses the `kaos` provider with grants projected from your CRDs and the agent token header-trusted, so you can explore route- and agent-level authorization without Keycloak or a broker.
+
+```bash
+kaos system install --gateway-enabled --full-auth-enabled kaos-internal-demo
+```
+
+### Full verified posture
+
+`keycloak-aib-enabled` (the default when `--full-auth-enabled` is passed without a value) installs Keycloak for user identity and wires the identity broker with RFC 8693 token exchange. Authorization reads the broker's permission sets and the agent token signature is verified against the IdP JWKS.
+
+```bash
+kaos system install --gateway-enabled --full-auth-enabled keycloak-aib-enabled
+```
+
+### Advanced configuration
+
+The presets cover the common cases. Every underlying knob remains available as a Helm chart value via `--set`, so you can compose any of the modes below. All modes are safe by construction: KAOS never overwrites or prunes policy data that it does not own.
+
+| Mode | Provider | `policyDataSource` | KAOS writes | Use when |
+|------|----------|--------------------|-------------|----------|
 | Automated (default) | `kaos` | `automated` | `policy.rego` + `data.json` grants | KAOS should project grants from CRDs |
 | Bring-your-own ConfigMap | `kaos` | `manual` | nothing | You author both the rego and the data in your own ConfigMap |
-| Operator-rego + admin data | `kaos` | `manual` (with `--policy-rego-override`) | `policy.rego` only | KAOS owns the policy, you author `data.kaos.grants` |
+| Operator-rego + admin data | `kaos` | `manual` (+ `policyRegoOverride`) | `policy.rego` only | KAOS owns the policy, you author `data.kaos.grants` |
 | Broker external off-switch | `aib` | `external` | identity only (no grants, no prune) | The broker owns authorization; KAOS only registers identity |
 
-### Automated (default)
-
-KAOS projects grants from your resources and keeps them in sync as agents are added or removed.
+The relevant chart values are:
 
 ```bash
-kaos system install \
-  --auth-enabled \
-  --authz-provider kaos \
-  --policy-data-source automated \
-  --agent-jwt-verification verified \
-  --policy-configmap-name kaos-authz-policy \
-  --policy-configmap-namespace kaos-system
-```
-
-### Bring-your-own ConfigMap
-
-KAOS points the enforcement engine at a ConfigMap you fully own and never modifies it. Author both `policy.rego` and `data.json` yourself.
-
-```bash
-kaos system install \
-  --auth-enabled \
-  --authz-provider kaos \
-  --policy-data-source manual \
-  --policy-configmap-name my-policy \
-  --policy-configmap-namespace kaos-system
-```
-
-### Operator-rego + admin data
-
-KAOS owns only the `policy.rego` key (via server-side-apply field ownership) and never writes `data.kaos.grants`, so you can author grants directly while still getting policy updates from KAOS.
-
-```bash
-kaos system install \
-  --auth-enabled \
-  --authz-provider kaos \
-  --policy-data-source manual \
-  --policy-rego-override \
-  --policy-configmap-name kaos-authz-policy \
-  --policy-configmap-namespace kaos-system
-```
-
-### Broker external off-switch
-
-KAOS keeps registering agent identities and minting per-agent credential Secrets, but disables authorization projection and forces prune off. The broker is authoritative; enforcement reads it live.
-
-```bash
-kaos system install \
-  --auth-enabled \
-  --authz-provider aib \
-  --policy-data-source external \
-  --admin-url http://aib.aib-system:8000/api
+kaos system install --gateway-enabled --full-auth-enabled kaos-internal-demo \
+  --set security.agentAuth.authorization.provider=kaos \
+  --set security.agentAuth.authorization.policyDataSource=manual \
+  --set security.agentAuth.authorization.policyRegoOverride=true \
+  --set security.agentAuth.authorization.agentJwtVerification=verified \
+  --set security.agentAuth.projection.policyConfigMap.name=kaos-authz-policy \
+  --set security.agentAuth.projection.policyConfigMap.namespace=kaos-system
 ```
 
 ## Verification modes
 
-The subject (user) token is always verified by the gateway's JWT authentication. The actor token needs the same treatment for a production posture, controlled by `--agent-jwt-verification`:
+The subject (user) token is always verified by the gateway's JWT authentication. The actor token needs the same treatment for a production posture, controlled by `security.agentAuth.authorization.agentJwtVerification` (the `keycloak-aib-enabled` preset sets `verified`; `kaos-internal-demo` sets `skip`):
 
 - `verified` — the operator injects the IdP JWKS at `data.kaos.jwks` and the policy verifies the actor token signature, issuer, and expiry before trusting its `sub`. This is the real posture.
 - `skip` — **demo mode, non-production.** The policy decodes the actor token without verifying its signature, so the `x-agent-authorization` header is spoofable. Use it only to try route- and agent-level authorization without an identity provider. Move to `verified` before any real deployment.
 
 ::: warning
-Demo mode (`--agent-jwt-verification skip`) trusts an unverified header and is spoofable. It exists to explore authorization without an IdP and must never be used in production.
+Demo mode (`agentJwtVerification=skip`, the `kaos-internal-demo` preset) trusts an unverified header and is spoofable. It exists to explore authorization without an IdP and must never be used in production.
 :::
 
 ## Policy data schema

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -27,22 +27,30 @@ Select a mode with `kaos system install` flags. All modes are safe by constructi
 
 ## Installing
 
-The `kaos system install` command exposes two curated end-to-end postures through the single `--full-auth-enabled` flag. Both enable OPA-in-`ext_proc` authorization, route internal traffic through the gateway, and generate bypass-prevention NetworkPolicies.
+The `kaos system install` command exposes three curated end-to-end postures through the single `--auth-enabled` flag. All enable OPA-in-`ext_proc` authorization, route internal traffic through the gateway, and generate bypass-prevention NetworkPolicies.
 
 ### Demo posture (no identity provider)
 
-`kaos-internal-demo` uses the `kaos` provider with grants projected from your CRDs and the agent token header-trusted, so you can explore route- and agent-level authorization without Keycloak or a broker.
+`kaos-internal` uses the `kaos` provider with grants projected from your CRDs and the agent token header-trusted, so you can explore route- and agent-level authorization without Keycloak or a broker. It bakes in the `kaos-authz-policy` ConfigMap projection target, so no additional flags are required.
 
 ```bash
-kaos system install --gateway-enabled --full-auth-enabled kaos-internal-demo
+kaos system install --gateway-enabled --auth-enabled kaos-internal
+```
+
+### Broker identity posture (no user login)
+
+`aib-only` wires the identity broker so agents receive broker-issued, signature-verified actor tokens, but installs neither Keycloak user identity nor RFC 8693 token exchange. Use it when you want verified agent identity without a user-auth layer.
+
+```bash
+kaos system install --gateway-enabled --auth-enabled aib-only
 ```
 
 ### Full verified posture
 
-`keycloak-aib-enabled` (the default when `--full-auth-enabled` is passed without a value) installs Keycloak for user identity and wires the identity broker with RFC 8693 token exchange. Authorization reads the broker's permission sets and the agent token signature is verified against the IdP JWKS.
+`aib-keycloak` (the default when `--auth-enabled` is passed without a value) installs Keycloak for user identity and wires the identity broker with RFC 8693 token exchange. Authorization reads the broker's permission sets and the agent token signature is verified against the IdP JWKS.
 
 ```bash
-kaos system install --gateway-enabled --full-auth-enabled keycloak-aib-enabled
+kaos system install --gateway-enabled --auth-enabled aib-keycloak
 ```
 
 ### Advanced configuration
@@ -59,7 +67,7 @@ The presets cover the common cases. Every underlying knob remains available as a
 The relevant chart values are:
 
 ```bash
-kaos system install --gateway-enabled --full-auth-enabled kaos-internal-demo \
+kaos system install --gateway-enabled --auth-enabled kaos-internal \
   --set security.agentAuth.authorization.provider=kaos \
   --set security.agentAuth.authorization.policyDataSource=manual \
   --set security.agentAuth.authorization.policyRegoOverride=true \
@@ -70,13 +78,13 @@ kaos system install --gateway-enabled --full-auth-enabled kaos-internal-demo \
 
 ## Verification modes
 
-The subject (user) token is always verified by the gateway's JWT authentication. The actor token needs the same treatment for a production posture, controlled by `security.agentAuth.authorization.agentJwtVerification` (the `keycloak-aib-enabled` preset sets `verified`; `kaos-internal-demo` sets `skip`):
+The subject (user) token is always verified by the gateway's JWT authentication. The actor token needs the same treatment for a production posture, controlled by `security.agentAuth.authorization.agentJwtVerification` (the `aib-keycloak` and `aib-only` presets set `verified`; `kaos-internal` sets `skip`):
 
 - `verified` — the operator injects the IdP JWKS at `data.kaos.jwks` and the policy verifies the actor token signature, issuer, and expiry before trusting its `sub`. This is the real posture.
 - `skip` — **demo mode, non-production.** The policy decodes the actor token without verifying its signature, so the `x-agent-authorization` header is spoofable. Use it only to try route- and agent-level authorization without an identity provider. Move to `verified` before any real deployment.
 
 ::: warning
-Demo mode (`agentJwtVerification=skip`, the `kaos-internal-demo` preset) trusts an unverified header and is spoofable. It exists to explore authorization without an IdP and must never be used in production.
+Demo mode (`agentJwtVerification=skip`, the `kaos-internal` preset) trusts an unverified header and is spoofable. It exists to explore authorization without an IdP and must never be used in production.
 :::
 
 ## Policy data schema

--- a/docs/security/opa-drop-in/README.md
+++ b/docs/security/opa-drop-in/README.md
@@ -17,9 +17,9 @@ This sample demonstrates that swap.
 The operator generates the `SecurityPolicy.spec.extAuth.grpc.backendRef` from a single configuration value — the ext_authz backend host:port. Pointing it at opa-envoy instead of AIB is a config change:
 
 ```bash
-# CLI
-kaos system install --auth-enabled \
-  --ext-authz-url opa-envoy.opa-system.svc.cluster.local:9191
+# CLI — select an auth preset and override the ext_authz backend
+kaos system install --auth-enabled aib-keycloak \
+  --set security.agentAuth.extAuthzUrl=opa-envoy.opa-system.svc.cluster.local:9191
 
 # or Helm
 helm upgrade kaos kaos/kaos-operator \
@@ -36,8 +36,8 @@ kubectl apply -f docs/security/opa-drop-in/opa-envoy.yaml
 kubectl -n opa-system rollout status deploy/opa-envoy
 
 # 2. Point KAOS at it (config only) and enable auth.
-kaos system install --auth-enabled \
-  --ext-authz-url opa-envoy.opa-system.svc.cluster.local:9191 --wait
+kaos system install --auth-enabled aib-keycloak \
+  --set security.agentAuth.extAuthzUrl=opa-envoy.opa-system.svc.cluster.local:9191 --wait
 
 # 3. A granted edge is allowed, an ungranted one is denied — equivalently to AIB.
 #    (agent `demo/researcher` is granted `call` on `mcpserver/demo/github` only.)

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -11,22 +11,26 @@ KAOS secures agent-to-agent and agent-to-tool traffic at the Envoy Gateway. Ever
 
 ## Install postures
 
-The `kaos system install` command bundles these layers into two curated postures selected with `--full-auth-enabled`:
+The `kaos system install` command bundles these layers into three curated postures selected with `--auth-enabled`:
 
 | Preset | Identity | Authorization | Agent token | Use when |
 |--------|----------|---------------|-------------|----------|
-| `kaos-internal-demo` | none | KAOS-projected grants (`kaos` provider) | header-trusted (spoofable) | Exploring authorization without an IdP |
-| `keycloak-aib-enabled` (default) | Keycloak + identity broker | broker permission sets (`aib` provider) | signature-verified against IdP JWKS | Production-like end-to-end security |
+| `kaos-internal` | none | KAOS-projected grants (`kaos` provider) | header-trusted (spoofable) | Exploring authorization without an IdP |
+| `aib-only` | identity broker | broker permission sets (`aib` provider) | signature-verified against IdP JWKS | Broker-issued agent identity without user login |
+| `aib-keycloak` (default) | Keycloak + identity broker | broker permission sets (`aib` provider) | signature-verified against IdP JWKS | Production-like end-to-end security with user auth + token exchange |
 
 ```bash
 # Self-contained demo — no external identity provider or broker
-kaos system install --gateway-enabled --full-auth-enabled kaos-internal-demo
+kaos system install --gateway-enabled --auth-enabled kaos-internal
 
-# Full verified path — Keycloak user identity + identity broker
-kaos system install --gateway-enabled --full-auth-enabled keycloak-aib-enabled
+# Broker-issued agent identity, no user login or token exchange
+kaos system install --gateway-enabled --auth-enabled aib-only
+
+# Full verified path — Keycloak user identity + identity broker + token exchange
+kaos system install --gateway-enabled --auth-enabled aib-keycloak
 ```
 
-Both presets imply `--gateway-enabled`, route internal traffic through the gateway, and generate bypass-prevention NetworkPolicies. Every underlying knob remains configurable via Helm `--set` for advanced compositions; see [Authorization](/security/authorization#advanced-configuration).
+All presets imply `--gateway-enabled`, route internal traffic through the gateway, and generate bypass-prevention NetworkPolicies. Every underlying knob remains configurable via Helm `--set` for advanced compositions; see [Authorization](/security/authorization#advanced-configuration).
 
 ## Enforcement model
 

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -1,0 +1,47 @@
+# Security Overview
+
+KAOS secures agent-to-agent and agent-to-tool traffic at the Envoy Gateway. Every call an agent makes to another KAOS resource can be authenticated, authorized, and confined to the gateway path, so a request is checked before it reaches the target workload. Each layer is independent and opt-in, and they compose into a full end-to-end posture.
+
+## Layers
+
+- **Identity** — each agent is issued a signed actor token (`sub = kaos://agent/<namespace>/<name>`) and each user authenticates against an identity provider. The gateway carries the user (subject) token in `Authorization` and the agent (actor) token in `x-agent-authorization`.
+- **Authorization** — an Open Policy Agent policy inside the Envoy `ext_proc` filter decides whether an actor may reach a resource. Grant data is either projected by KAOS from your CRDs (`kaos` provider) or owned by an external identity broker (`aib` provider). See [Authorization](/security/authorization).
+- **Gateway-only traffic** — NetworkPolicies deny direct workload-to-workload traffic and internal calls are routed through the gateway, so the enforcement point cannot be bypassed. This can be enabled on its own as a defence-in-depth posture. See [Gateway API](/operator/gateway-api#strict-gateway-only-traffic).
+- **Transport security** — the gateway can terminate HTTPS (self-signed, cert-manager, or a provided certificate).
+
+## Install postures
+
+The `kaos system install` command bundles these layers into two curated postures selected with `--full-auth-enabled`:
+
+| Preset | Identity | Authorization | Agent token | Use when |
+|--------|----------|---------------|-------------|----------|
+| `kaos-internal-demo` | none | KAOS-projected grants (`kaos` provider) | header-trusted (spoofable) | Exploring authorization without an IdP |
+| `keycloak-aib-enabled` (default) | Keycloak + identity broker | broker permission sets (`aib` provider) | signature-verified against IdP JWKS | Production-like end-to-end security |
+
+```bash
+# Self-contained demo — no external identity provider or broker
+kaos system install --gateway-enabled --full-auth-enabled kaos-internal-demo
+
+# Full verified path — Keycloak user identity + identity broker
+kaos system install --gateway-enabled --full-auth-enabled keycloak-aib-enabled
+```
+
+Both presets imply `--gateway-enabled`, route internal traffic through the gateway, and generate bypass-prevention NetworkPolicies. Every underlying knob remains configurable via Helm `--set` for advanced compositions; see [Authorization](/security/authorization#advanced-configuration).
+
+## Enforcement model
+
+Authorization runs as OPA embedded in the gateway `ext_proc` filter. On each request the policy sees the subject identity (from `Authorization`), the actor identity (from `x-agent-authorization`), the target resource (from `x-kaos-target-resource`), and the grant facts — whether KAOS-owned (`data.kaos.grants`) or broker-owned (`granted_permission_sets`). Because the actor token is always present, KAOS-owned authorization also enforces in autonomous mode.
+
+::: warning
+OPA only evaluates when a subject bearer token is present. Pure-autonomous agent-to-resource calls with no user token bypass the policy. Use the verified posture and require a token on protected paths for production.
+:::
+
+## Gateway-only strict traffic
+
+Strict gateway-only traffic can be enabled independently of authorization to make the gateway the single application path between workloads:
+
+```bash
+kaos system install --gateway-enabled --gateway-api-strict
+```
+
+Enforcement of the generated NetworkPolicies requires a CNI that implements NetworkPolicy (for example Calico); the default KIND CNI does not. See [Gateway API](/operator/gateway-api#strict-gateway-only-traffic).

--- a/docs/security/walkthrough-aib.md
+++ b/docs/security/walkthrough-aib.md
@@ -208,6 +208,66 @@ Every outbound URL routes through the gateway path (the `ext_proc` enforcement p
 
 **Proves:** internal calls are gateway-routed and the `ext_proc` authorization hook plus bypass-prevention NetworkPolicies are in place.
 
+## Step 6 — Prove requests are allowed or rejected at the gateway
+
+The previous steps confirm the objects exist. This step sends real requests through the gateway and observes them being **accepted or rejected** by the `jwt_authn` identity gate. Every agent route carries the two `jwt_authn` providers from its `SecurityPolicy` — `user` (Keycloak subject token in `Authorization`) and `agent` (broker actor token in `x-agent-authorization`) — so a request that presents no valid token for either provider never reaches the workload.
+
+The gateway is a `LoadBalancer` whose MetalLB address is only reachable from inside the KIND network (not from the macOS host), so drive the requests from an in-cluster pod. Grab the gateway address and the agent's route path first:
+
+```bash
+export GW_IP=$(kubectl get gateway kaos-gateway -n "$KAOS_NS" -o jsonpath='{.status.addresses[0].value}')
+export ROUTE="/$APP_NS/agent/coordinator/"
+echo "gateway=$GW_IP route=$ROUTE"
+```
+
+Mint a fresh user token (Step 4 leaves `USER_TOKEN` set; re-run that step if your shell has expired it), then send four requests from a throwaway curl pod — three that must be **rejected** and one that must be **admitted**:
+
+```bash
+kubectl -n "$APP_NS" run authz-demo --rm -i --restart=Never --image=curlimages/curl --command -- sh -c '
+GW="http://'"$GW_IP$ROUTE"'"
+echo "1) no token          -> $(curl -s -o /dev/null -w %{http_code} $GW)"
+echo "2) malformed token   -> $(curl -s -o /dev/null -w %{http_code} -H "Authorization: Bearer not-a-jwt" $GW)"
+echo "3) wrong-issuer JWT   -> $(curl -s -o /dev/null -w %{http_code} -H "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJldmlsIiwiYXVkIjoia2FvcyJ9.ZmFrZQ" $GW)"
+echo "4) valid user token  -> $(curl -s -o /dev/null -w %{http_code} -H "Authorization: Bearer '"$USER_TOKEN"'" $GW)"
+'
+```
+
+Expected:
+
+```text
+1) no token          -> 401
+2) malformed token   -> 401
+3) wrong-issuer JWT   -> 401
+4) valid user token   -> 500
+```
+
+The first three are **rejected by the gateway** before any workload is touched. The fourth **passes the identity gate** (it is no longer a 401) and is handed to the AIB `ext_proc` token-exchange path — which returns `500` here because user→agent consent and the third-party token vault are not wired in this environment (see [What is not yet wired](#what-is-not-yet-wired-consent-vault)). The important signal is the transition from `401` (rejected at identity) to "past identity" for a genuine Keycloak token.
+
+Read the exact reason Envoy recorded for each request from the gateway access log:
+
+```bash
+EPOD=$(kubectl get pod -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-name=kaos-gateway -o name | head -1)
+kubectl logs -n envoy-gateway-system "$EPOD" --tail=4 \
+  | python3 -c 'import sys,json
+for l in sys.stdin:
+    try:
+        d=json.loads(l); print(d["response_code"], d["response_code_details"])
+    except Exception: pass'
+```
+
+Expected — the rejections name the precise validation that failed, and the admitted request shows it left `jwt_authn` and hit the `ext_proc` direct response:
+
+```text
+401 jwt_authn_access_denied{Jwt_is_missing}
+401 jwt_authn_access_denied{Jwt_is_not_in_the_form_of_Header.Payload.Signature_with_two_dots_and_3_sections}
+401 jwt_authn_access_denied{Jwt_issuer_is_not_configured}
+500 direct_response
+```
+
+You can also confirm the NetworkPolicy bypass guard: a pod trying to reach the agent workload directly (not via the gateway) simply hangs/times out, because only gateway traffic is permitted to the agent.
+
+**Proves:** the gateway cryptographically validates the caller's identity — missing, malformed, and untrusted-issuer tokens are rejected with a specific reason, and only a Keycloak-signed token is admitted past the identity gate — and the workload is unreachable except through that gate.
+
 ## Token exchange (RFC 8693)
 
 The `aib-keycloak` posture runs the RFC 8693 **token-exchange** path so an agent can call a protected third-party API on behalf of a user: the broker exchanges the user's Keycloak-issued subject token for a vaulted third-party token, gated by the user's consent grant. The broker's `ext_proc` sidecar automates this exchange inline in the Envoy data path.

--- a/docs/security/walkthrough-aib.md
+++ b/docs/security/walkthrough-aib.md
@@ -148,20 +148,103 @@ Every outbound URL routes through the gateway path (the `ext_proc` enforcement p
 
 **Proves:** internal calls are gateway-routed and the `ext_proc` authorization hook plus bypass-prevention NetworkPolicies are in place.
 
-## Token exchange (RFC 8693) and current status
+## Token exchange (RFC 8693)
 
-The `aib-keycloak` posture is designed to run the RFC 8693 **token-exchange** path in the broker's `ext_proc` sidecar: for a user-present request, the sidecar exchanges the user subject token for the agent's `granted_permission_sets` (and, for third-party APIs, a vaulted upstream OAuth token) before the OPA policy decides allow/deny.
+The `aib-keycloak` posture runs the RFC 8693 **token-exchange** path so an agent can call a protected third-party API on behalf of a user: the broker exchanges the user's Keycloak-issued subject token for a vaulted third-party token, gated by the user's consent grant. The broker's `ext_proc` sidecar automates this exchange inline in the Envoy data path.
 
-::: warning Token-exchange sidecar prerequisites
-The `ext_proc` token-exchange sidecar performs an OAuth2 `client_credentials` grant against the broker **at startup** to mint its own client assertion. This requires:
+### How the exchange is wired
 
-1. The broker running in **federated** or **hybrid** OAuth2 mode. The chart's `values-dev.yaml` dev preset runs in `local` mode, which mints enduser tokens in-memory and **does not accept the `client_credentials` grant** — so the token-exchange sidecar cannot bootstrap against the dev preset.
-2. A bootstrapped OAuth client for the sidecar: an agent registered with the broker admin API, a credential minted via `POST /api/agents/{agent-id}/client-credentials`, and the sidecar configured with the agent's **UUID** as its `client_id` (the broker resolves opaque `client_id` values as agent UUIDs, not display names) plus the minted secret.
+The exchange involves two Keycloak-issued JWTs, both signature-verified by the broker against Keycloak's JWKS:
 
-Automating this bootstrap end-to-end (federated broker mode wired to Keycloak, plus sidecar credential provisioning) is the remaining work for a fully self-serve token-exchange install. Until then, deploy the broker in `local` mode for identity + agent-credential minting and provision the token-exchange sidecar's OAuth client out of band, or run the broker in federated mode against Keycloak.
+- **`subject_token`** — the user's access token (minted through the agent's OAuth client). Its `sub` claim is the user principal and its `azp` claim is the agent's client_id, which the broker maps to a registered agent via `resolveAgentIdByClientId(subject_token.azp)`.
+- **`client_assertion`** — the gateway's own identity, obtained by the `ext_proc` sidecar via a `client_credentials` grant **against Keycloak** (not the broker) using the `extproc-gateway` client.
+
+The broker therefore runs in **hybrid** OAuth2 mode with Keycloak configured as the upstream issuer. Crucially, the sidecar authenticates against **Keycloak**, and the broker validates both tokens against Keycloak's JWKS — the broker never issues these tokens itself in this posture.
+
+### Broker `--aib-values` for hybrid mode against Keycloak
+
+The stock `values-dev.yaml` runs the broker in `local` mode, which mints tokens in-memory and rejects the `client_credentials` grant the sidecar needs. Supply a hybrid values file instead (adjust the Keycloak namespace/realm and keys for your install):
+
+```yaml
+storage:
+  type: memory
+broker:
+  oauth2AuthorizationServer:
+    mode: hybrid
+    proxy:
+      upstreamIssuerUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos
+      upstreamAuthorizeEndpoint: http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/auth
+      upstreamTokenEndpoint: http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/token
+    supportedGrantTypes:
+      - authorization_code
+      - refresh_token
+      - urn:ietf:params:oauth:grant-type:token-exchange
+  tokenExchange:
+    expectedAudience: token-exchange-broker
+    claimExtraction:
+      principalExpression: "subject_token.sub"
+      agentIdExpression: "resolveAgentIdByClientId(subject_token.azp)"
+    authorization:
+      type: cel
+      cel:
+        expression: "true"
+        evaluationTimeout: "5s"
+  security:
+    skipThirdpartyHttpsValidation: true
+extProc:
+  enabled: true
+  oauth2:
+    tokenEndpoint: http://aib-agentic-identity-broker.aib-system.svc.cluster.local:8000/oauth2/token
+    issuer: http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos
+    clientId: extproc-gateway
+    clientSecret: extproc-gateway-secret
+    clientAssertionType: access_token
+    allowHttp: true
+```
+
+The broker validates that both the `subject_token` and `client_assertion` carry `aud: token-exchange-broker`. Add a custom-audience mapper to the user client (`kaos`) and create the `extproc-gateway` service-account client (with the same audience mapper) in Keycloak so both tokens carry that audience.
+
+::: warning ExtProc client-credentials endpoint against Keycloak
+When `extProc.oauth2.clientCredentialsEndpoint` is unset, the sidecar derives its token endpoint as `issuer + /oauth/token`, which is the mock-upstream path and returns `404` against Keycloak (whose path is `/protocol/openid-connect/token`). The stock chart does not template this env var, so set it directly on the sidecar Deployment:
+
+```bash
+kubectl -n aib-system set env deploy/aib-agentic-identity-broker-extproc \
+  EXTPROC_OAUTH2_CLIENT_CREDENTIALS_ENDPOINT=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/token
+```
 :::
 
-**Proves / documents:** the intended enforcement flow and the exact bootstrap prerequisites the token-exchange sidecar needs — captured so the posture can be completed without rediscovering them.
+### Verify the exchange reaches the broker
+
+Register an agent whose `client_id` matches the user token's `azp` (`kaos`), plus a third-party service, then run the exchange from inside the cluster (so the token `iss` matches the broker's configured upstream issuer):
+
+```bash
+kubectl -n aib-system run tx --rm -i --restart=Never --image=curlimages/curl -- sh -c '
+KC=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/token
+BROKER=http://aib-agentic-identity-broker.aib-system.svc.cluster.local:8000/oauth2/token
+SUBJ=$(curl -s -X POST $KC -d grant_type=password -d client_id=kaos -d client_secret=kaos-dev-secret -d username=kaos-user -d password=kaos-password | sed -n "s/.*\"access_token\":\"\([^\"]*\)\".*/\1/p")
+ASSERT=$(curl -s -X POST $KC -d grant_type=client_credentials -d client_id=extproc-gateway -d client_secret=extproc-gateway-secret | sed -n "s/.*\"access_token\":\"\([^\"]*\)\".*/\1/p")
+curl -s -w "\nHTTP %{http_code}\n" -X POST $BROKER \
+  --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  --data-urlencode "subject_token=$SUBJ" \
+  --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:jwt" \
+  --data-urlencode "client_assertion=$ASSERT" \
+  --data-urlencode "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" \
+  --data-urlencode "resource=https://api.demo.local"'
+```
+
+A correctly wired install returns:
+
+```json
+{"error":"access_denied","error_description":"user has not granted permission for this agent to access the requested service"}
+```
+
+This `403` is the **expected** result up to the consent boundary: it proves the broker verified both Keycloak-issued JWT signatures, enforced the `token-exchange-broker` audience, resolved the agent from `azp`, and passed CEL authorization — failing only at the user-grant/vault stage. Any earlier misconfiguration (issuer mismatch, wrong audience, unresolved agent) surfaces as a `400`/`401` before this point.
+
+### What is not yet wired: consent + vault
+
+Returning an actual third-party token requires a **user consent grant** for a service with an **active third-party OAuth session** (a vaulted token). The broker enforces this: creating the grant fails with `unconnected services` until the user has completed an OAuth authorization-code flow with the third-party service. KAOS does not currently project consent grants or a real third-party vault (only agent identity + permission sets), so a fully green exchange needs the consent-based delegated-access workflow — tracked as a followup, not part of this posture.
+
+**Proves:** the `aib-keycloak` token-exchange integration end-to-end through Keycloak JWT verification, audience enforcement, agent resolution, and authorization — up to the consent/vault boundary.
 
 ## Clean up
 

--- a/docs/security/walkthrough-aib.md
+++ b/docs/security/walkthrough-aib.md
@@ -29,16 +29,56 @@ The seam is deliberate: KAOS owns agent identity and topology, Keycloak owns use
 As with `kaos-internal`, the generated `NetworkPolicy` objects are only *enforced* by a NetworkPolicy-capable CNI (for example Calico). The default KIND CNI (kindnet) creates them without enforcing them, which is fine for exploring authorization and routing.
 :::
 
+## Reproducible variables
+
+Every command below uses these shell variables so you can copy-paste each step verbatim. The credentials are the fixed dev defaults the `aib-keycloak` preset seeds into Keycloak — they are demo-only, not for real use. Set them once in your shell:
+
+```bash
+# Namespaces
+export KAOS_NS=kaos-system
+export AIB_NS=aib-system
+export KC_NS=keycloak
+export APP_NS=kaos-walkthrough
+
+# AIB broker chart (unpublished — point at your local clone)
+export AIB_CHART=<path-to>/charts/agentic-identity-broker
+
+# Keycloak realm + demo user identity (seeded by the preset)
+export REALM=kaos
+export KC_USER=kaos-user
+export KC_PASSWORD=kaos-password
+export USER_CLIENT_ID=kaos
+export USER_CLIENT_SECRET=kaos-dev-secret
+
+# Token-exchange gateway client + broker audience (seeded by the preset)
+export EXTPROC_CLIENT_ID=extproc-gateway
+export EXTPROC_CLIENT_SECRET=extproc-gateway-secret
+export TX_AUDIENCE=token-exchange-broker
+
+# In-cluster endpoints
+export KC_ISSUER=http://keycloak.${KC_NS}.svc.cluster.local:8080/realms/${REALM}
+export BROKER_TOKEN_URL=http://aib-agentic-identity-broker.${AIB_NS}.svc.cluster.local:8000/oauth2/token
+```
+
+::: tip Where these values come from
+The realm, user, client, secret, and audience are baked into the CLI as the `aib-keycloak` preset defaults. You can confirm them at any time from the seeded realm-import ConfigMap:
+
+```bash
+kubectl get configmap aib-agentic-identity-broker-realm-import -n "$KC_NS" \
+  -o jsonpath='{.data}' | python3 -m json.tool | grep -iE 'username|value|clientId|secret'
+```
+:::
+
 ## Step 1 — Install with the `aib-keycloak` preset
 
 Install KAOS with the default `aib-keycloak` preset, pointing at the broker chart. The CLI installs the operator, the AIB broker (into `aib-system`), and Keycloak (into `keycloak`, bootstrapping the `kaos` realm). The preset auto-wires the broker into hybrid mode against Keycloak and enables the token-exchange sidecar — see [Token exchange](#token-exchange-rfc-8693) below:
 
 ```bash
 kaos system install \
-  --namespace kaos-system \
+  --namespace "$KAOS_NS" \
   --auth-enabled aib-keycloak \
   --gateway-enabled --metallb-enabled \
-  --aib-chart-path <path-to>/charts/agentic-identity-broker \
+  --aib-chart-path "$AIB_CHART" \
   --wait
 ```
 
@@ -55,7 +95,7 @@ The three presets differ only in the identity and verification layers:
 ### Verify the operator picked up the configuration
 
 ```bash
-kubectl get configmap kaos-operator-config -n kaos-system -o json \
+kubectl get configmap kaos-operator-config -n "$KAOS_NS" -o json \
   | jq -r '.data | to_entries[] | select(.key | test("SECURITY|AUTHZ|GATEWAY")) | "\(.key)=\(.value)"'
 ```
 
@@ -78,15 +118,15 @@ SECURITY_GATEWAY_ROUTING_ENABLED=true
 ## Step 2 — Confirm the identity components are running
 
 ```bash
-kubectl get pods -n aib-system      # AIB broker (+ ext_proc sidecar)
-kubectl get pods -n keycloak        # Keycloak
-kubectl get pods -n kaos-system     # operator
+kubectl get pods -n "$AIB_NS"       # AIB broker (+ ext_proc sidecar)
+kubectl get pods -n "$KC_NS"        # Keycloak
+kubectl get pods -n "$KAOS_NS"      # operator
 ```
 
 Confirm the Keycloak realm was bootstrapped:
 
 ```bash
-kubectl logs -n keycloak deploy/keycloak | grep -i "realm 'kaos'"
+kubectl logs -n "$KC_NS" deploy/keycloak | grep -i "realm '$REALM'"
 ```
 
 **Proves:** the broker (agent identity + authorization) and Keycloak (user identity) are both live and the `kaos` realm exists.
@@ -96,34 +136,55 @@ kubectl logs -n keycloak deploy/keycloak | grep -i "realm 'kaos'"
 Deploy a small topology, then confirm the operator registered each agent with the broker and minted a per-agent credential Secret:
 
 ```bash
-kubectl create namespace kaos-walkthrough
-kubectl apply -n kaos-walkthrough -f \
+kubectl create namespace "$APP_NS"
+kubectl apply -n "$APP_NS" -f \
   https://raw.githubusercontent.com/axsaucedo/kaos/main/operator/config/samples/2-multi-agent-mcp.yaml
 ```
 
-Unlike `kaos-internal` (where the agent token is header-trusted), each agent here is issued a real broker credential. Inspect the minted Secret:
+Unlike `kaos-internal` (where the agent token is header-trusted), each agent here is issued a real broker credential. The operator's projection controller labels the Secrets it manages with `app.kubernetes.io/managed-by=kaos-operator-authz`. List them and read one:
 
 ```bash
-kubectl get secret -n kaos-walkthrough -l kaos.tools/managed-by=kaos \
-  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
-kubectl get secret kaos-aib-coordinator -n kaos-walkthrough \
-  -o jsonpath='{.data.AGENT_AUTH_CLIENT_ID}' | base64 -d; echo
+kubectl get secret -n "$APP_NS" -l app.kubernetes.io/managed-by=kaos-operator-authz
+kubectl get secret kaos-aib-coordinator -n "$APP_NS" \
+  -o jsonpath='{.data.client_id}' | base64 -d; echo
 ```
 
-The `AGENT_AUTH_CLIENT_ID` / `AGENT_AUTH_CLIENT_SECRET` are populated (broker-issued), not empty. The agent runtime uses them to mint a signed actor-token JWT via OAuth2 `client_credentials` against the broker.
+Each Secret holds the agent's broker `client_id` and `client_secret`. The agent runtime mounts them (as `AGENT_AUTH_CLIENT_ID` / `AGENT_AUTH_CLIENT_SECRET`) and uses them to mint a signed actor-token JWT via OAuth2 `client_credentials` against the broker.
 
 **Proves:** agent identity is broker-backed and cryptographically real, not self-asserted.
+
+::: tip No Secrets appear?
+The operator mints these Secrets only when it is running with the auth configuration. A single-shot `kaos system install --auth-enabled aib-keycloak` starts the operator with that config from the outset, and any later `helm upgrade` that changes the config now rolls the operator automatically (the pod template carries a `checksum/config` annotation). If you enabled auth on an operator that predates that annotation and see no Secrets, force one reload:
+
+```bash
+kubectl rollout restart deploy/kaos-kaos-operator-controller-manager -n "$KAOS_NS"
+kubectl rollout status  deploy/kaos-kaos-operator-controller-manager -n "$KAOS_NS"
+```
+
+Then confirm the projection ran (`failed=0`):
+
+```bash
+kubectl logs -n "$KAOS_NS" deploy/kaos-kaos-operator-controller-manager \
+  | grep "reconciled authorization projection" | tail -1
+```
+:::
 
 ## Step 4 — Mint a user token from Keycloak
 
 User identity flows from Keycloak. Port-forward Keycloak and request a subject token with the OIDC password grant:
 
 ```bash
-kubectl port-forward -n keycloak svc/keycloak 8080:8080 &
-curl -s -X POST http://localhost:8080/realms/kaos/protocol/openid-connect/token \
+kubectl port-forward -n "$KC_NS" svc/keycloak 8080:8080 >/dev/null 2>&1 &
+sleep 2
+USER_TOKEN=$(curl -s -X POST http://localhost:8080/realms/$REALM/protocol/openid-connect/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=password&client_id=kaos&username=<realm-user>&password=<password>" \
-  | jq -r .access_token
+  -d "grant_type=password" \
+  -d "client_id=$USER_CLIENT_ID" \
+  -d "client_secret=$USER_CLIENT_SECRET" \
+  -d "username=$KC_USER" \
+  -d "password=$KC_PASSWORD" \
+  | jq -r .access_token)
+echo "${USER_TOKEN:0:24}..."   # non-empty JWT prefix
 ```
 
 This subject token is what a user presents to KAOS. At the gateway it is validated by the `jwt_authn` provider against the Keycloak JWKS before any authorization runs.
@@ -135,12 +196,12 @@ This subject token is what a user presents to KAOS. At the gateway it is validat
 As with `kaos-internal`, agents reach other resources through the gateway, and the operator generates the enforcement objects:
 
 ```bash
-kubectl get deploy agent-coordinator -n kaos-walkthrough -o json \
+kubectl get deploy agent-coordinator -n "$APP_NS" -o json \
   | jq -r '.spec.template.spec.containers[0].env[]
       | select(.name | test("URL|AGENT_AUTH_IDENTITY"))
       | "\(.name)=\(.value)"'
 
-kubectl get securitypolicy,networkpolicy -n kaos-walkthrough
+kubectl get securitypolicy,networkpolicy -n "$APP_NS"
 ```
 
 Every outbound URL routes through the gateway path (the `ext_proc` enforcement point cannot be bypassed), and `AGENT_AUTH_IDENTITY` is the single logical identity that threads the whole system — the actor-token `sub`, the broker agent identity, and the authorization subject.
@@ -172,19 +233,58 @@ You do not need to hand-write a values file or run manual Keycloak/`kubectl` ste
 When `extProc.oauth2.clientCredentialsEndpoint` is unset, the sidecar derives its token endpoint as `issuer + /oauth/token`, which is the mock-upstream path and returns `404` against Keycloak (whose path is `/protocol/openid-connect/token`). The stock AIB chart does not template this env var yet, so the CLI applies it as a post-install patch on the sidecar Deployment:
 
 ```bash
-kubectl -n aib-system set env deploy/aib-agentic-identity-broker-extproc \
+kubectl -n "$AIB_NS" set env deploy/aib-agentic-identity-broker-extproc \
   EXTPROC_OAUTH2_CLIENT_CREDENTIALS_ENDPOINT=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/token
 ```
 
 The CLI runs this automatically. It is shown here for transparency and to reapply manually if you redeploy the sidecar. Once the endpoint is templated upstream (followup F0), this patch is dropped and the value comes from the chart.
 :::
 
-### Verify the exchange reaches the broker
+### Register the demo agent and third-party service
 
-Register an agent whose `client_id` matches the user token's `azp` (`kaos`), plus a third-party service, then run the exchange from inside the cluster (so the token `iss` matches the broker's configured upstream issuer):
+The exchange resolves the agent from the user token's `azp` (`resolveAgentIdByClientId`), so a broker agent whose `client_id` equals the user client (`kaos`) must exist, along with a third-party service to exchange for. The operator projects one broker agent per KAOS Agent (each with its own synthetic `client_id`), so for this demo register the `kaos`-client agent and a demo service directly against the broker admin API:
 
 ```bash
-kubectl -n aib-system run tx --rm -i --restart=Never --image=curlimages/curl -- sh -c '
+kubectl port-forward -n "$AIB_NS" svc/aib-agentic-identity-broker 14000:14000 >/dev/null 2>&1 &
+sleep 2
+ADMIN=http://localhost:14000/api
+
+# 1. Third-party service exposing the protected resource
+SERVICE_ID=$(curl -s -X POST $ADMIN/services -H 'Content-Type: application/json' -d '{
+  "display_name": "Demo API",
+  "client_id": "demo-thirdparty",
+  "client_secret": "demo-thirdparty-secret",
+  "issuer_uri": "http://demo-idp.local",
+  "discovery": {"enable_discovery": false},
+  "endpoints": {"token_endpoint": "http://demo-idp.local/token", "authorize_endpoint": "http://demo-idp.local/authorize"},
+  "scopes": [{"scope_value": "read", "description": "Read"}],
+  "protected_resources": ["https://api.demo.local"]
+}' | jq -r .id)
+
+# 2. Permission set granting read on that service
+PSET_ID=$(curl -s -X POST $ADMIN/permission-sets -H 'Content-Type: application/json' -d "{
+  \"name\": \"demo-read\",
+  \"description\": \"Demo read\",
+  \"service_scopes\": [{\"service_id\": \"$SERVICE_ID\", \"scopes\": [\"read\"], \"requirement_type\": \"mandatory\"}]
+}" | jq -r .id)
+
+# 3. Agent whose client_id matches the user token azp (kaos)
+curl -s -X POST $ADMIN/agents -H 'Content-Type: application/json' -d "{
+  \"client_id\": \"$USER_CLIENT_ID\",
+  \"display_name\": \"KAOS Agent\",
+  \"description\": \"KAOS agent for token exchange validation\",
+  \"permission_sets\": [{\"permission_set_id\": \"$PSET_ID\", \"requirement_type\": \"mandatory\"}]
+}" | jq -r .id
+
+echo "service=$SERVICE_ID pset=$PSET_ID"
+```
+
+### Verify the exchange reaches the broker
+
+Run the exchange from inside the cluster (so the token `iss` matches the broker's configured upstream issuer). The credentials below are the preset defaults from [Reproducible variables](#reproducible-variables):
+
+```bash
+kubectl -n "$AIB_NS" run tx --rm -i --restart=Never --image=curlimages/curl -- sh -c '
 KC=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/token
 BROKER=http://aib-agentic-identity-broker.aib-system.svc.cluster.local:8000/oauth2/token
 SUBJ=$(curl -s -X POST $KC -d grant_type=password -d client_id=kaos -d client_secret=kaos-dev-secret -d username=kaos-user -d password=kaos-password | sed -n "s/.*\"access_token\":\"\([^\"]*\)\".*/\1/p")
@@ -215,7 +315,7 @@ Returning an actual third-party token requires a **user consent grant** for a se
 ## Clean up
 
 ```bash
-kubectl delete namespace kaos-walkthrough
+kubectl delete namespace "$APP_NS"
 ```
 
 ## Where to go next

--- a/docs/security/walkthrough-aib.md
+++ b/docs/security/walkthrough-aib.md
@@ -22,7 +22,7 @@ The seam is deliberate: KAOS owns agent identity and topology, Keycloak owns use
 - A Kubernetes cluster with Gateway API and a LoadBalancer (a local KIND cluster with `--gateway-enabled --metallb-enabled` is fine).
 - The `kaos` CLI installed (`pip install kaos-cli`).
 - `kubectl` pointed at the cluster.
-- The AIB broker Helm chart and a values file available locally (the chart ships a dev preset — see the note on token exchange below).
+- The AIB broker Helm chart available locally (it is unpublished, so a chart path is required). The `aib-keycloak` preset auto-wires the broker values for token exchange — no hand-written values file is needed.
 - On KIND, the operator, agent, and broker images loaded into the cluster (`kind load docker-image ...`).
 
 ::: tip NetworkPolicy enforcement
@@ -31,7 +31,7 @@ As with `kaos-internal`, the generated `NetworkPolicy` objects are only *enforce
 
 ## Step 1 — Install with the `aib-keycloak` preset
 
-Install KAOS with the default `aib-keycloak` preset, pointing at the broker chart and values. The CLI installs the operator, the AIB broker (into `aib-system`), and Keycloak (into `keycloak`, bootstrapping the `kaos` realm):
+Install KAOS with the default `aib-keycloak` preset, pointing at the broker chart. The CLI installs the operator, the AIB broker (into `aib-system`), and Keycloak (into `keycloak`, bootstrapping the `kaos` realm). The preset auto-wires the broker into hybrid mode against Keycloak and enables the token-exchange sidecar — see [Token exchange](#token-exchange-rfc-8693) below:
 
 ```bash
 kaos system install \
@@ -39,7 +39,6 @@ kaos system install \
   --auth-enabled aib-keycloak \
   --gateway-enabled --metallb-enabled \
   --aib-chart-path <path-to>/charts/agentic-identity-broker \
-  --aib-values <path-to>/charts/agentic-identity-broker/values-dev.yaml \
   --wait
 ```
 
@@ -161,56 +160,23 @@ The exchange involves two Keycloak-issued JWTs, both signature-verified by the b
 
 The broker therefore runs in **hybrid** OAuth2 mode with Keycloak configured as the upstream issuer. Crucially, the sidecar authenticates against **Keycloak**, and the broker validates both tokens against Keycloak's JWKS — the broker never issues these tokens itself in this posture.
 
-### Broker `--aib-values` for hybrid mode against Keycloak
+### What the `aib-keycloak` preset wires automatically
 
-The stock `values-dev.yaml` runs the broker in `local` mode, which mints tokens in-memory and rejects the `client_credentials` grant the sidecar needs. Supply a hybrid values file instead (adjust the Keycloak namespace/realm and keys for your install):
+You do not need to hand-write a values file or run manual Keycloak/`kubectl` steps — the `aib-keycloak` preset provisions the entire hybrid posture:
 
-```yaml
-storage:
-  type: memory
-broker:
-  oauth2AuthorizationServer:
-    mode: hybrid
-    proxy:
-      upstreamIssuerUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos
-      upstreamAuthorizeEndpoint: http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/auth
-      upstreamTokenEndpoint: http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/token
-    supportedGrantTypes:
-      - authorization_code
-      - refresh_token
-      - urn:ietf:params:oauth:grant-type:token-exchange
-  tokenExchange:
-    expectedAudience: token-exchange-broker
-    claimExtraction:
-      principalExpression: "subject_token.sub"
-      agentIdExpression: "resolveAgentIdByClientId(subject_token.azp)"
-    authorization:
-      type: cel
-      cel:
-        expression: "true"
-        evaluationTimeout: "5s"
-  security:
-    skipThirdpartyHttpsValidation: true
-extProc:
-  enabled: true
-  oauth2:
-    tokenEndpoint: http://aib-agentic-identity-broker.aib-system.svc.cluster.local:8000/oauth2/token
-    issuer: http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos
-    clientId: extproc-gateway
-    clientSecret: extproc-gateway-secret
-    clientAssertionType: access_token
-    allowHttp: true
-```
+- **Broker (hybrid mode):** sets `broker.oauth2AuthorizationServer.mode=hybrid` with Keycloak's authorize/token endpoints as the upstream, enables the `urn:ietf:params:oauth:grant-type:token-exchange` grant, and sets `tokenExchange.expectedAudience=token-exchange-broker`.
+- **ExtProc sidecar:** enables `extProc`, points its OAuth `issuer` at the Keycloak realm and its `tokenEndpoint` at the broker's exchange endpoint, and enables `allowHttp` for the in-cluster plain-http endpoints.
+- **Keycloak realm:** registers the `extproc-gateway` service-account client (secret `extproc-gateway-secret`) and adds a `token-exchange-broker` custom-audience mapper to **both** the user client (`kaos`) and the `extproc-gateway` client, so the `subject_token` and `client_assertion` both carry the audience the broker enforces.
 
-The broker validates that both the `subject_token` and `client_assertion` carry `aud: token-exchange-broker`. Add a custom-audience mapper to the user client (`kaos`) and create the `extproc-gateway` service-account client (with the same audience mapper) in Keycloak so both tokens carry that audience.
-
-::: warning ExtProc client-credentials endpoint against Keycloak
-When `extProc.oauth2.clientCredentialsEndpoint` is unset, the sidecar derives its token endpoint as `issuer + /oauth/token`, which is the mock-upstream path and returns `404` against Keycloak (whose path is `/protocol/openid-connect/token`). The stock chart does not template this env var, so set it directly on the sidecar Deployment:
+::: warning Temporary ExtProc client-credentials patch (followup F0)
+When `extProc.oauth2.clientCredentialsEndpoint` is unset, the sidecar derives its token endpoint as `issuer + /oauth/token`, which is the mock-upstream path and returns `404` against Keycloak (whose path is `/protocol/openid-connect/token`). The stock AIB chart does not template this env var yet, so the CLI applies it as a post-install patch on the sidecar Deployment:
 
 ```bash
 kubectl -n aib-system set env deploy/aib-agentic-identity-broker-extproc \
   EXTPROC_OAUTH2_CLIENT_CREDENTIALS_ENDPOINT=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos/protocol/openid-connect/token
 ```
+
+The CLI runs this automatically. It is shown here for transparency and to reapply manually if you redeploy the sidecar. Once the endpoint is templated upstream (followup F0), this patch is dropped and the value comes from the chart.
 :::
 
 ### Verify the exchange reaches the broker

--- a/docs/security/walkthrough-aib.md
+++ b/docs/security/walkthrough-aib.md
@@ -1,0 +1,176 @@
+# End-to-end walkthrough: `aib-keycloak` preset
+
+This walkthrough stands up KAOS with the broker-backed `aib-keycloak` security posture — the default, production-shaped posture — and verifies, step by step, that user identity, agent identity, authorization, and gateway-only routing take effect. Every step lists what it proves, and each check can be run from the command line or observed in the KAOS UI.
+
+Unlike the self-contained [`kaos-internal` walkthrough](./walkthrough-kaos), this posture wires KAOS to two external identity components:
+
+- **Keycloak** as the OpenID Connect provider for **user** identity.
+- The **Agentic Identity Broker (AIB)** as the issuer of signature-verified **agent** credentials and the enforcement engine (OPA embedded in an Envoy `ext_proc` sidecar).
+
+The seam is deliberate: KAOS owns agent identity and topology, Keycloak owns user identity, and AIB owns authorization. A user's request carries a Keycloak-issued subject token; the calling agent carries a broker-issued actor token; the gateway `ext_proc` hook evaluates both against the agent's granted permission sets.
+
+## What you will verify
+
+1. The `aib-keycloak` preset expands into the operator's `aib` authorization provider with signature-verified agent tokens.
+2. Keycloak is installed and bootstrapped with the `kaos` realm for user identity.
+3. The AIB broker is installed and the operator registers agents and mints per-agent broker credentials.
+4. Each agent reaches other resources **through the gateway**, and its identity is a broker-verified JWT.
+5. `SecurityPolicy` (wiring `ext_proc`) and `NetworkPolicy` (bypass prevention) objects are generated.
+
+## Prerequisites
+
+- A Kubernetes cluster with Gateway API and a LoadBalancer (a local KIND cluster with `--gateway-enabled --metallb-enabled` is fine).
+- The `kaos` CLI installed (`pip install kaos-cli`).
+- `kubectl` pointed at the cluster.
+- The AIB broker Helm chart and a values file available locally (the chart ships a dev preset — see the note on token exchange below).
+- On KIND, the operator, agent, and broker images loaded into the cluster (`kind load docker-image ...`).
+
+::: tip NetworkPolicy enforcement
+As with `kaos-internal`, the generated `NetworkPolicy` objects are only *enforced* by a NetworkPolicy-capable CNI (for example Calico). The default KIND CNI (kindnet) creates them without enforcing them, which is fine for exploring authorization and routing.
+:::
+
+## Step 1 — Install with the `aib-keycloak` preset
+
+Install KAOS with the default `aib-keycloak` preset, pointing at the broker chart and values. The CLI installs the operator, the AIB broker (into `aib-system`), and Keycloak (into `keycloak`, bootstrapping the `kaos` realm):
+
+```bash
+kaos system install \
+  --namespace kaos-system \
+  --auth-enabled aib-keycloak \
+  --gateway-enabled --metallb-enabled \
+  --aib-chart-path <path-to>/charts/agentic-identity-broker \
+  --aib-values <path-to>/charts/agentic-identity-broker/values-dev.yaml \
+  --wait
+```
+
+The three presets differ only in the identity and verification layers:
+
+| Preset | User identity | Agent token | Authorization provider |
+|--------|---------------|-------------|------------------------|
+| `kaos-internal` | none | header-trusted (spoofable, demo only) | `kaos` (grants projected from CRDs) |
+| `aib-only` | none | broker-issued, signature-verified | `aib` (broker permission sets) |
+| `aib-keycloak` (default) | Keycloak + token exchange | broker-issued, signature-verified | `aib` (broker permission sets) |
+
+**Proves:** a single preset provisions the full broker-backed posture instead of a large set of auth flags.
+
+### Verify the operator picked up the configuration
+
+```bash
+kubectl get configmap kaos-operator-config -n kaos-system -o json \
+  | jq -r '.data | to_entries[] | select(.key | test("SECURITY|AUTHZ|GATEWAY")) | "\(.key)=\(.value)"'
+```
+
+Expected keys for `aib-keycloak`:
+
+```
+SECURITY_AUTHORIZATION_PROVIDER=aib
+SECURITY_AUTHORIZATION_AGENT_JWT_VERIFICATION=verified
+SECURITY_AUTHORIZATION_GATEWAY_EXTENSION=ext_proc
+SECURITY_AGENT_AUTH_ISSUER=http://aib-agentic-identity-broker.aib-system.svc.cluster.local:8000
+SECURITY_AGENT_AUTH_EXT_PROC_URL=aib-agentic-identity-broker-extproc.aib-system.svc.cluster.local:50051
+SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX=kaos-aib
+SECURITY_USER_AUTH_ISSUER=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos
+SECURITY_USER_AUTH_AUDIENCE=kaos
+SECURITY_GATEWAY_ROUTING_ENABLED=true
+```
+
+**Proves:** the preset baked in the `aib` provider, signature-verified agent tokens, the broker issuer/`ext_proc` endpoints, and the Keycloak user-auth issuer — no extra flags were needed.
+
+## Step 2 — Confirm the identity components are running
+
+```bash
+kubectl get pods -n aib-system      # AIB broker (+ ext_proc sidecar)
+kubectl get pods -n keycloak        # Keycloak
+kubectl get pods -n kaos-system     # operator
+```
+
+Confirm the Keycloak realm was bootstrapped:
+
+```bash
+kubectl logs -n keycloak deploy/keycloak | grep -i "realm 'kaos'"
+```
+
+**Proves:** the broker (agent identity + authorization) and Keycloak (user identity) are both live and the `kaos` realm exists.
+
+## Step 3 — Deploy resources and confirm broker credential minting
+
+Deploy a small topology, then confirm the operator registered each agent with the broker and minted a per-agent credential Secret:
+
+```bash
+kubectl create namespace kaos-walkthrough
+kubectl apply -n kaos-walkthrough -f \
+  https://raw.githubusercontent.com/axsaucedo/kaos/main/operator/config/samples/2-multi-agent-mcp.yaml
+```
+
+Unlike `kaos-internal` (where the agent token is header-trusted), each agent here is issued a real broker credential. Inspect the minted Secret:
+
+```bash
+kubectl get secret -n kaos-walkthrough -l kaos.tools/managed-by=kaos \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+kubectl get secret kaos-aib-coordinator -n kaos-walkthrough \
+  -o jsonpath='{.data.AGENT_AUTH_CLIENT_ID}' | base64 -d; echo
+```
+
+The `AGENT_AUTH_CLIENT_ID` / `AGENT_AUTH_CLIENT_SECRET` are populated (broker-issued), not empty. The agent runtime uses them to mint a signed actor-token JWT via OAuth2 `client_credentials` against the broker.
+
+**Proves:** agent identity is broker-backed and cryptographically real, not self-asserted.
+
+## Step 4 — Mint a user token from Keycloak
+
+User identity flows from Keycloak. Port-forward Keycloak and request a subject token with the OIDC password grant:
+
+```bash
+kubectl port-forward -n keycloak svc/keycloak 8080:8080 &
+curl -s -X POST http://localhost:8080/realms/kaos/protocol/openid-connect/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password&client_id=kaos&username=<realm-user>&password=<password>" \
+  | jq -r .access_token
+```
+
+This subject token is what a user presents to KAOS. At the gateway it is validated by the `jwt_authn` provider against the Keycloak JWKS before any authorization runs.
+
+**Proves:** user identity is issued and verified against Keycloak, on the same trust root as the rest of the posture.
+
+## Step 5 — Confirm gateway-routed identity and enforcement objects
+
+As with `kaos-internal`, agents reach other resources through the gateway, and the operator generates the enforcement objects:
+
+```bash
+kubectl get deploy agent-coordinator -n kaos-walkthrough -o json \
+  | jq -r '.spec.template.spec.containers[0].env[]
+      | select(.name | test("URL|AGENT_AUTH_IDENTITY"))
+      | "\(.name)=\(.value)"'
+
+kubectl get securitypolicy,networkpolicy -n kaos-walkthrough
+```
+
+Every outbound URL routes through the gateway path (the `ext_proc` enforcement point cannot be bypassed), and `AGENT_AUTH_IDENTITY` is the single logical identity that threads the whole system — the actor-token `sub`, the broker agent identity, and the authorization subject.
+
+**Proves:** internal calls are gateway-routed and the `ext_proc` authorization hook plus bypass-prevention NetworkPolicies are in place.
+
+## Token exchange (RFC 8693) and current status
+
+The `aib-keycloak` posture is designed to run the RFC 8693 **token-exchange** path in the broker's `ext_proc` sidecar: for a user-present request, the sidecar exchanges the user subject token for the agent's `granted_permission_sets` (and, for third-party APIs, a vaulted upstream OAuth token) before the OPA policy decides allow/deny.
+
+::: warning Token-exchange sidecar prerequisites
+The `ext_proc` token-exchange sidecar performs an OAuth2 `client_credentials` grant against the broker **at startup** to mint its own client assertion. This requires:
+
+1. The broker running in **federated** or **hybrid** OAuth2 mode. The chart's `values-dev.yaml` dev preset runs in `local` mode, which mints enduser tokens in-memory and **does not accept the `client_credentials` grant** — so the token-exchange sidecar cannot bootstrap against the dev preset.
+2. A bootstrapped OAuth client for the sidecar: an agent registered with the broker admin API, a credential minted via `POST /api/agents/{agent-id}/client-credentials`, and the sidecar configured with the agent's **UUID** as its `client_id` (the broker resolves opaque `client_id` values as agent UUIDs, not display names) plus the minted secret.
+
+Automating this bootstrap end-to-end (federated broker mode wired to Keycloak, plus sidecar credential provisioning) is the remaining work for a fully self-serve token-exchange install. Until then, deploy the broker in `local` mode for identity + agent-credential minting and provision the token-exchange sidecar's OAuth client out of band, or run the broker in federated mode against Keycloak.
+:::
+
+**Proves / documents:** the intended enforcement flow and the exact bootstrap prerequisites the token-exchange sidecar needs — captured so the posture can be completed without rediscovering them.
+
+## Clean up
+
+```bash
+kubectl delete namespace kaos-walkthrough
+```
+
+## Where to go next
+
+- [`kaos-internal` walkthrough](./walkthrough-kaos) — the self-contained posture with no external IdP or broker.
+- [Security Overview](/security/overview) — the layered model and install postures.
+- [Authorization](/security/authorization) — providers, modes, verification, and the policy-data schema.

--- a/docs/security/walkthrough-aib.md
+++ b/docs/security/walkthrough-aib.md
@@ -64,7 +64,7 @@ export BROKER_TOKEN_URL=http://aib-agentic-identity-broker.${AIB_NS}.svc.cluster
 The realm, user, client, secret, and audience are baked into the CLI as the `aib-keycloak` preset defaults. You can confirm them at any time from the seeded realm-import ConfigMap:
 
 ```bash
-kubectl get configmap aib-agentic-identity-broker-realm-import -n "$KC_NS" \
+kubectl get configmap keycloak-realm-import -n "$KC_NS" \
   -o jsonpath='{.data}' | python3 -m json.tool | grep -iE 'username|value|clientId|secret'
 ```
 :::

--- a/docs/security/walkthrough-kaos.md
+++ b/docs/security/walkthrough-kaos.md
@@ -1,8 +1,8 @@
-# End-to-end security walkthrough
+# End-to-end walkthrough: `kaos-internal` preset
 
-This walkthrough stands up KAOS with a full security posture and then verifies, step by step, that agent identity, authorization, and gateway-only routing actually take effect. Every step lists what it proves, and each check can be run from the command line or observed in the KAOS UI.
+This walkthrough stands up KAOS with the self-contained `kaos-internal` security posture and then verifies, step by step, that agent identity, authorization, and gateway-only routing actually take effect. Every step lists what it proves, and each check can be run from the command line or observed in the KAOS UI.
 
-It uses the self-contained `kaos-internal` preset so the whole flow runs on a local KIND cluster with no external identity provider or broker. The same steps apply to the `aib-only` and `aib-keycloak` postures; the differences are called out where they matter.
+The `kaos-internal` preset runs the whole flow on a local KIND cluster with **no external identity provider or broker** — the operator itself is the authorization source of truth. For the broker-backed posture with Keycloak user identity and AIB agent credentials, see the [`aib-keycloak` walkthrough](./walkthrough-aib).
 
 ## What you will verify
 

--- a/docs/security/walkthrough.md
+++ b/docs/security/walkthrough.md
@@ -1,0 +1,216 @@
+# End-to-end security walkthrough
+
+This walkthrough stands up KAOS with a full security posture and then verifies, step by step, that agent identity, authorization, and gateway-only routing actually take effect. Every step lists what it proves, and each check can be run from the command line or observed in the KAOS UI.
+
+It uses the self-contained `kaos-internal` preset so the whole flow runs on a local KIND cluster with no external identity provider or broker. The same steps apply to the `aib-only` and `aib-keycloak` postures; the differences are called out where they matter.
+
+## What you will verify
+
+1. The install preset expands into the operator's authorization and routing configuration.
+2. The operator projects a policy ConfigMap (`policy.rego` + `data.json`) whose grant graph is derived from your CRDs.
+3. Each agent is wired to reach other resources **through the gateway**, and its identity matches the grant graph.
+4. `SecurityPolicy` and `NetworkPolicy` objects are generated to keep the gateway on the request path.
+5. The projected grants stay stable across reconciles.
+
+## Prerequisites
+
+- A Kubernetes cluster. A local KIND cluster is fine for `kaos-internal`.
+- The `kaos` CLI installed (`pip install kaos-cli`).
+- `kubectl` pointed at the cluster.
+
+::: tip NetworkPolicy enforcement
+The generated `NetworkPolicy` objects are always created, but they are only *enforced* by a CNI that implements NetworkPolicy (for example Calico). The default KIND CNI (kindnet) creates them without enforcing them, which is fine for exploring authorization and routing. Use Calico when you need the isolation to actually block traffic.
+:::
+
+## Step 1 — Install with a security preset
+
+Install KAOS with the `kaos-internal` preset. It enables OPA-in-`ext_proc` authorization with the KAOS-owned policy provider, routes internal traffic through the gateway, and generates bypass-prevention NetworkPolicies — all without an external IdP or broker.
+
+```bash
+kaos system install \
+  --namespace kaos-system \
+  --auth-enabled kaos-internal \
+  --gateway-enabled \
+  --metallb-enabled \
+  --wait
+```
+
+The three presets differ only in the identity and verification layers:
+
+| Preset | User identity | Agent token | Authorization provider |
+|--------|---------------|-------------|------------------------|
+| `kaos-internal` | none | header-trusted (spoofable, demo only) | `kaos` (grants projected from CRDs) |
+| `aib-only` | none | broker-issued, signature-verified | `aib` (broker permission sets) |
+| `aib-keycloak` (default) | Keycloak + token exchange | broker-issued, signature-verified | `aib` (broker permission sets) |
+
+**Proves:** the install command accepts a single preset instead of a large set of auth flags.
+
+### Verify the operator picked up the configuration
+
+The preset is expanded into operator configuration, delivered through the `kaos-operator-config` ConfigMap:
+
+```bash
+kubectl get configmap kaos-operator-config -n kaos-system -o json \
+  | jq -r '.data | to_entries[] | select(.key | test("SECURITY|AUTHZ|GATEWAY")) | "\(.key)=\(.value)"'
+```
+
+Expected keys for `kaos-internal`:
+
+```
+SECURITY_AUTHORIZATION_PROVIDER=kaos
+SECURITY_AUTHORIZATION_AGENT_JWT_VERIFICATION=skip
+SECURITY_AUTHORIZATION_POLICY_DATA_SOURCE=automated
+SECURITY_GATEWAY_ROUTING_ENABLED=true
+AUTHZ_POLICY_CONFIGMAP_NAME=kaos-authz-policy
+AUTHZ_POLICY_CONFIGMAP_NAMESPACE=kaos-system
+```
+
+**Proves:** the preset baked in the KAOS authorization provider, the demo (header-trusted) verification mode, and the policy ConfigMap projection target — no extra flags were needed.
+
+## Step 2 — Deploy resources to authorize
+
+Authorization data is derived from your resources, so deploy a small topology: a model API, an MCP tool server, a coordinator agent, and two worker agents the coordinator delegates to.
+
+```bash
+kubectl create namespace kaos-walkthrough
+kubectl apply -n kaos-walkthrough -f \
+  https://raw.githubusercontent.com/axsaucedo/kaos/main/operator/config/samples/2-multi-agent-mcp.yaml
+```
+
+Wait for the workloads to come up:
+
+```bash
+kubectl get agents,mcpservers,modelapis -n kaos-walkthrough
+kubectl get deploy -n kaos-walkthrough
+```
+
+**Proves:** the operator reconciles the CRDs into running workloads under the security posture.
+
+::: tip In the UI
+Run `kaos ui` and open the namespace. The coordinator, the two workers, the MCP server, and the model API appear as connected resources, showing the delegation and tool topology the grant graph is derived from.
+:::
+
+## Step 3 — Inspect the projected policy
+
+Once resources exist, the operator projects the policy ConfigMap the enforcement engine reads:
+
+```bash
+kubectl get configmap kaos-authz-policy -n kaos-system \
+  -o jsonpath='{.data.data\.json}' | jq
+```
+
+Expected grant graph (derived from the sample topology — the coordinator may reach the workers, the MCP server, and the model API; each worker may reach the MCP server and the model API):
+
+```json
+{
+  "kaos": {
+    "grants": {
+      "kaos://agent/kaos-walkthrough/coordinator": [
+        "kaos://agent/kaos-walkthrough/worker-1",
+        "kaos://agent/kaos-walkthrough/worker-2",
+        "kaos://mcpserver/kaos-walkthrough/multi-echo-mcp",
+        "kaos://modelapi/kaos-walkthrough/multi-modelapi"
+      ],
+      "kaos://agent/kaos-walkthrough/worker-1": [
+        "kaos://mcpserver/kaos-walkthrough/multi-echo-mcp",
+        "kaos://modelapi/kaos-walkthrough/multi-modelapi"
+      ],
+      "kaos://agent/kaos-walkthrough/worker-2": [
+        "kaos://mcpserver/kaos-walkthrough/multi-echo-mcp",
+        "kaos://modelapi/kaos-walkthrough/multi-modelapi"
+      ]
+    }
+  }
+}
+```
+
+The ConfigMap also carries a `policy.rego` key — the static policy that decides `allow`/`deny` by looking up the actor identity in `data.kaos.grants` and matching the target resource. The rego is fixed; only the data changes as resources come and go. See the [Policy data schema](/security/authorization#policy-data-schema) for the published contract.
+
+**Proves:** authorization data is projected automatically from the CRD topology, with no hand-authored policy.
+
+## Step 4 — Confirm gateway-routed identity
+
+Inspect a coordinator pod's environment to see how it reaches other resources and how it identifies itself:
+
+```bash
+kubectl get deploy agent-coordinator -n kaos-walkthrough -o json \
+  | jq -r '.spec.template.spec.containers[0].env[]
+      | select(.name | test("URL|AGENT_AUTH_IDENTITY"))
+      | "\(.name)=\(.value)"'
+```
+
+Expected (addresses point at the gateway, not the target Service directly):
+
+```
+MODEL_API_URL=http://<gateway-ip>/kaos-walkthrough/modelapi/multi-modelapi
+MCP_SERVER_multi-echo-mcp_URL=http://<gateway-ip>/kaos-walkthrough/mcp/multi-echo-mcp
+PEER_AGENT_WORKER_1_CARD_URL=http://<gateway-ip>/kaos-walkthrough/agent/worker-1
+AGENT_AUTH_IDENTITY=kaos://agent/kaos-walkthrough/coordinator
+```
+
+Two things line up here: every outbound URL routes through the gateway path (so the enforcement point cannot be bypassed), and `AGENT_AUTH_IDENTITY` matches the grant graph key from Step 3 exactly. That single logical identity threads the whole system — it is the actor token `sub`, the OPA data key, and the resource identity.
+
+**Proves:** internal calls are routed through the gateway and the agent's identity is the same key authorization decisions are made against.
+
+## Step 5 — Confirm the enforcement objects
+
+The operator generates the gateway and isolation objects that keep the gateway on the path:
+
+```bash
+kubectl get securitypolicy,networkpolicy -n kaos-walkthrough
+```
+
+Each MCP server, model API, and agent gets a `SecurityPolicy` (wiring the `ext_proc` authorization hook) and a `NetworkPolicy` (denying direct workload-to-workload traffic so requests must traverse the gateway).
+
+**Proves:** the bypass-prevention layer is generated alongside the workloads.
+
+## Step 6 — Confirm grant stability
+
+Grants should only change when the topology changes, not on every reconcile. Capture the data, force a reconcile, and compare:
+
+```bash
+before=$(kubectl get configmap kaos-authz-policy -n kaos-system -o jsonpath='{.data.data\.json}' | shasum)
+kubectl annotate agent coordinator -n kaos-walkthrough kaos.tools/rev="$(date +%s)" --overwrite
+sleep 8
+after=$(kubectl get configmap kaos-authz-policy -n kaos-system -o jsonpath='{.data.data\.json}' | shasum)
+[ "$before" = "$after" ] && echo "grants stable" || echo "grants changed"
+```
+
+Now change the topology and watch the grants follow it — delete a worker and confirm its grants disappear:
+
+```bash
+kubectl delete agent worker-2 -n kaos-walkthrough
+sleep 8
+kubectl get configmap kaos-authz-policy -n kaos-system -o jsonpath='{.data.data\.json}' | jq '.kaos.grants | keys'
+```
+
+The `kaos://agent/kaos-walkthrough/worker-2` key is gone, and it is removed from the coordinator's grants.
+
+**Proves:** projection is idempotent across reconciles and tracks the live topology.
+
+## Verification modes and production posture
+
+`kaos-internal` runs in **demo mode**: the agent token is header-trusted and therefore spoofable. It exists to explore route- and agent-level authorization without an identity provider and must never be used in production.
+
+For a real posture, use `aib-only` or `aib-keycloak`, where the agent token is a broker-issued, signature-verified JWT and the policy verifies its signature, issuer, and expiry against the IdP JWKS before trusting the actor identity. See [Verification modes](/security/authorization#verification-modes).
+
+## Strict gateway-only traffic
+
+Gateway-only isolation can also be enabled independently of authorization as a defence-in-depth posture:
+
+```bash
+kaos system install --gateway-enabled --gateway-api-strict
+```
+
+This turns on the NetworkPolicy isolation and gateway routing without requiring any auth layer. As noted above, isolation is only enforced by a NetworkPolicy-capable CNI. See [Gateway API](/operator/gateway-api#strict-gateway-only-traffic).
+
+## Clean up
+
+```bash
+kubectl delete namespace kaos-walkthrough
+```
+
+## Where to go next
+
+- [Security Overview](/security/overview) — the layered model and install postures.
+- [Authorization](/security/authorization) — providers, modes, verification, and the policy-data schema.

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -37,10 +37,16 @@ DEFAULT_THIRD_PARTY_SERVICE_ID = "dummy-third-party"
 
 # Full-auth presets: curated end-to-end security postures selected with the
 # single --full-auth-enabled flag, replacing the fine-grained auth knobs.
-FULL_AUTH_KEYCLOAK_AIB = "keycloak-aib-enabled"
-FULL_AUTH_KAOS_DEMO = "kaos-internal-demo"
-FULL_AUTH_PRESETS = (FULL_AUTH_KEYCLOAK_AIB, FULL_AUTH_KAOS_DEMO)
-DEFAULT_FULL_AUTH_PRESET = FULL_AUTH_KEYCLOAK_AIB
+AUTH_PRESET_AIB_KEYCLOAK = "aib-keycloak"
+AUTH_PRESET_KAOS_INTERNAL = "kaos-internal"
+AUTH_PRESET_AIB_ONLY = "aib-only"
+AUTH_PRESETS = (
+    AUTH_PRESET_AIB_KEYCLOAK,
+    AUTH_PRESET_KAOS_INTERNAL,
+    AUTH_PRESET_AIB_ONLY,
+)
+DEFAULT_AUTH_PRESET = AUTH_PRESET_AIB_KEYCLOAK
+DEFAULT_POLICY_CONFIGMAP_NAME = "kaos-authz-policy"
 
 # User-auth (human identity provider, Keycloak by default) defaults
 DEFAULT_KEYCLOAK_NAMESPACE = "keycloak"
@@ -1122,25 +1128,31 @@ def _get_otel_endpoint(backend: str, namespace: str) -> str:
     return f"http://signoz-otel-collector.{namespace}:4317"
 
 
-def _expand_full_auth_preset(preset: str) -> dict:
-    """Expand a --full-auth-enabled preset into install_command auth kwargs.
+def _expand_auth_preset(preset: str, namespace: str) -> dict:
+    """Expand an --auth-enabled preset into install_command auth kwargs.
 
-    The two presets collapse the fine-grained auth knobs into curated postures:
+    Three presets are the whole security surface; each names a real deployment
+    posture and bakes in the curated defaults so no fine-grained flags are
+    needed:
 
-    - keycloak-aib-enabled: the full verified path. Keycloak provides human user
-      identity, the identity broker provides agent identity and RFC 8693 token
-      exchange, and authorization is enforced by OPA in the gateway ext_proc
-      using broker permission sets, with the agent (actor) JWT signature
-      verified against the IdP JWKS.
-    - kaos-internal-demo: a self-contained demo needing no external IdP or
-      broker. KAOS projects authorization policy data into a ConfigMap enforced
-      by OPA in ext_proc, with the agent JWT header-trusted (non-production).
+    - aib-keycloak (default): the full verified path. Keycloak provides human
+      user identity, the identity broker provides agent identity and RFC 8693
+      token exchange, and authorization is enforced by OPA in the gateway
+      ext_proc using broker permission sets, with the agent (actor) JWT
+      signature verified against the IdP JWKS.
+    - kaos-internal: a self-contained demo needing no external IdP or broker.
+      KAOS projects authorization policy data into a ConfigMap enforced by OPA
+      in ext_proc, with the agent JWT header-trusted (non-production). The
+      policy ConfigMap name/namespace are baked in.
+    - aib-only: agent identity via the broker with no human-user layer and no
+      token exchange -- autonomous/agent-only deployments that still get real
+      broker-minted agent credentials and permission-set projection.
 
-    Both presets route internal agent->ModelAPI/MCP/peer traffic through the
+    All presets route internal agent->ModelAPI/MCP/peer traffic through the
     gateway and generate bypass-prevention NetworkPolicies so the enforcement
     point cannot be sidestepped.
     """
-    if preset == FULL_AUTH_KEYCLOAK_AIB:
+    if preset == AUTH_PRESET_AIB_KEYCLOAK:
         return {
             "auth_enabled": True,
             "user_auth": True,
@@ -1152,7 +1164,7 @@ def _expand_full_auth_preset(preset: str) -> dict:
             "agent_jwt_verification": "verified",
             "policy_data_source": "automated",
         }
-    if preset == FULL_AUTH_KAOS_DEMO:
+    if preset == AUTH_PRESET_KAOS_INTERNAL:
         return {
             "auth_enabled": True,
             "user_auth": False,
@@ -1163,8 +1175,22 @@ def _expand_full_auth_preset(preset: str) -> dict:
             "authz_gateway_extension": "ext_proc",
             "agent_jwt_verification": "skip",
             "policy_data_source": "automated",
+            "policy_configmap_name": DEFAULT_POLICY_CONFIGMAP_NAME,
+            "policy_configmap_namespace": namespace,
         }
-    raise ValueError(f"unknown full-auth preset: {preset!r}")
+    if preset == AUTH_PRESET_AIB_ONLY:
+        return {
+            "auth_enabled": True,
+            "user_auth": False,
+            "token_exchange": False,
+            "network_policy": True,
+            "gateway_routing": True,
+            "authz_provider": "aib",
+            "authz_gateway_extension": "ext_proc",
+            "agent_jwt_verification": "verified",
+            "policy_data_source": "automated",
+        }
+    raise ValueError(f"unknown auth preset: {preset!r}")
 
 
 def install_command(

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -35,6 +35,13 @@ AUTH_EXT_PROC_CLIENT_ID = "extproc-gateway"
 AUTH_EXT_PROC_CLIENT_SECRET = "extproc-gateway-secret"
 DEFAULT_THIRD_PARTY_SERVICE_ID = "dummy-third-party"
 
+# Full-auth presets: curated end-to-end security postures selected with the
+# single --full-auth-enabled flag, replacing the fine-grained auth knobs.
+FULL_AUTH_KEYCLOAK_AIB = "keycloak-aib-enabled"
+FULL_AUTH_KAOS_DEMO = "kaos-internal-demo"
+FULL_AUTH_PRESETS = (FULL_AUTH_KEYCLOAK_AIB, FULL_AUTH_KAOS_DEMO)
+DEFAULT_FULL_AUTH_PRESET = FULL_AUTH_KEYCLOAK_AIB
+
 # User-auth (human identity provider, Keycloak by default) defaults
 DEFAULT_KEYCLOAK_NAMESPACE = "keycloak"
 DEFAULT_KEYCLOAK_RELEASE = "keycloak"
@@ -1113,6 +1120,51 @@ def _get_otel_endpoint(backend: str, namespace: str) -> str:
     if backend == "jaeger":
         return f"http://jaeger.{namespace}:4317"
     return f"http://signoz-otel-collector.{namespace}:4317"
+
+
+def _expand_full_auth_preset(preset: str) -> dict:
+    """Expand a --full-auth-enabled preset into install_command auth kwargs.
+
+    The two presets collapse the fine-grained auth knobs into curated postures:
+
+    - keycloak-aib-enabled: the full verified path. Keycloak provides human user
+      identity, the identity broker provides agent identity and RFC 8693 token
+      exchange, and authorization is enforced by OPA in the gateway ext_proc
+      using broker permission sets, with the agent (actor) JWT signature
+      verified against the IdP JWKS.
+    - kaos-internal-demo: a self-contained demo needing no external IdP or
+      broker. KAOS projects authorization policy data into a ConfigMap enforced
+      by OPA in ext_proc, with the agent JWT header-trusted (non-production).
+
+    Both presets route internal agent->ModelAPI/MCP/peer traffic through the
+    gateway and generate bypass-prevention NetworkPolicies so the enforcement
+    point cannot be sidestepped.
+    """
+    if preset == FULL_AUTH_KEYCLOAK_AIB:
+        return {
+            "auth_enabled": True,
+            "user_auth": True,
+            "token_exchange": True,
+            "network_policy": True,
+            "gateway_routing": True,
+            "authz_provider": "aib",
+            "authz_gateway_extension": "ext_proc",
+            "agent_jwt_verification": "verified",
+            "policy_data_source": "automated",
+        }
+    if preset == FULL_AUTH_KAOS_DEMO:
+        return {
+            "auth_enabled": True,
+            "user_auth": False,
+            "token_exchange": False,
+            "network_policy": True,
+            "gateway_routing": True,
+            "authz_provider": "kaos",
+            "authz_gateway_extension": "ext_proc",
+            "agent_jwt_verification": "skip",
+            "policy_data_source": "automated",
+        }
+    raise ValueError(f"unknown full-auth preset: {preset!r}")
 
 
 def install_command(

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -33,7 +33,10 @@ AUTH_ADMIN_PORT = 14000
 AUTH_EXT_PROC_PORT = 50051
 AUTH_EXT_PROC_CLIENT_ID = "extproc-gateway"
 AUTH_EXT_PROC_CLIENT_SECRET = "extproc-gateway-secret"
-DEFAULT_THIRD_PARTY_SERVICE_ID = "dummy-third-party"
+# RFC 8693 broker audience the token-exchange path enforces on both the
+# subject_token and the client_assertion (see AIB tokenExchange.expectedAudience).
+AUTH_TOKEN_EXCHANGE_AUDIENCE = "token-exchange-broker"
+
 
 # Full-auth presets: curated end-to-end security postures selected with the
 # single --full-auth-enabled flag, replacing the fine-grained auth knobs.
@@ -756,15 +759,21 @@ def _build_aib_extproc_args(
     ext_proc_client_id: str,
     ext_proc_client_secret: str,
     client_assertion_type: str = "access_token",
+    issuer: str | None = None,
+    token_endpoint: str | None = None,
 ) -> list[str]:
     """Build the broker-chart Helm --set args enabling the ExtProc component.
 
     Returns the flat ``--set key=value`` list so it can be unit-tested without
-    running Helm. The OAuth2 token endpoint and issuer are left to the chart
-    defaults (the in-cluster broker enduser service), which are plain http, so
-    ``allowHttp`` is enabled to let the ExtProc binary accept them at startup.
+    running Helm. All in-cluster endpoints are plain http, so ``allowHttp`` is
+    enabled to let the ExtProc binary accept them at startup.
+
+    ``issuer`` is the OAuth2 authorization server the ExtProc mints its client
+    assertion against (the Keycloak realm in the ``aib-keycloak`` posture, not
+    the broker). ``token_endpoint`` is the broker's RFC 8693 exchange endpoint.
+    When omitted, the chart defaults (the broker enduser service) apply.
     """
-    return [
+    args = [
         "--set",
         "extProc.enabled=true",
         "--set",
@@ -776,74 +785,77 @@ def _build_aib_extproc_args(
         "--set",
         "extProc.oauth2.allowHttp=true",
     ]
+    if issuer:
+        args += ["--set", f"extProc.oauth2.issuer={issuer}"]
+    if token_endpoint:
+        args += ["--set", f"extProc.oauth2.tokenEndpoint={token_endpoint}"]
+    return args
 
 
-def _provision_token_exchange(
-    admin_url: str,
-    ext_proc_client_id: str,
-    third_party_service_id: str,
-    third_party_issuer: str,
-) -> bool:
-    """Register the ExtProc OAuth client and a dummy third-party service.
+def _build_aib_hybrid_broker_args(user_auth_issuer: str) -> list[str]:
+    """Build the broker-chart Helm --set args wiring hybrid mode to Keycloak.
 
-    Best-effort, dev/validation-only provisioning against the broker admin API so
-    that the token-exchange path has an OAuth client to assert as and a
-    third-party service to exchange for. Failures are non-fatal: the install
-    continues and the validation surface can register the grant interactively.
+    In the ``aib-keycloak`` posture the broker validates the RFC 8693
+    ``subject_token`` and ``client_assertion`` against the upstream (Keycloak)
+    JWKS, so it must run in ``hybrid`` mode with Keycloak configured as the
+    upstream issuer and the token-exchange grant enabled. ``user_auth_issuer``
+    is the Keycloak realm URL (e.g. ``http://keycloak...:8080/realms/kaos``).
     """
-    import json
-    import urllib.error
-    import urllib.request
-
-    def _post(path: str, payload: dict) -> bool:
-        data = json.dumps(payload).encode()
-        req = urllib.request.Request(
-            f"{admin_url.rstrip('/')}{path}",
-            data=data,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        try:
-            urllib.request.urlopen(req, timeout=10)  # noqa: S310 (in-cluster URL)
-            return True
-        except urllib.error.HTTPError as exc:
-            # 409/422 (already exists) is acceptable for idempotent provisioning.
-            if exc.code in (409, 422):
-                return True
-            typer.echo(
-                f"Warning: token-exchange provisioning {path} -> HTTP {exc.code}",
-                err=True,
-            )
-            return False
-        except urllib.error.URLError as exc:
-            typer.echo(
-                f"Warning: token-exchange provisioning {path} unreachable: {exc}",
-                err=True,
-            )
-            return False
-
-    ok = _post(
-        "/agents",
-        {
-            "client_id": ext_proc_client_id,
-            "display_name": "ExtProc Gateway",
-            "description": "Gateway token-exchange client (auto-provisioned)",
-        },
+    grant_types = (
+        "{authorization_code,refresh_token,"
+        "urn:ietf:params:oauth:grant-type:token-exchange}"
     )
-    ok = (
-        _post(
-            "/services",
-            {
-                "display_name": "Dummy Third Party",
-                "client_id": "dummy-third-party",
-                "client_secret": "dummy-third-party-secret",
-                "issuer_uri": third_party_issuer,
-                "service_id": third_party_service_id,
-            },
-        )
-        and ok
+    return [
+        "--set",
+        "broker.oauth2AuthorizationServer.mode=hybrid",
+        "--set",
+        f"broker.oauth2AuthorizationServer.proxy.upstreamIssuerUri={user_auth_issuer}",
+        "--set",
+        "broker.oauth2AuthorizationServer.proxy.upstreamAuthorizeEndpoint="
+        f"{user_auth_issuer}/protocol/openid-connect/auth",
+        "--set",
+        "broker.oauth2AuthorizationServer.proxy.upstreamTokenEndpoint="
+        f"{user_auth_issuer}/protocol/openid-connect/token",
+        "--set",
+        f"broker.oauth2AuthorizationServer.supportedGrantTypes={grant_types}",
+        "--set",
+        f"broker.tokenExchange.expectedAudience={AUTH_TOKEN_EXCHANGE_AUDIENCE}",
+    ]
+
+
+def _patch_aib_extproc_client_credentials_endpoint(
+    namespace: str,
+    release: str,
+    token_endpoint: str,
+) -> bool:
+    """Set the ExtProc client-credentials endpoint to the Keycloak token URL.
+
+    The ExtProc binary derives its client-credentials endpoint as
+    ``issuer + "/oauth/token"`` when unset — a mock-upstream path that returns
+    404 against Keycloak (whose path is ``/protocol/openid-connect/token``). The
+    AIB chart does not template ``EXTPROC_OAUTH2_CLIENT_CREDENTIALS_ENDPOINT``,
+    so it is applied here as a post-install patch. This is a temporary bridge
+    until the chart exposes the value (tracked as followup F0).
+    """
+    deployment = f"{_auth_broker_fullname(release)}-extproc"
+    result = _run_kubectl(
+        [
+            "set",
+            "env",
+            f"deployment/{deployment}",
+            "-n",
+            namespace,
+            f"EXTPROC_OAUTH2_CLIENT_CREDENTIALS_ENDPOINT={token_endpoint}",
+        ],
+        check=False,
     )
-    return ok
+    if result.returncode != 0:
+        typer.echo(
+            f"Warning: could not set ExtProc client-credentials endpoint: {result.stderr}",
+            err=True,
+        )
+        return False
+    return True
 
 
 def _keycloak_realm_json(
@@ -859,7 +871,24 @@ def _keycloak_realm_json(
     The realm exposes a confidential client with the direct-access-grant flow so a
     user access token can be minted programmatically (password grant), and an
     audience mapper so the issued token carries the audience the gateway verifies.
+    It also registers the ExtProc gateway service-account client so the
+    token-exchange sidecar can mint its client assertion via ``client_credentials``.
+    Both clients carry the token-exchange broker audience the broker enforces on
+    the ``subject_token`` and ``client_assertion``.
     """
+
+    def _audience_mapper(name: str, custom_audience: str) -> dict:
+        return {
+            "name": name,
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-audience-mapper",
+            "config": {
+                "included.custom.audience": custom_audience,
+                "id.token.claim": "false",
+                "access.token.claim": "true",
+            },
+        }
+
     return {
         "realm": realm,
         "enabled": True,
@@ -883,9 +912,26 @@ def _keycloak_realm_json(
                             "id.token.claim": "false",
                             "access.token.claim": "true",
                         },
-                    }
+                    },
+                    _audience_mapper(
+                        "token-exchange-audience", AUTH_TOKEN_EXCHANGE_AUDIENCE
+                    ),
                 ],
-            }
+            },
+            {
+                "clientId": AUTH_EXT_PROC_CLIENT_ID,
+                "enabled": True,
+                "publicClient": False,
+                "secret": AUTH_EXT_PROC_CLIENT_SECRET,
+                "directAccessGrantsEnabled": False,
+                "standardFlowEnabled": False,
+                "serviceAccountsEnabled": True,
+                "protocolMappers": [
+                    _audience_mapper(
+                        "token-exchange-audience", AUTH_TOKEN_EXCHANGE_AUDIENCE
+                    ),
+                ],
+            },
         ],
         "users": [
             {
@@ -1272,12 +1318,11 @@ def install_command(
     if auth_enabled:
         ext_authz_url = ext_authz_url or _default_ext_authz_url(auth_namespace)
         auth_issuer = auth_issuer or _default_auth_issuer(auth_namespace, auth_release)
-        auth_admin_url = _default_auth_admin_url(auth_namespace, auth_release)
         if token_exchange:
             ext_proc_url = ext_proc_url or _default_ext_proc_url(
                 auth_namespace, auth_release
             )
-        if user_auth:
+        if user_auth or token_exchange:
             user_auth_issuer = user_auth_issuer or _default_user_auth_issuer(
                 keycloak_namespace, keycloak_release
             )
@@ -1286,13 +1331,15 @@ def install_command(
         # unpublished, so a chart path is required to install it here). The
         # ExtProc token-exchange component is enabled when token exchange is on.
         if aib_chart_path:
-            aib_extra_set = (
-                _build_aib_extproc_args(
-                    AUTH_EXT_PROC_CLIENT_ID, AUTH_EXT_PROC_CLIENT_SECRET
-                )
-                if token_exchange
-                else None
-            )
+            aib_extra_set = None
+            if token_exchange:
+                broker_token_endpoint = f"{auth_issuer}/oauth2/token"
+                aib_extra_set = _build_aib_extproc_args(
+                    AUTH_EXT_PROC_CLIENT_ID,
+                    AUTH_EXT_PROC_CLIENT_SECRET,
+                    issuer=user_auth_issuer,
+                    token_endpoint=broker_token_endpoint,
+                ) + _build_aib_hybrid_broker_args(user_auth_issuer)
             if not _install_aib(
                 auth_namespace,
                 auth_release,
@@ -1306,11 +1353,14 @@ def install_command(
                     err=True,
                 )
             elif token_exchange:
-                _provision_token_exchange(
-                    auth_admin_url,
-                    AUTH_EXT_PROC_CLIENT_ID,
-                    DEFAULT_THIRD_PARTY_SERVICE_ID,
-                    auth_issuer,
+                # Temporary bridge until the AIB chart templates the ExtProc
+                # client-credentials endpoint (followup F0): point it at the
+                # Keycloak token URL so the sidecar mints its client assertion
+                # against Keycloak rather than the mock upstream default.
+                _patch_aib_extproc_client_credentials_endpoint(
+                    auth_namespace,
+                    auth_release,
+                    f"{user_auth_issuer}/protocol/openid-connect/token",
                 )
         else:
             typer.echo(

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -792,6 +792,20 @@ def _build_aib_extproc_args(
     return args
 
 
+def _build_aib_broker_public_url_args(public_url: str) -> list[str]:
+    """Set the broker enduser ``public_url`` to its in-cluster service URL.
+
+    The broker defaults ``server.enduser.public_url`` to ``http://localhost:8000``
+    and stamps that value as the ``iss`` claim on the ``client_credentials``
+    agent tokens it mints. The gateway ``agent`` JWT provider validates those
+    tokens against the broker's in-cluster issuer, so without this override the
+    ``iss`` never matches and every agent-identity request is rejected with
+    ``Jwt_issuer_is_not_configured``. ``public_url`` is the broker enduser
+    endpoint (same value propagated to agents as their auth issuer).
+    """
+    return ["--set", f"broker.server.enduser.publicUrl={public_url}"]
+
+
 def _build_aib_hybrid_broker_args(user_auth_issuer: str) -> list[str]:
     """Build the broker-chart Helm --set args wiring hybrid mode to Keycloak.
 
@@ -1331,10 +1345,10 @@ def install_command(
         # unpublished, so a chart path is required to install it here). The
         # ExtProc token-exchange component is enabled when token exchange is on.
         if aib_chart_path:
-            aib_extra_set = None
+            aib_extra_set = _build_aib_broker_public_url_args(auth_issuer)
             if token_exchange:
                 broker_token_endpoint = f"{auth_issuer}/oauth2/token"
-                aib_extra_set = _build_aib_extproc_args(
+                aib_extra_set += _build_aib_extproc_args(
                     AUTH_EXT_PROC_CLIENT_ID,
                     AUTH_EXT_PROC_CLIENT_SECRET,
                     issuer=user_auth_issuer,

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -583,6 +583,7 @@ def _build_auth_operator_args(
     network_policy: bool = True,
     network_policy_egress: bool = False,
     gateway_routing: bool = False,
+    gateway_api_strict: bool = False,
     gateway_host: str = "",
     tls_mode: str = "",
     tls_issuer_name: str = "",
@@ -684,6 +685,8 @@ def _build_auth_operator_args(
         args.extend(["--set", "security.networkPolicy.egress.enabled=true"])
     if gateway_routing:
         args.extend(["--set", "security.gatewayRouting.enabled=true"])
+    if gateway_api_strict:
+        args.extend(["--set", "security.strictGatewayApi.enabled=true"])
     if gateway_host:
         args.extend(["--set", f"security.gatewayHost={gateway_host}"])
     if tls_mode:
@@ -1142,6 +1145,7 @@ def install_command(
     network_policy: bool = True,
     network_policy_egress: bool = False,
     gateway_routing: bool = False,
+    gateway_api_strict: bool = False,
     gateway_host: str | None = None,
     tls_mode: str | None = None,
     tls_issuer_name: str | None = None,
@@ -1380,6 +1384,7 @@ def install_command(
                 network_policy=network_policy,
                 network_policy_egress=network_policy_egress,
                 gateway_routing=gateway_routing,
+                gateway_api_strict=gateway_api_strict,
                 gateway_host=gateway_host or "",
                 tls_mode=tls_mode or "",
                 tls_issuer_name=tls_issuer_name or "",
@@ -1394,6 +1399,11 @@ def install_command(
                 policy_configmap_namespace=policy_configmap_namespace or "",
             )
         )
+    elif gateway_api_strict:
+        # Strict gateway-only traffic is a standalone posture: it applies even
+        # without an authorization enforcement hook, so emit it directly when
+        # auth is not enabled.
+        helm_args.extend(["--set", "security.strictGatewayApi.enabled=true"])
 
     typer.echo(f"Installing chart {HELM_CHART_NAME}...")
     result = run_helm_command(helm_args)

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -588,6 +588,13 @@ def _build_auth_operator_args(
     tls_issuer_name: str = "",
     tls_issuer_kind: str = "ClusterIssuer",
     tls_secret_name: str = "",
+    authz_provider: str = "",
+    authz_gateway_extension: str = "",
+    agent_jwt_verification: str = "",
+    policy_data_source: str = "",
+    policy_rego_override: bool = False,
+    policy_configmap_name: str = "",
+    policy_configmap_namespace: str = "",
 ) -> list[str]:
     """Build the operator Helm --set arguments that enable agent-auth wiring.
 
@@ -604,6 +611,10 @@ def _build_auth_operator_args(
     NetworkPolicy is on unless explicitly disabled, egress isolation is opt-in,
     gateway routing and host are set when requested, and ``security.tls.*`` is
     configured when a TLS mode is supplied.
+
+    Authorization knobs (``security.agentAuth.authorization.*``) and the policy
+    ConfigMap projection target are appended only when set, so the default
+    install leaves authorization projection off.
     """
     args: list[str] = []
     args.extend(["--set", f"security.agentAuth.extAuthzUrl={ext_authz_url}"])
@@ -618,6 +629,49 @@ def _build_auth_operator_args(
         args.extend(["--set", f"security.agentAuth.extProcUrl={ext_proc_url}"])
     if admin_url:
         args.extend(["--set", f"security.agentAuth.adminUrl={admin_url}"])
+    if authz_provider:
+        args.extend(
+            ["--set", f"security.agentAuth.authorization.provider={authz_provider}"]
+        )
+    if authz_gateway_extension:
+        args.extend(
+            [
+                "--set",
+                f"security.agentAuth.authorization.gatewayExtension={authz_gateway_extension}",
+            ]
+        )
+    if agent_jwt_verification:
+        args.extend(
+            [
+                "--set",
+                f"security.agentAuth.authorization.agentJwtVerification={agent_jwt_verification}",
+            ]
+        )
+    if policy_data_source:
+        args.extend(
+            [
+                "--set",
+                f"security.agentAuth.authorization.policyDataSource={policy_data_source}",
+            ]
+        )
+    if policy_rego_override:
+        args.extend(
+            ["--set", "security.agentAuth.authorization.policyRegoOverride=true"]
+        )
+    if policy_configmap_name:
+        args.extend(
+            [
+                "--set",
+                f"security.agentAuth.projection.policyConfigMap.name={policy_configmap_name}",
+            ]
+        )
+    if policy_configmap_namespace:
+        args.extend(
+            [
+                "--set",
+                f"security.agentAuth.projection.policyConfigMap.namespace={policy_configmap_namespace}",
+            ]
+        )
     if user_issuer:
         args.extend(["--set", f"security.userAuth.issuer={user_issuer}"])
     if user_audience:
@@ -1093,6 +1147,14 @@ def install_command(
     tls_issuer_name: str | None = None,
     tls_issuer_kind: str = "ClusterIssuer",
     tls_secret_name: str | None = None,
+    authz_provider: str | None = None,
+    authz_gateway_extension: str | None = None,
+    agent_jwt_verification: str | None = None,
+    policy_data_source: str | None = None,
+    policy_rego_override: bool = False,
+    admin_url: str | None = None,
+    policy_configmap_name: str | None = None,
+    policy_configmap_namespace: str | None = None,
 ) -> None:
     """Install the KAOS operator using Helm."""
     if not check_helm_installed():
@@ -1306,7 +1368,8 @@ def install_command(
                 ext_authz_url or _default_ext_authz_url(auth_namespace),
                 auth_issuer or _default_auth_issuer(auth_namespace, auth_release),
                 credential_secret_prefix,
-                admin_url=_default_auth_admin_url(auth_namespace, auth_release),
+                admin_url=admin_url
+                or _default_auth_admin_url(auth_namespace, auth_release),
                 user_issuer=resolved_user_issuer,
                 user_audience=user_auth_audience if user_auth else "",
                 ext_proc_url=(
@@ -1322,6 +1385,13 @@ def install_command(
                 tls_issuer_name=tls_issuer_name or "",
                 tls_issuer_kind=tls_issuer_kind,
                 tls_secret_name=tls_secret_name or "",
+                authz_provider=authz_provider or "",
+                authz_gateway_extension=authz_gateway_extension or "",
+                agent_jwt_verification=agent_jwt_verification or "",
+                policy_data_source=policy_data_source or "",
+                policy_rego_override=policy_rego_override,
+                policy_configmap_name=policy_configmap_name or "",
+                policy_configmap_namespace=policy_configmap_namespace or "",
             )
         )
 

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -761,7 +761,8 @@ def _build_aib_extproc_args(
 
     Returns the flat ``--set key=value`` list so it can be unit-tested without
     running Helm. The OAuth2 token endpoint and issuer are left to the chart
-    defaults (the in-cluster broker enduser service).
+    defaults (the in-cluster broker enduser service), which are plain http, so
+    ``allowHttp`` is enabled to let the ExtProc binary accept them at startup.
     """
     return [
         "--set",
@@ -772,6 +773,8 @@ def _build_aib_extproc_args(
         f"extProc.oauth2.clientSecret={ext_proc_client_secret}",
         "--set",
         f"extProc.oauth2.clientAssertionType={client_assertion_type}",
+        "--set",
+        "extProc.oauth2.allowHttp=true",
     ]
 
 

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -212,6 +212,54 @@ def install(
         "--tls-secret-name",
         help="Existing kubernetes.io/tls Secret name (with --tls-mode provided).",
     ),
+    authz_provider: str | None = typer.Option(
+        None,
+        "--authz-provider",
+        help="Authorization provider: 'kaos' (KAOS-owned policy data) or 'aib' "
+        "(broker permission sets). Omit to leave authorization projection off.",
+    ),
+    authz_gateway_extension: str | None = typer.Option(
+        None,
+        "--authz-gateway-extension",
+        help="Envoy gateway extension that enforces authorization: 'ext_proc' "
+        "(default OPA in ext_proc) or 'ext_authz'.",
+    ),
+    agent_jwt_verification: str | None = typer.Option(
+        None,
+        "--agent-jwt-verification",
+        help="How the agent (actor) JWT is trusted: 'skip' (header-trust, "
+        "non-production) or 'verified' (signature verified against the IdP JWKS).",
+    ),
+    policy_data_source: str | None = typer.Option(
+        None,
+        "--policy-data-source",
+        help="Who authors the authorization policy data: 'automated' (operator "
+        "projects from CRDs), 'manual' (admin authors), or 'external' (broker "
+        "authoritative, projection and prune off).",
+    ),
+    policy_rego_override: bool = typer.Option(
+        False,
+        "--policy-rego-override",
+        help="Have the operator own only the policy.rego key and leave the grant "
+        "data for an admin to author. Orthogonal to --policy-data-source.",
+    ),
+    admin_url: str | None = typer.Option(
+        None,
+        "--admin-url",
+        help="Base URL of the identity broker admin API. Defaults to the "
+        "conventional broker service when authorization is enabled.",
+    ),
+    policy_configmap_name: str | None = typer.Option(
+        None,
+        "--policy-configmap-name",
+        help="Name of the ConfigMap the operator writes the KAOS authorization "
+        "policy and grant data into for the enforcement engine to mount.",
+    ),
+    policy_configmap_namespace: str | None = typer.Option(
+        None,
+        "--policy-configmap-namespace",
+        help="Namespace of the authorization policy ConfigMap.",
+    ),
 ) -> None:
     """Install the KAOS operator using Helm."""
     # Default to signoz if flag provided without value
@@ -254,6 +302,14 @@ def install(
         tls_issuer_name=tls_issuer_name,
         tls_issuer_kind=tls_issuer_kind,
         tls_secret_name=tls_secret_name,
+        authz_provider=authz_provider,
+        authz_gateway_extension=authz_gateway_extension,
+        agent_jwt_verification=agent_jwt_verification,
+        policy_data_source=policy_data_source,
+        policy_rego_override=policy_rego_override,
+        admin_url=admin_url,
+        policy_configmap_name=policy_configmap_name,
+        policy_configmap_namespace=policy_configmap_namespace,
     )
 
 

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -9,7 +9,15 @@ from typer.core import TyperGroup
 from kaos_cli.system.install import install_command, uninstall_command
 from kaos_cli.system.create_rbac import create_rbac_command
 from kaos_cli.system.status import status_command
-from kaos_cli.install import DEFAULT_RELEASE_NAME, MONITORING_BACKENDS
+from kaos_cli.install import (
+    DEFAULT_FULL_AUTH_PRESET,
+    DEFAULT_RELEASE_NAME,
+    FULL_AUTH_KAOS_DEMO,
+    FULL_AUTH_KEYCLOAK_AIB,
+    FULL_AUTH_PRESETS,
+    MONITORING_BACKENDS,
+    _expand_full_auth_preset,
+)
 from kaos_cli.system.runtimes import runtimes_command
 from kaos_cli.utils import DEFAULT_MONITORING_BACKEND, preprocess_optional_value_flag
 
@@ -25,6 +33,9 @@ class _SystemGroup(TyperGroup):
             def patched_parse(ctx, args):
                 args = preprocess_optional_value_flag(
                     args, "--monitoring-enabled", DEFAULT_MONITORING_BACKEND
+                )
+                args = preprocess_optional_value_flag(
+                    args, "--full-auth-enabled", DEFAULT_FULL_AUTH_PRESET
                 )
                 return original_parse(ctx, args)
 
@@ -60,7 +71,8 @@ def install(
     set_values: list[str] = typer.Option(
         [],
         "--set",
-        help="Set Helm values (can be used multiple times).",
+        help="Set Helm values directly (can be used multiple times). Escape hatch "
+        "for any chart value not exposed as a dedicated flag.",
     ),
     wait: bool = typer.Option(
         False,
@@ -75,7 +87,8 @@ def install(
     gateway_enabled: bool = typer.Option(
         False,
         "--gateway-enabled",
-        help="Install Gateway API (Envoy Gateway) and configure routing.",
+        help="Install Gateway API (Envoy Gateway) and configure routing. Implied by "
+        "--full-auth-enabled.",
     ),
     metallb_enabled: bool = typer.Option(
         False,
@@ -87,103 +100,15 @@ def install(
         "--redis-enabled",
         help="Enable Redis for distributed agent memory.",
     ),
-    chart_path: str | None = typer.Option(
+    full_auth_enabled: str | None = typer.Option(
         None,
-        "--chart-path",
-        help="Path to local Helm chart directory (for development). Uses published chart if not set.",
-    ),
-    auth_enabled: bool = typer.Option(
-        False,
-        "--auth-enabled",
-        help="Enable agent authentication: wire the operator to the identity broker, "
-        "mount per-agent credentials, and optionally install the identity broker.",
-    ),
-    auth_namespace: str = typer.Option(
-        "aib-system",
-        "--auth-namespace",
-        help="Namespace for the identity broker.",
-    ),
-    ext_authz_url: str | None = typer.Option(
-        None,
-        "--ext-authz-url",
-        help="Override the access-check gRPC backend host:port. Defaults to the "
-        "conventional service in the auth namespace.",
-    ),
-    auth_issuer: str | None = typer.Option(
-        None,
-        "--auth-issuer",
-        help="Override the broker issuer URL propagated to agent pods. Defaults to the "
-        "broker enduser service in the auth namespace.",
-    ),
-    token_exchange: bool = typer.Option(
-        True,
-        "--token-exchange/--no-token-exchange",
-        help="Enable the RFC 8693 token-exchange path: deploy the broker ExtProc "
-        "component and wire the gateway ext_proc backend. Effective only with "
-        "--auth-enabled.",
-    ),
-    ext_proc_url: str | None = typer.Option(
-        None,
-        "--ext-proc-url",
-        help="Override the token-exchange ext_proc gRPC backend host:port. Defaults "
-        "to the broker ExtProc service in the auth namespace.",
-    ),
-    aib_chart_path: str | None = typer.Option(
-        None,
-        "--aib-chart-path",
-        help="Path to a local identity broker Helm chart to install (unpublished/dev path).",
-    ),
-    aib_values_path: str | None = typer.Option(
-        None,
-        "--aib-values",
-        help="Values file for the identity broker chart (e.g. the dev preset).",
-    ),
-    user_auth: bool = typer.Option(
-        True,
-        "--user-auth/--no-user-auth",
-        help="Install the human user identity provider (Keycloak) and wire user "
-        "subject-token validation at the gateway. Effective only with --auth-enabled.",
-    ),
-    keycloak_namespace: str = typer.Option(
-        "keycloak",
-        "--keycloak-namespace",
-        help="Namespace for the user identity provider (Keycloak).",
-    ),
-    keycloak_chart_path: str | None = typer.Option(
-        None,
-        "--keycloak-chart-path",
-        help="Path to a local Keycloak Helm chart to install. When omitted, a "
-        "self-contained dev deployment is applied instead.",
-    ),
-    user_auth_issuer: str | None = typer.Option(
-        None,
-        "--user-auth-issuer",
-        help="Override the user-auth OIDC issuer URL. Defaults to the bootstrapped "
-        "Keycloak realm in the keycloak namespace.",
-    ),
-    user_auth_audience: str = typer.Option(
-        "kaos",
-        "--user-auth-audience",
-        help="Expected audience claim for user subject tokens.",
-    ),
-    network_policy: bool = typer.Option(
-        True,
-        "--network-policy/--no-network-policy",
-        help="Generate NetworkPolicies that deny direct workload-to-workload traffic "
-        "so the Envoy Gateway cannot be bypassed. Effective only with --auth-enabled.",
-    ),
-    network_policy_egress: bool = typer.Option(
-        False,
-        "--network-policy-egress/--no-network-policy-egress",
-        help="Add egress default-deny rules to generated NetworkPolicies. Effective "
-        "only with --auth-enabled and --network-policy.",
-    ),
-    gateway_routing: bool = typer.Option(
-        False,
-        "--gateway-routing/--no-gateway-routing",
-        help="Route internal agent->ModelAPI/MCP/peer traffic through the gateway so "
-        "gateway authentication and authorization apply to it. Effective only with "
-        "--auth-enabled.",
+        "--full-auth-enabled",
+        help="Enable an end-to-end security posture. Options: "
+        f"'{FULL_AUTH_KEYCLOAK_AIB}' (default; full Keycloak user identity + identity "
+        "broker with token exchange + verified OPA authorization) or "
+        f"'{FULL_AUTH_KAOS_DEMO}' (self-contained demo; KAOS-projected policy "
+        "ConfigMap, header-trusted agent JWT, no external IdP/broker). The flag may "
+        "be passed without a value to select the default. Implies --gateway-enabled.",
     ),
     gateway_api_strict: bool = typer.Option(
         False,
@@ -193,80 +118,43 @@ def install(
         "only application path between workloads. Enforcement requires a CNI that "
         "enforces NetworkPolicy (e.g. Calico).",
     ),
-    gateway_host: str | None = typer.Option(
+    chart_path: str | None = typer.Option(
         None,
-        "--gateway-host",
-        help="In-cluster host[:port] of the Envoy Gateway used for gateway routing. "
-        "Defaults to the Gateway resource's status address.",
+        "--chart-path",
+        help="Path to local operator Helm chart directory (for development).",
     ),
-    tls_mode: str | None = typer.Option(
+    auth_namespace: str = typer.Option(
+        "aib-system",
+        "--auth-namespace",
+        hidden=True,
+        help="Namespace for the identity broker (advanced).",
+    ),
+    keycloak_namespace: str = typer.Option(
+        "keycloak",
+        "--keycloak-namespace",
+        hidden=True,
+        help="Namespace for the user identity provider (advanced).",
+    ),
+    aib_chart_path: str | None = typer.Option(
         None,
-        "--tls-mode",
-        help="Enable HTTPS termination on the gateway. One of: selfSigned, "
-        "certManager, provided.",
+        "--aib-chart-path",
+        hidden=True,
+        help="Path to a local identity broker Helm chart to install (unpublished/dev "
+        "path). Required to install the broker in-cluster for the "
+        f"{FULL_AUTH_KEYCLOAK_AIB} preset.",
     ),
-    tls_issuer_name: str | None = typer.Option(
+    aib_values_path: str | None = typer.Option(
         None,
-        "--tls-issuer-name",
-        help="cert-manager Issuer/ClusterIssuer name (with --tls-mode certManager).",
+        "--aib-values",
+        hidden=True,
+        help="Values file for the identity broker chart (advanced).",
     ),
-    tls_issuer_kind: str = typer.Option(
-        "ClusterIssuer",
-        "--tls-issuer-kind",
-        help="cert-manager issuer kind: Issuer or ClusterIssuer.",
-    ),
-    tls_secret_name: str | None = typer.Option(
+    keycloak_chart_path: str | None = typer.Option(
         None,
-        "--tls-secret-name",
-        help="Existing kubernetes.io/tls Secret name (with --tls-mode provided).",
-    ),
-    authz_provider: str | None = typer.Option(
-        None,
-        "--authz-provider",
-        help="Authorization provider: 'kaos' (KAOS-owned policy data) or 'aib' "
-        "(broker permission sets). Omit to leave authorization projection off.",
-    ),
-    authz_gateway_extension: str | None = typer.Option(
-        None,
-        "--authz-gateway-extension",
-        help="Envoy gateway extension that enforces authorization: 'ext_proc' "
-        "(default OPA in ext_proc) or 'ext_authz'.",
-    ),
-    agent_jwt_verification: str | None = typer.Option(
-        None,
-        "--agent-jwt-verification",
-        help="How the agent (actor) JWT is trusted: 'skip' (header-trust, "
-        "non-production) or 'verified' (signature verified against the IdP JWKS).",
-    ),
-    policy_data_source: str | None = typer.Option(
-        None,
-        "--policy-data-source",
-        help="Who authors the authorization policy data: 'automated' (operator "
-        "projects from CRDs), 'manual' (admin authors), or 'external' (broker "
-        "authoritative, projection and prune off).",
-    ),
-    policy_rego_override: bool = typer.Option(
-        False,
-        "--policy-rego-override",
-        help="Have the operator own only the policy.rego key and leave the grant "
-        "data for an admin to author. Orthogonal to --policy-data-source.",
-    ),
-    admin_url: str | None = typer.Option(
-        None,
-        "--admin-url",
-        help="Base URL of the identity broker admin API. Defaults to the "
-        "conventional broker service when authorization is enabled.",
-    ),
-    policy_configmap_name: str | None = typer.Option(
-        None,
-        "--policy-configmap-name",
-        help="Name of the ConfigMap the operator writes the KAOS authorization "
-        "policy and grant data into for the enforcement engine to mount.",
-    ),
-    policy_configmap_namespace: str | None = typer.Option(
-        None,
-        "--policy-configmap-namespace",
-        help="Namespace of the authorization policy ConfigMap.",
+        "--keycloak-chart-path",
+        hidden=True,
+        help="Path to a local Keycloak Helm chart to install. When omitted, a "
+        "self-contained dev deployment is applied instead (advanced).",
     ),
 ) -> None:
     """Install the KAOS operator using Helm."""
@@ -277,6 +165,21 @@ def install(
             err=True,
         )
         raise typer.Exit(1)
+
+    auth_kwargs: dict = {}
+    if full_auth_enabled is not None:
+        if full_auth_enabled not in FULL_AUTH_PRESETS:
+            typer.echo(
+                f"Error: Invalid full-auth preset '{full_auth_enabled}'. Options: "
+                f"{', '.join(FULL_AUTH_PRESETS)}",
+                err=True,
+            )
+            raise typer.Exit(1)
+        # The gateway is the enforcement point for every auth posture, so ensure
+        # it is installed even if --gateway-enabled was not passed explicitly.
+        gateway_enabled = True
+        auth_kwargs = _expand_full_auth_preset(full_auth_enabled)
+
     install_command(
         namespace=namespace,
         release_name=release_name,
@@ -288,37 +191,14 @@ def install(
         metallb_enabled=metallb_enabled,
         redis_enabled=redis_enabled,
         chart_path=chart_path,
-        auth_enabled=auth_enabled,
         auth_namespace=auth_namespace,
-        ext_authz_url=ext_authz_url,
-        auth_issuer=auth_issuer,
-        token_exchange=token_exchange,
-        ext_proc_url=ext_proc_url,
-        aib_chart_path=aib_chart_path,
-        aib_values_path=aib_values_path,
-        user_auth=user_auth,
         keycloak_namespace=keycloak_namespace,
         keycloak_release="keycloak",
+        aib_chart_path=aib_chart_path,
+        aib_values_path=aib_values_path,
         keycloak_chart_path=keycloak_chart_path,
-        user_auth_issuer=user_auth_issuer,
-        user_auth_audience=user_auth_audience,
-        network_policy=network_policy,
-        network_policy_egress=network_policy_egress,
-        gateway_routing=gateway_routing,
         gateway_api_strict=gateway_api_strict,
-        gateway_host=gateway_host,
-        tls_mode=tls_mode,
-        tls_issuer_name=tls_issuer_name,
-        tls_issuer_kind=tls_issuer_kind,
-        tls_secret_name=tls_secret_name,
-        authz_provider=authz_provider,
-        authz_gateway_extension=authz_gateway_extension,
-        agent_jwt_verification=agent_jwt_verification,
-        policy_data_source=policy_data_source,
-        policy_rego_override=policy_rego_override,
-        admin_url=admin_url,
-        policy_configmap_name=policy_configmap_name,
-        policy_configmap_namespace=policy_configmap_namespace,
+        **auth_kwargs,
     )
 
 

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -156,6 +156,141 @@ def install(
         help="Path to a local Keycloak Helm chart to install. When omitted, a "
         "self-contained dev deployment is applied instead (advanced).",
     ),
+    auth_enabled: bool = typer.Option(
+        False,
+        "--auth-enabled/--no-auth-enabled",
+        hidden=True,
+        help="Advanced: enable agent-auth wiring directly without a preset.",
+    ),
+    ext_authz_url: str | None = typer.Option(
+        None, "--ext-authz-url", hidden=True, help="Advanced: ext_authz backend."
+    ),
+    auth_issuer: str | None = typer.Option(
+        None, "--auth-issuer", hidden=True, help="Advanced: broker issuer URL."
+    ),
+    token_exchange: bool = typer.Option(
+        True,
+        "--token-exchange/--no-token-exchange",
+        hidden=True,
+        help="Advanced: RFC 8693 token-exchange path.",
+    ),
+    ext_proc_url: str | None = typer.Option(
+        None,
+        "--ext-proc-url",
+        hidden=True,
+        help="Advanced: token-exchange ext_proc backend.",
+    ),
+    user_auth: bool = typer.Option(
+        True,
+        "--user-auth/--no-user-auth",
+        hidden=True,
+        help="Advanced: install the user identity provider (Keycloak).",
+    ),
+    user_auth_issuer: str | None = typer.Option(
+        None, "--user-auth-issuer", hidden=True, help="Advanced: user-auth OIDC issuer."
+    ),
+    user_auth_audience: str = typer.Option(
+        "kaos",
+        "--user-auth-audience",
+        hidden=True,
+        help="Advanced: user token audience.",
+    ),
+    network_policy: bool = typer.Option(
+        True,
+        "--network-policy/--no-network-policy",
+        hidden=True,
+        help="Advanced: generate bypass-prevention NetworkPolicies.",
+    ),
+    network_policy_egress: bool = typer.Option(
+        False,
+        "--network-policy-egress/--no-network-policy-egress",
+        hidden=True,
+        help="Advanced: add egress default-deny to NetworkPolicies.",
+    ),
+    gateway_routing: bool = typer.Option(
+        False,
+        "--gateway-routing/--no-gateway-routing",
+        hidden=True,
+        help="Advanced: route internal traffic through the gateway.",
+    ),
+    gateway_host: str | None = typer.Option(
+        None,
+        "--gateway-host",
+        hidden=True,
+        help="Advanced: in-cluster gateway host[:port].",
+    ),
+    tls_mode: str | None = typer.Option(
+        None,
+        "--tls-mode",
+        hidden=True,
+        help="Advanced: gateway HTTPS termination mode.",
+    ),
+    tls_issuer_name: str | None = typer.Option(
+        None,
+        "--tls-issuer-name",
+        hidden=True,
+        help="Advanced: cert-manager issuer name.",
+    ),
+    tls_issuer_kind: str = typer.Option(
+        "ClusterIssuer",
+        "--tls-issuer-kind",
+        hidden=True,
+        help="Advanced: cert-manager issuer kind.",
+    ),
+    tls_secret_name: str | None = typer.Option(
+        None,
+        "--tls-secret-name",
+        hidden=True,
+        help="Advanced: existing TLS Secret name.",
+    ),
+    authz_provider: str | None = typer.Option(
+        None,
+        "--authz-provider",
+        hidden=True,
+        help="Advanced: authorization provider (kaos|aib).",
+    ),
+    authz_gateway_extension: str | None = typer.Option(
+        None,
+        "--authz-gateway-extension",
+        hidden=True,
+        help="Advanced: enforcement extension (ext_proc|ext_authz).",
+    ),
+    agent_jwt_verification: str | None = typer.Option(
+        None,
+        "--agent-jwt-verification",
+        hidden=True,
+        help="Advanced: agent JWT trust (skip|verified).",
+    ),
+    policy_data_source: str | None = typer.Option(
+        None,
+        "--policy-data-source",
+        hidden=True,
+        help="Advanced: policy data author (automated|manual|external).",
+    ),
+    policy_rego_override: bool = typer.Option(
+        False,
+        "--policy-rego-override",
+        hidden=True,
+        help="Advanced: operator owns policy.rego only, admin authors grant data.",
+    ),
+    admin_url: str | None = typer.Option(
+        None,
+        "--admin-url",
+        hidden=True,
+        help="Advanced: identity broker admin API URL.",
+    ),
+    policy_configmap_name: str | None = typer.Option(
+        None,
+        "--policy-configmap-name",
+        hidden=True,
+        help="Advanced: policy ConfigMap name.",
+    ),
+    policy_configmap_namespace: str | None = typer.Option(
+        None,
+        "--policy-configmap-namespace",
+        hidden=True,
+        help="Advanced: policy ConfigMap namespace.",
+    ),
 ) -> None:
     """Install the KAOS operator using Helm."""
     # Default to signoz if flag provided without value
@@ -180,7 +315,7 @@ def install(
         gateway_enabled = True
         auth_kwargs = _expand_full_auth_preset(full_auth_enabled)
 
-    install_command(
+    call_kwargs = dict(
         namespace=namespace,
         release_name=release_name,
         version=version,
@@ -198,8 +333,34 @@ def install(
         aib_values_path=aib_values_path,
         keycloak_chart_path=keycloak_chart_path,
         gateway_api_strict=gateway_api_strict,
-        **auth_kwargs,
+        auth_enabled=auth_enabled,
+        ext_authz_url=ext_authz_url,
+        auth_issuer=auth_issuer,
+        token_exchange=token_exchange,
+        ext_proc_url=ext_proc_url,
+        user_auth=user_auth,
+        user_auth_issuer=user_auth_issuer,
+        user_auth_audience=user_auth_audience,
+        network_policy=network_policy,
+        network_policy_egress=network_policy_egress,
+        gateway_routing=gateway_routing,
+        gateway_host=gateway_host,
+        tls_mode=tls_mode,
+        tls_issuer_name=tls_issuer_name,
+        tls_issuer_kind=tls_issuer_kind,
+        tls_secret_name=tls_secret_name,
+        authz_provider=authz_provider,
+        authz_gateway_extension=authz_gateway_extension,
+        agent_jwt_verification=agent_jwt_verification,
+        policy_data_source=policy_data_source,
+        policy_rego_override=policy_rego_override,
+        admin_url=admin_url,
+        policy_configmap_name=policy_configmap_name,
+        policy_configmap_namespace=policy_configmap_namespace,
     )
+    # Preset values take precedence over the advanced flag defaults.
+    call_kwargs.update(auth_kwargs)
+    install_command(**call_kwargs)
 
 
 @app.command(name="uninstall")

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -10,13 +10,14 @@ from kaos_cli.system.install import install_command, uninstall_command
 from kaos_cli.system.create_rbac import create_rbac_command
 from kaos_cli.system.status import status_command
 from kaos_cli.install import (
-    DEFAULT_FULL_AUTH_PRESET,
+    AUTH_PRESET_AIB_KEYCLOAK,
+    AUTH_PRESET_AIB_ONLY,
+    AUTH_PRESET_KAOS_INTERNAL,
+    AUTH_PRESETS,
+    DEFAULT_AUTH_PRESET,
     DEFAULT_RELEASE_NAME,
-    FULL_AUTH_KAOS_DEMO,
-    FULL_AUTH_KEYCLOAK_AIB,
-    FULL_AUTH_PRESETS,
     MONITORING_BACKENDS,
-    _expand_full_auth_preset,
+    _expand_auth_preset,
 )
 from kaos_cli.system.runtimes import runtimes_command
 from kaos_cli.utils import DEFAULT_MONITORING_BACKEND, preprocess_optional_value_flag
@@ -35,7 +36,7 @@ class _SystemGroup(TyperGroup):
                     args, "--monitoring-enabled", DEFAULT_MONITORING_BACKEND
                 )
                 args = preprocess_optional_value_flag(
-                    args, "--full-auth-enabled", DEFAULT_FULL_AUTH_PRESET
+                    args, "--auth-enabled", DEFAULT_AUTH_PRESET
                 )
                 return original_parse(ctx, args)
 
@@ -71,8 +72,9 @@ def install(
     set_values: list[str] = typer.Option(
         [],
         "--set",
-        help="Set Helm values directly (can be used multiple times). Escape hatch "
-        "for any chart value not exposed as a dedicated flag.",
+        help="Set Helm values directly (repeatable). Escape hatch for any chart "
+        "value not exposed as a dedicated flag, e.g. advanced security overrides "
+        "under security.agentAuth.*",
     ),
     wait: bool = typer.Option(
         False,
@@ -88,7 +90,7 @@ def install(
         False,
         "--gateway-enabled",
         help="Install Gateway API (Envoy Gateway) and configure routing. Implied by "
-        "--full-auth-enabled.",
+        "--auth-enabled.",
     ),
     metallb_enabled: bool = typer.Option(
         False,
@@ -100,15 +102,18 @@ def install(
         "--redis-enabled",
         help="Enable Redis for distributed agent memory.",
     ),
-    full_auth_enabled: str | None = typer.Option(
+    auth_enabled: str | None = typer.Option(
         None,
-        "--full-auth-enabled",
-        help="Enable an end-to-end security posture. Options: "
-        f"'{FULL_AUTH_KEYCLOAK_AIB}' (default; full Keycloak user identity + identity "
-        "broker with token exchange + verified OPA authorization) or "
-        f"'{FULL_AUTH_KAOS_DEMO}' (self-contained demo; KAOS-projected policy "
-        "ConfigMap, header-trusted agent JWT, no external IdP/broker). The flag may "
-        "be passed without a value to select the default. Implies --gateway-enabled.",
+        "--auth-enabled",
+        help="Enable an end-to-end security posture by preset. Options: "
+        f"'{AUTH_PRESET_AIB_KEYCLOAK}' (default; Keycloak user identity + identity "
+        "broker agent identity with RFC 8693 token exchange + verified OPA "
+        f"authorization), '{AUTH_PRESET_KAOS_INTERNAL}' (self-contained demo; "
+        "KAOS-projected policy ConfigMap, header-trusted agent JWT, no external "
+        f"IdP/broker), or '{AUTH_PRESET_AIB_ONLY}' (broker agent identity, no "
+        "user layer, no token exchange). May be passed without a value to select "
+        "the default. Implies --gateway-enabled. Advanced overrides go through "
+        "--set security.agentAuth.*",
     ),
     gateway_api_strict: bool = typer.Option(
         False,
@@ -127,173 +132,37 @@ def install(
         "aib-system",
         "--auth-namespace",
         hidden=True,
-        help="Namespace for the identity broker (advanced).",
+        help="Namespace for the identity broker (advanced/dev).",
     ),
     keycloak_namespace: str = typer.Option(
         "keycloak",
         "--keycloak-namespace",
         hidden=True,
-        help="Namespace for the user identity provider (advanced).",
+        help="Namespace for the user identity provider (advanced/dev).",
     ),
     aib_chart_path: str | None = typer.Option(
         None,
         "--aib-chart-path",
         hidden=True,
         help="Path to a local identity broker Helm chart to install (unpublished/dev "
-        "path). Required to install the broker in-cluster for the "
-        f"{FULL_AUTH_KEYCLOAK_AIB} preset.",
+        f"path). Required to install the broker for the {AUTH_PRESET_AIB_KEYCLOAK} "
+        f"and {AUTH_PRESET_AIB_ONLY} presets.",
     ),
     aib_values_path: str | None = typer.Option(
         None,
         "--aib-values",
         hidden=True,
-        help="Values file for the identity broker chart (advanced).",
+        help="Values file for the identity broker chart (advanced/dev).",
     ),
     keycloak_chart_path: str | None = typer.Option(
         None,
         "--keycloak-chart-path",
         hidden=True,
         help="Path to a local Keycloak Helm chart to install. When omitted, a "
-        "self-contained dev deployment is applied instead (advanced).",
-    ),
-    auth_enabled: bool = typer.Option(
-        False,
-        "--auth-enabled/--no-auth-enabled",
-        hidden=True,
-        help="Advanced: enable agent-auth wiring directly without a preset.",
-    ),
-    ext_authz_url: str | None = typer.Option(
-        None, "--ext-authz-url", hidden=True, help="Advanced: ext_authz backend."
-    ),
-    auth_issuer: str | None = typer.Option(
-        None, "--auth-issuer", hidden=True, help="Advanced: broker issuer URL."
-    ),
-    token_exchange: bool = typer.Option(
-        True,
-        "--token-exchange/--no-token-exchange",
-        hidden=True,
-        help="Advanced: RFC 8693 token-exchange path.",
-    ),
-    ext_proc_url: str | None = typer.Option(
-        None,
-        "--ext-proc-url",
-        hidden=True,
-        help="Advanced: token-exchange ext_proc backend.",
-    ),
-    user_auth: bool = typer.Option(
-        True,
-        "--user-auth/--no-user-auth",
-        hidden=True,
-        help="Advanced: install the user identity provider (Keycloak).",
-    ),
-    user_auth_issuer: str | None = typer.Option(
-        None, "--user-auth-issuer", hidden=True, help="Advanced: user-auth OIDC issuer."
-    ),
-    user_auth_audience: str = typer.Option(
-        "kaos",
-        "--user-auth-audience",
-        hidden=True,
-        help="Advanced: user token audience.",
-    ),
-    network_policy: bool = typer.Option(
-        True,
-        "--network-policy/--no-network-policy",
-        hidden=True,
-        help="Advanced: generate bypass-prevention NetworkPolicies.",
-    ),
-    network_policy_egress: bool = typer.Option(
-        False,
-        "--network-policy-egress/--no-network-policy-egress",
-        hidden=True,
-        help="Advanced: add egress default-deny to NetworkPolicies.",
-    ),
-    gateway_routing: bool = typer.Option(
-        False,
-        "--gateway-routing/--no-gateway-routing",
-        hidden=True,
-        help="Advanced: route internal traffic through the gateway.",
-    ),
-    gateway_host: str | None = typer.Option(
-        None,
-        "--gateway-host",
-        hidden=True,
-        help="Advanced: in-cluster gateway host[:port].",
-    ),
-    tls_mode: str | None = typer.Option(
-        None,
-        "--tls-mode",
-        hidden=True,
-        help="Advanced: gateway HTTPS termination mode.",
-    ),
-    tls_issuer_name: str | None = typer.Option(
-        None,
-        "--tls-issuer-name",
-        hidden=True,
-        help="Advanced: cert-manager issuer name.",
-    ),
-    tls_issuer_kind: str = typer.Option(
-        "ClusterIssuer",
-        "--tls-issuer-kind",
-        hidden=True,
-        help="Advanced: cert-manager issuer kind.",
-    ),
-    tls_secret_name: str | None = typer.Option(
-        None,
-        "--tls-secret-name",
-        hidden=True,
-        help="Advanced: existing TLS Secret name.",
-    ),
-    authz_provider: str | None = typer.Option(
-        None,
-        "--authz-provider",
-        hidden=True,
-        help="Advanced: authorization provider (kaos|aib).",
-    ),
-    authz_gateway_extension: str | None = typer.Option(
-        None,
-        "--authz-gateway-extension",
-        hidden=True,
-        help="Advanced: enforcement extension (ext_proc|ext_authz).",
-    ),
-    agent_jwt_verification: str | None = typer.Option(
-        None,
-        "--agent-jwt-verification",
-        hidden=True,
-        help="Advanced: agent JWT trust (skip|verified).",
-    ),
-    policy_data_source: str | None = typer.Option(
-        None,
-        "--policy-data-source",
-        hidden=True,
-        help="Advanced: policy data author (automated|manual|external).",
-    ),
-    policy_rego_override: bool = typer.Option(
-        False,
-        "--policy-rego-override",
-        hidden=True,
-        help="Advanced: operator owns policy.rego only, admin authors grant data.",
-    ),
-    admin_url: str | None = typer.Option(
-        None,
-        "--admin-url",
-        hidden=True,
-        help="Advanced: identity broker admin API URL.",
-    ),
-    policy_configmap_name: str | None = typer.Option(
-        None,
-        "--policy-configmap-name",
-        hidden=True,
-        help="Advanced: policy ConfigMap name.",
-    ),
-    policy_configmap_namespace: str | None = typer.Option(
-        None,
-        "--policy-configmap-namespace",
-        hidden=True,
-        help="Advanced: policy ConfigMap namespace.",
+        "self-contained dev deployment is applied instead (advanced/dev).",
     ),
 ) -> None:
     """Install the KAOS operator using Helm."""
-    # Default to signoz if flag provided without value
     if monitoring_enabled is not None and monitoring_enabled not in MONITORING_BACKENDS:
         typer.echo(
             f"Error: Invalid monitoring backend '{monitoring_enabled}'. Options: {', '.join(MONITORING_BACKENDS)}",
@@ -302,18 +171,18 @@ def install(
         raise typer.Exit(1)
 
     auth_kwargs: dict = {}
-    if full_auth_enabled is not None:
-        if full_auth_enabled not in FULL_AUTH_PRESETS:
+    if auth_enabled is not None:
+        if auth_enabled not in AUTH_PRESETS:
             typer.echo(
-                f"Error: Invalid full-auth preset '{full_auth_enabled}'. Options: "
-                f"{', '.join(FULL_AUTH_PRESETS)}",
+                f"Error: Invalid auth preset '{auth_enabled}'. Options: "
+                f"{', '.join(AUTH_PRESETS)}",
                 err=True,
             )
             raise typer.Exit(1)
         # The gateway is the enforcement point for every auth posture, so ensure
         # it is installed even if --gateway-enabled was not passed explicitly.
         gateway_enabled = True
-        auth_kwargs = _expand_full_auth_preset(full_auth_enabled)
+        auth_kwargs = _expand_auth_preset(auth_enabled, namespace)
 
     call_kwargs = dict(
         namespace=namespace,
@@ -333,32 +202,7 @@ def install(
         aib_values_path=aib_values_path,
         keycloak_chart_path=keycloak_chart_path,
         gateway_api_strict=gateway_api_strict,
-        auth_enabled=auth_enabled,
-        ext_authz_url=ext_authz_url,
-        auth_issuer=auth_issuer,
-        token_exchange=token_exchange,
-        ext_proc_url=ext_proc_url,
-        user_auth=user_auth,
-        user_auth_issuer=user_auth_issuer,
-        user_auth_audience=user_auth_audience,
-        network_policy=network_policy,
-        network_policy_egress=network_policy_egress,
-        gateway_routing=gateway_routing,
-        gateway_host=gateway_host,
-        tls_mode=tls_mode,
-        tls_issuer_name=tls_issuer_name,
-        tls_issuer_kind=tls_issuer_kind,
-        tls_secret_name=tls_secret_name,
-        authz_provider=authz_provider,
-        authz_gateway_extension=authz_gateway_extension,
-        agent_jwt_verification=agent_jwt_verification,
-        policy_data_source=policy_data_source,
-        policy_rego_override=policy_rego_override,
-        admin_url=admin_url,
-        policy_configmap_name=policy_configmap_name,
-        policy_configmap_namespace=policy_configmap_namespace,
     )
-    # Preset values take precedence over the advanced flag defaults.
     call_kwargs.update(auth_kwargs)
     install_command(**call_kwargs)
 

--- a/kaos-cli/kaos_cli/system/__init__.py
+++ b/kaos-cli/kaos_cli/system/__init__.py
@@ -185,6 +185,14 @@ def install(
         "gateway authentication and authorization apply to it. Effective only with "
         "--auth-enabled.",
     ),
+    gateway_api_strict: bool = typer.Option(
+        False,
+        "--gateway-api-strict/--no-gateway-api-strict",
+        help="Enable gateway-only strict traffic: NetworkPolicy isolation and gateway "
+        "routing together, independent of authorization. Makes the Envoy Gateway the "
+        "only application path between workloads. Enforcement requires a CNI that "
+        "enforces NetworkPolicy (e.g. Calico).",
+    ),
     gateway_host: str | None = typer.Option(
         None,
         "--gateway-host",
@@ -297,6 +305,7 @@ def install(
         network_policy=network_policy,
         network_policy_egress=network_policy_egress,
         gateway_routing=gateway_routing,
+        gateway_api_strict=gateway_api_strict,
         gateway_host=gateway_host,
         tls_mode=tls_mode,
         tls_issuer_name=tls_issuer_name,

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -1296,6 +1296,9 @@ class TestAuthWiring:
         assert "extProc.enabled=true" in joined
         assert "extProc.oauth2.clientId=extproc-gateway" in joined
         assert "extProc.oauth2.clientSecret=secret" in joined
+        # The in-cluster broker enduser endpoint is plain http, so the ExtProc
+        # binary must be told to accept http:// endpoints at startup.
+        assert "extProc.oauth2.allowHttp=true" in joined
 
     def test_default_user_auth_issuer(self):
         from kaos_cli.install import _default_user_auth_issuer

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -1299,6 +1299,75 @@ class TestAuthWiring:
         # The in-cluster broker enduser endpoint is plain http, so the ExtProc
         # binary must be told to accept http:// endpoints at startup.
         assert "extProc.oauth2.allowHttp=true" in joined
+        # Issuer/tokenEndpoint are omitted unless supplied (chart defaults apply).
+        assert "extProc.oauth2.issuer" not in joined
+        assert "extProc.oauth2.tokenEndpoint" not in joined
+
+    def test_build_aib_extproc_args_with_endpoints(self):
+        from kaos_cli.install import _build_aib_extproc_args
+
+        args = _build_aib_extproc_args(
+            "extproc-gateway",
+            "secret",
+            issuer="http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos",
+            token_endpoint="http://broker.aib.svc.cluster.local:8080/oauth2/token",
+        )
+        joined = " ".join(args)
+        assert (
+            "extProc.oauth2.issuer="
+            "http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos" in joined
+        )
+        assert (
+            "extProc.oauth2.tokenEndpoint="
+            "http://broker.aib.svc.cluster.local:8080/oauth2/token" in joined
+        )
+
+    def test_build_aib_hybrid_broker_args(self):
+        from kaos_cli.install import _build_aib_hybrid_broker_args
+
+        issuer = "http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos"
+        joined = " ".join(_build_aib_hybrid_broker_args(issuer))
+        assert "broker.oauth2AuthorizationServer.mode=hybrid" in joined
+        assert (
+            f"broker.oauth2AuthorizationServer.proxy.upstreamIssuerUri={issuer}"
+            in joined
+        )
+        assert (
+            "broker.oauth2AuthorizationServer.proxy.upstreamTokenEndpoint="
+            f"{issuer}/protocol/openid-connect/token" in joined
+        )
+        assert (
+            "broker.oauth2AuthorizationServer.proxy.upstreamAuthorizeEndpoint="
+            f"{issuer}/protocol/openid-connect/auth" in joined
+        )
+        assert "urn:ietf:params:oauth:grant-type:token-exchange" in joined
+        assert "broker.tokenExchange.expectedAudience=token-exchange-broker" in joined
+
+    def test_keycloak_realm_json_registers_extproc_client(self):
+        from kaos_cli.install import (
+            AUTH_EXT_PROC_CLIENT_ID,
+            AUTH_EXT_PROC_CLIENT_SECRET,
+            AUTH_TOKEN_EXCHANGE_AUDIENCE,
+            _keycloak_realm_json,
+        )
+
+        realm = _keycloak_realm_json(
+            "kaos", "kaos", "kaos-dev-secret", "kaos", "kaos-user", "kaos-password"
+        )
+        clients = {c["clientId"]: c for c in realm["clients"]}
+        # The ExtProc gateway service-account client is registered so the
+        # token-exchange sidecar can mint its client assertion.
+        assert AUTH_EXT_PROC_CLIENT_ID in clients
+        extproc = clients[AUTH_EXT_PROC_CLIENT_ID]
+        assert extproc["secret"] == AUTH_EXT_PROC_CLIENT_SECRET
+        assert extproc["serviceAccountsEnabled"] is True
+        # Both clients carry the token-exchange broker audience the broker enforces.
+        for client_id in ("kaos", AUTH_EXT_PROC_CLIENT_ID):
+            audiences = [
+                m["config"].get("included.custom.audience")
+                for m in clients[client_id]["protocolMappers"]
+            ]
+            assert AUTH_TOKEN_EXCHANGE_AUDIENCE in audiences
 
     def test_default_user_auth_issuer(self):
         from kaos_cli.install import _default_user_auth_issuer

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -881,14 +881,32 @@ class TestSystemInstallFlags:
         result = runner.invoke(app, ["system", "install", "--help"])
         assert result.exit_code == 0
         output = strip_ansi(result.output)
-        assert "--auth-enabled" in output
-        assert "--auth-namespace" in output
-        assert "--aib-chart-path" in output
-        assert "--user-auth" in output
-        assert "--keycloak-namespace" in output
+        assert "--full-auth-enabled" in output
+        # The fine-grained auth knobs are collapsed into the preset and no longer
+        # exposed on the command surface.
+        assert "--auth-enabled" not in output
+        assert "--authz-provider" not in output
+        assert "--agent-jwt-verification" not in output
+        # Advanced dev chart paths remain available but hidden from help.
+        assert "--aib-chart-path" not in output
 
 
 class TestAuthWiring:
+    @pytest.fixture(autouse=True)
+    def _stub_gateway_install(self):
+        """Stub the gateway install/wait helpers so preset-driven installs.
+
+        The full-auth presets force --gateway-enabled, which otherwise polls the
+        cluster for GatewayClass acceptance for 60s. Tests here assert on the
+        operator --set wiring, not the gateway bootstrap, so short-circuit it.
+        """
+        from unittest.mock import patch
+
+        with patch("kaos_cli.install._install_gateway_api", return_value=True), patch(
+            "kaos_cli.install._wait_for_gateway_class", return_value=True
+        ):
+            yield
+
     def test_build_auth_operator_args(self):
         from kaos_cli.install import _build_auth_operator_args
 
@@ -925,7 +943,7 @@ class TestAuthWiring:
         )
 
     def test_auth_enabled_wires_operator_security_values(self):
-        """--auth-enabled adds the security.agentAuth.* helm --set args."""
+        """--full-auth-enabled adds the security.agentAuth.* helm --set args."""
         from unittest.mock import patch
 
         captured = {}
@@ -953,7 +971,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--auth-enabled",
+                    "--full-auth-enabled",
+                    "keycloak-aib-enabled",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1286,7 +1305,7 @@ class TestAuthWiring:
         assert issuer == "http://keycloak.kc-ns.svc.cluster.local:8080/realms/kaos"
 
     def test_auth_enabled_wires_user_auth_values(self):
-        """--auth-enabled (user-auth on by default) adds security.userAuth.* args."""
+        """keycloak-aib-enabled (user-auth on) adds security.userAuth.* args."""
         from unittest.mock import patch
         from types import SimpleNamespace
 
@@ -1310,7 +1329,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--auth-enabled",
+                    "--full-auth-enabled",
+                    "keycloak-aib-enabled",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1322,7 +1342,7 @@ class TestAuthWiring:
         assert "security.userAuth.audience=kaos" in joined
 
     def test_no_user_auth_omits_user_auth_values(self):
-        """--no-user-auth installs neither Keycloak nor the userAuth wiring."""
+        """kaos-internal-demo installs neither Keycloak nor the userAuth wiring."""
         from unittest.mock import patch
         from types import SimpleNamespace
 
@@ -1348,8 +1368,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--auth-enabled",
-                    "--no-user-auth",
+                    "--full-auth-enabled",
+                    "kaos-internal-demo",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1361,9 +1381,13 @@ class TestAuthWiring:
         assert "security.userAuth" not in joined
         # Agent-auth wiring is unaffected.
         assert "security.agentAuth.extAuthzUrl=" in joined
+        # Demo posture selects the KAOS-owned policy provider with header-trusted
+        # agent JWT.
+        assert "security.agentAuth.authorization.provider=kaos" in joined
+        assert "security.agentAuth.authorization.agentJwtVerification=skip" in joined
 
     def test_keycloak_install_applies_realm_and_deployment(self):
-        """--auth-enabled applies the realm ConfigMap and Keycloak dev deployment."""
+        """keycloak-aib-enabled applies the realm ConfigMap and Keycloak deployment."""
         from unittest.mock import patch
         from types import SimpleNamespace
 
@@ -1383,7 +1407,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--auth-enabled",
+                    "--full-auth-enabled",
+                    "keycloak-aib-enabled",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1417,7 +1442,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--auth-enabled",
+                    "--full-auth-enabled",
+                    "keycloak-aib-enabled",
                     "--keycloak-chart-path",
                     "charts/keycloak",
                     "--chart-path",
@@ -1430,7 +1456,107 @@ class TestAuthWiring:
         assert "charts/keycloak" in joined
         assert "realmImport.configMapName=keycloak-realm-import" in joined
 
-    def test_install_monitoring_enabled_without_value(self):
+    def test_expand_full_auth_preset_keycloak_aib(self):
+        from kaos_cli.install import _expand_full_auth_preset
+
+        kwargs = _expand_full_auth_preset("keycloak-aib-enabled")
+        assert kwargs["auth_enabled"] is True
+        assert kwargs["user_auth"] is True
+        assert kwargs["token_exchange"] is True
+        assert kwargs["authz_provider"] == "aib"
+        assert kwargs["authz_gateway_extension"] == "ext_proc"
+        assert kwargs["agent_jwt_verification"] == "verified"
+
+    def test_expand_full_auth_preset_kaos_demo(self):
+        from kaos_cli.install import _expand_full_auth_preset
+
+        kwargs = _expand_full_auth_preset("kaos-internal-demo")
+        assert kwargs["auth_enabled"] is True
+        assert kwargs["user_auth"] is False
+        assert kwargs["token_exchange"] is False
+        assert kwargs["authz_provider"] == "kaos"
+        assert kwargs["agent_jwt_verification"] == "skip"
+
+    def test_full_auth_enabled_without_value_defaults_to_keycloak_aib(self):
+        """--full-auth-enabled with no value selects the keycloak-aib preset."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+
+        captured = {}
+
+        def fake_helm(args, check=True, **kwargs):
+            if "upgrade" in args and any(
+                "kaos-operator" in a or a.endswith("/chart") for a in args
+            ):
+                captured["args"] = args
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("kaos_cli.install.check_helm_installed", return_value=True), patch(
+            "kaos_cli.install.run_helm_command", side_effect=fake_helm
+        ), patch("kaos_cli.install._run_kubectl") as mock_kubectl:
+            mock_kubectl.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            result = runner.invoke(
+                app,
+                [
+                    "system",
+                    "install",
+                    "--full-auth-enabled",
+                    "--chart-path",
+                    "operator/chart",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        joined = " ".join(captured.get("args", []))
+        assert "security.agentAuth.authorization.provider=aib" in joined
+        # Preset implies the gateway is installed for enforcement.
+        assert "gatewayAPI.enabled=true" in joined
+
+    def test_full_auth_enabled_rejects_unknown_preset(self):
+        result = runner.invoke(
+            app, ["system", "install", "--full-auth-enabled", "nonsense"]
+        )
+        assert result.exit_code != 0
+        assert "Invalid full-auth preset" in strip_ansi(result.output)
+
+    def test_gateway_api_strict_standalone_without_auth(self):
+        """--gateway-api-strict alone emits the strict value without an auth preset."""
+        from unittest.mock import patch
+        from types import SimpleNamespace
+
+        captured = {}
+
+        def fake_helm(args, check=True, **kwargs):
+            if "upgrade" in args and any(
+                "kaos-operator" in a or a.endswith("/chart") for a in args
+            ):
+                captured["args"] = args
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("kaos_cli.install.check_helm_installed", return_value=True), patch(
+            "kaos_cli.install.run_helm_command", side_effect=fake_helm
+        ), patch("kaos_cli.install._run_kubectl") as mock_kubectl:
+            mock_kubectl.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            result = runner.invoke(
+                app,
+                [
+                    "system",
+                    "install",
+                    "--gateway-api-strict",
+                    "--chart-path",
+                    "operator/chart",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        joined = " ".join(captured.get("args", []))
+        assert "security.strictGatewayApi.enabled=true" in joined
+        # No auth preset means no agentAuth wiring.
+        assert "security.agentAuth.extAuthzUrl=" not in joined
         """--monitoring-enabled without value defaults to signoz (not an invalid backend error)."""
         from unittest.mock import patch
 

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -881,10 +881,9 @@ class TestSystemInstallFlags:
         result = runner.invoke(app, ["system", "install", "--help"])
         assert result.exit_code == 0
         output = strip_ansi(result.output)
-        assert "--full-auth-enabled" in output
+        assert "--auth-enabled" in output
         # The fine-grained auth knobs are collapsed into the preset and no longer
         # exposed on the command surface.
-        assert "--auth-enabled" not in output
         assert "--authz-provider" not in output
         assert "--agent-jwt-verification" not in output
         # Advanced dev chart paths remain available but hidden from help.
@@ -896,7 +895,7 @@ class TestAuthWiring:
     def _stub_gateway_install(self):
         """Stub the gateway install/wait helpers so preset-driven installs.
 
-        The full-auth presets force --gateway-enabled, which otherwise polls the
+        The auth presets force --gateway-enabled, which otherwise polls the
         cluster for GatewayClass acceptance for 60s. Tests here assert on the
         operator --set wiring, not the gateway bootstrap, so short-circuit it.
         """
@@ -943,7 +942,7 @@ class TestAuthWiring:
         )
 
     def test_auth_enabled_wires_operator_security_values(self):
-        """--full-auth-enabled adds the security.agentAuth.* helm --set args."""
+        """--auth-enabled adds the security.agentAuth.* helm --set args."""
         from unittest.mock import patch
 
         captured = {}
@@ -971,8 +970,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--full-auth-enabled",
-                    "keycloak-aib-enabled",
+                    "--auth-enabled",
+                    "aib-keycloak",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1305,7 +1304,7 @@ class TestAuthWiring:
         assert issuer == "http://keycloak.kc-ns.svc.cluster.local:8080/realms/kaos"
 
     def test_auth_enabled_wires_user_auth_values(self):
-        """keycloak-aib-enabled (user-auth on) adds security.userAuth.* args."""
+        """aib-keycloak (user-auth on) adds security.userAuth.* args."""
         from unittest.mock import patch
         from types import SimpleNamespace
 
@@ -1329,8 +1328,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--full-auth-enabled",
-                    "keycloak-aib-enabled",
+                    "--auth-enabled",
+                    "aib-keycloak",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1342,7 +1341,7 @@ class TestAuthWiring:
         assert "security.userAuth.audience=kaos" in joined
 
     def test_no_user_auth_omits_user_auth_values(self):
-        """kaos-internal-demo installs neither Keycloak nor the userAuth wiring."""
+        """kaos-internal installs neither Keycloak nor the userAuth wiring."""
         from unittest.mock import patch
         from types import SimpleNamespace
 
@@ -1368,8 +1367,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--full-auth-enabled",
-                    "kaos-internal-demo",
+                    "--auth-enabled",
+                    "kaos-internal",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1385,9 +1384,14 @@ class TestAuthWiring:
         # agent JWT.
         assert "security.agentAuth.authorization.provider=kaos" in joined
         assert "security.agentAuth.authorization.agentJwtVerification=skip" in joined
+        # The demo preset bakes in the policy ConfigMap projection target.
+        assert (
+            "security.agentAuth.projection.policyConfigMap.name=kaos-authz-policy"
+            in joined
+        )
 
     def test_keycloak_install_applies_realm_and_deployment(self):
-        """keycloak-aib-enabled applies the realm ConfigMap and Keycloak deployment."""
+        """aib-keycloak applies the realm ConfigMap and Keycloak deployment."""
         from unittest.mock import patch
         from types import SimpleNamespace
 
@@ -1407,8 +1411,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--full-auth-enabled",
-                    "keycloak-aib-enabled",
+                    "--auth-enabled",
+                    "aib-keycloak",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1442,8 +1446,8 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--full-auth-enabled",
-                    "keycloak-aib-enabled",
+                    "--auth-enabled",
+                    "aib-keycloak",
                     "--keycloak-chart-path",
                     "charts/keycloak",
                     "--chart-path",
@@ -1456,10 +1460,10 @@ class TestAuthWiring:
         assert "charts/keycloak" in joined
         assert "realmImport.configMapName=keycloak-realm-import" in joined
 
-    def test_expand_full_auth_preset_keycloak_aib(self):
-        from kaos_cli.install import _expand_full_auth_preset
+    def test_expand_auth_preset_keycloak_aib(self):
+        from kaos_cli.install import _expand_auth_preset
 
-        kwargs = _expand_full_auth_preset("keycloak-aib-enabled")
+        kwargs = _expand_auth_preset("aib-keycloak", "kaos-system")
         assert kwargs["auth_enabled"] is True
         assert kwargs["user_auth"] is True
         assert kwargs["token_exchange"] is True
@@ -1467,18 +1471,32 @@ class TestAuthWiring:
         assert kwargs["authz_gateway_extension"] == "ext_proc"
         assert kwargs["agent_jwt_verification"] == "verified"
 
-    def test_expand_full_auth_preset_kaos_demo(self):
-        from kaos_cli.install import _expand_full_auth_preset
+    def test_expand_auth_preset_kaos_internal(self):
+        from kaos_cli.install import _expand_auth_preset
 
-        kwargs = _expand_full_auth_preset("kaos-internal-demo")
+        kwargs = _expand_auth_preset("kaos-internal", "kaos-system")
         assert kwargs["auth_enabled"] is True
         assert kwargs["user_auth"] is False
         assert kwargs["token_exchange"] is False
         assert kwargs["authz_provider"] == "kaos"
         assert kwargs["agent_jwt_verification"] == "skip"
+        # The demo preset bakes in the policy ConfigMap projection target so no
+        # extra flags are needed for the operator to project policy data.
+        assert kwargs["policy_configmap_name"] == "kaos-authz-policy"
+        assert kwargs["policy_configmap_namespace"] == "kaos-system"
 
-    def test_full_auth_enabled_without_value_defaults_to_keycloak_aib(self):
-        """--full-auth-enabled with no value selects the keycloak-aib preset."""
+    def test_expand_auth_preset_aib_only(self):
+        from kaos_cli.install import _expand_auth_preset
+
+        kwargs = _expand_auth_preset("aib-only", "kaos-system")
+        assert kwargs["auth_enabled"] is True
+        assert kwargs["user_auth"] is False
+        assert kwargs["token_exchange"] is False
+        assert kwargs["authz_provider"] == "aib"
+        assert kwargs["agent_jwt_verification"] == "verified"
+
+    def test_auth_enabled_without_value_defaults_to_aib_keycloak(self):
+        """--auth-enabled with no value selects the keycloak-aib preset."""
         from unittest.mock import patch
         from types import SimpleNamespace
 
@@ -1502,7 +1520,7 @@ class TestAuthWiring:
                 [
                     "system",
                     "install",
-                    "--full-auth-enabled",
+                    "--auth-enabled",
                     "--chart-path",
                     "operator/chart",
                 ],
@@ -1514,12 +1532,10 @@ class TestAuthWiring:
         # Preset implies the gateway is installed for enforcement.
         assert "gatewayAPI.enabled=true" in joined
 
-    def test_full_auth_enabled_rejects_unknown_preset(self):
-        result = runner.invoke(
-            app, ["system", "install", "--full-auth-enabled", "nonsense"]
-        )
+    def test_auth_enabled_rejects_unknown_preset(self):
+        result = runner.invoke(app, ["system", "install", "--auth-enabled", "nonsense"])
         assert result.exit_code != 0
-        assert "Invalid full-auth preset" in strip_ansi(result.output)
+        assert "Invalid auth preset" in strip_ansi(result.output)
 
     def test_gateway_api_strict_standalone_without_auth(self):
         """--gateway-api-strict alone emits the strict value without an auth preset."""

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -1045,6 +1045,79 @@ class TestAuthWiring:
         )
         assert "security.agentAuth.extProcUrl=" not in " ".join(args)
 
+    def test_build_auth_operator_args_kaos_authorization(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            authz_provider="kaos",
+            policy_data_source="automated",
+            agent_jwt_verification="verified",
+            policy_configmap_name="kaos-authz-policy",
+            policy_configmap_namespace="aib-system",
+        )
+        joined = " ".join(args)
+        assert "security.agentAuth.authorization.provider=kaos" in joined
+        assert "security.agentAuth.authorization.policyDataSource=automated" in joined
+        assert (
+            "security.agentAuth.authorization.agentJwtVerification=verified" in joined
+        )
+        assert (
+            "security.agentAuth.projection.policyConfigMap.name=kaos-authz-policy"
+            in joined
+        )
+        assert (
+            "security.agentAuth.projection.policyConfigMap.namespace=aib-system"
+            in joined
+        )
+
+    def test_build_auth_operator_args_rego_override(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            authz_provider="kaos",
+            policy_data_source="manual",
+            policy_rego_override=True,
+        )
+        joined = " ".join(args)
+        assert "security.agentAuth.authorization.policyRegoOverride=true" in joined
+        assert "security.agentAuth.authorization.policyDataSource=manual" in joined
+
+    def test_build_auth_operator_args_broker_external_off_switch(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            admin_url="http://aib.aib-system:8000/api",
+            authz_provider="aib",
+            policy_data_source="external",
+            authz_gateway_extension="ext_authz",
+        )
+        joined = " ".join(args)
+        assert "security.agentAuth.authorization.provider=aib" in joined
+        assert "security.agentAuth.authorization.policyDataSource=external" in joined
+        assert "security.agentAuth.authorization.gatewayExtension=ext_authz" in joined
+        assert "security.agentAuth.adminUrl=http://aib.aib-system:8000/api" in joined
+
+    def test_build_auth_operator_args_omits_authorization_when_unset(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+        )
+        joined = " ".join(args)
+        assert "security.agentAuth.authorization" not in joined
+        assert "security.agentAuth.projection.policyConfigMap" not in joined
+
     def test_build_auth_operator_args_network_policy_default_on(self):
         from kaos_cli.install import _build_auth_operator_args
 

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -1343,6 +1343,18 @@ class TestAuthWiring:
         assert "urn:ietf:params:oauth:grant-type:token-exchange" in joined
         assert "broker.tokenExchange.expectedAudience=token-exchange-broker" in joined
 
+    def test_build_aib_broker_public_url_args(self):
+        from kaos_cli.install import _build_aib_broker_public_url_args
+
+        public_url = (
+            "http://aib-agentic-identity-broker.aib-system.svc.cluster.local:8000"
+        )
+        args = _build_aib_broker_public_url_args(public_url)
+        assert args == [
+            "--set",
+            f"broker.server.enduser.publicUrl={public_url}",
+        ]
+
     def test_keycloak_realm_json_registers_extproc_client(self):
         from kaos_cli.install import (
             AUTH_EXT_PROC_CLIENT_ID,

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -1187,6 +1187,28 @@ class TestAuthWiring:
         assert "security.gatewayRouting.enabled=true" not in joined
         assert "security.gatewayHost=" not in joined
 
+    def test_build_auth_operator_args_gateway_api_strict(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+            gateway_api_strict=True,
+        )
+        joined = " ".join(args)
+        assert "security.strictGatewayApi.enabled=true" in joined
+
+    def test_build_auth_operator_args_omits_strict_when_default(self):
+        from kaos_cli.install import _build_auth_operator_args
+
+        args = _build_auth_operator_args(
+            "aib-access-check-grpc.aib-system:9191",
+            "http://aib.aib-system:8000",
+            "kaos-aib",
+        )
+        assert "security.strictGatewayApi.enabled=true" not in " ".join(args)
+
     def test_build_auth_operator_args_tls_self_signed(self):
         from kaos_cli.install import _build_auth_operator_args
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build docker-build deploy generate manifests test test-unit clean envtest helm kind-create kind-delete kind-load-images kind-e2e-install-kaos kind-e2e-run-tests e2e-test e2e-test-seq e2e-clean kind-load-aib-images kind-e2e-install-aib e2e-test-aib kind-e2e-aib
+.PHONY: help build docker-build deploy generate manifests test test-unit test-chart clean envtest helm kind-create kind-delete kind-load-images kind-e2e-install-kaos kind-e2e-run-tests e2e-test e2e-test-seq e2e-clean kind-load-aib-images kind-e2e-install-aib e2e-test-aib kind-e2e-aib
 
 # Configuration
 IMG ?= axsauze/kaos-operator:latest
@@ -70,6 +70,10 @@ test-unit: generate manifests envtest
 
 # Alias for backward compatibility
 test: test-unit
+
+# Render the operator chart across the authorization mode combinations
+test-chart:
+	./chart/tests/render_authz_modes.sh
 
 # Generate Helm chart from kustomize manifests
 # CRDs are moved to crds/ dir so --skip-crds works properly during install

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -188,7 +188,7 @@ kind-e2e-install-aib:
 	@pip install -e ../kaos-cli -q 2>/dev/null || true
 	@kaos system install \
 		--namespace kaos-system \
-		--auth-enabled --no-user-auth --no-token-exchange \
+		--auth-enabled aib-only \
 		--gateway-enabled --metallb-enabled \
 		--chart-path chart/ \
 		--set controllerManager.manager.image.repository=$(REGISTRY)/kaos-operator \
@@ -219,14 +219,9 @@ kind-e2e-install-authz:
 	@pip install -e ../kaos-cli -q 2>/dev/null || true
 	@kaos system install \
 		--namespace kaos-system \
-		--auth-enabled --no-user-auth --no-token-exchange \
+		--auth-enabled kaos-internal \
 		--gateway-enabled --metallb-enabled \
 		--chart-path chart/ \
-		--authz-provider kaos \
-		--policy-data-source automated \
-		--agent-jwt-verification skip \
-		--policy-configmap-name $(AUTHZ_POLICY_CONFIGMAP) \
-		--policy-configmap-namespace $(AUTHZ_POLICY_NAMESPACE) \
 		--set controllerManager.manager.image.repository=$(REGISTRY)/kaos-operator \
 		--set controllerManager.manager.image.tag=$(AIB_OPERATOR_TAG) \
 		--set defaultImages.agentRuntime=$(AIB_AGENT_IMAGE) \

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build docker-build deploy generate manifests test test-unit test-chart clean envtest helm kind-create kind-delete kind-load-images kind-e2e-install-kaos kind-e2e-run-tests e2e-test e2e-test-seq e2e-clean kind-load-aib-images kind-e2e-install-aib e2e-test-aib kind-e2e-aib
+.PHONY: help build docker-build deploy generate manifests test test-unit test-chart clean envtest helm kind-create kind-delete kind-load-images kind-e2e-install-kaos kind-e2e-run-tests e2e-test e2e-test-seq e2e-clean kind-load-aib-images kind-e2e-install-aib e2e-test-aib kind-e2e-aib kind-e2e-install-authz e2e-test-authz kind-e2e-authz
 
 # Configuration
 IMG ?= axsauze/kaos-operator:latest
@@ -204,3 +204,40 @@ e2e-test-aib:
 
 # Full local agent-auth E2E: load images, install, run the test.
 kind-e2e-aib: kind-load-aib-images kind-e2e-install-aib e2e-test-aib
+
+# --- Authorization projection E2E (KAOS-owned Model-1 policy ConfigMap) -------
+# Opt-in, local-only suite that installs the operator with the KAOS
+# authorization provider and a policy ConfigMap projection target, then verifies
+# the operator renders the static rego and a grant graph and keeps grants stable
+# across reconciles. Model-1 is KAOS-owned so it needs no identity broker.
+AUTHZ_POLICY_CONFIGMAP ?= kaos-authz-policy
+AUTHZ_POLICY_NAMESPACE ?= kaos-system
+
+# Install KAOS with the KAOS authorization provider and automated policy-data
+# projection into the policy ConfigMap the enforcement engine mounts.
+kind-e2e-install-authz:
+	@pip install -e ../kaos-cli -q 2>/dev/null || true
+	@kaos system install \
+		--namespace kaos-system \
+		--auth-enabled --no-user-auth --no-token-exchange \
+		--gateway-enabled --metallb-enabled \
+		--chart-path chart/ \
+		--authz-provider kaos \
+		--policy-data-source automated \
+		--agent-jwt-verification skip \
+		--policy-configmap-name $(AUTHZ_POLICY_CONFIGMAP) \
+		--policy-configmap-namespace $(AUTHZ_POLICY_NAMESPACE) \
+		--set controllerManager.manager.image.repository=$(REGISTRY)/kaos-operator \
+		--set controllerManager.manager.image.tag=$(AIB_OPERATOR_TAG) \
+		--set defaultImages.agentRuntime=$(AIB_AGENT_IMAGE) \
+		--wait
+
+# Run only the authorization projection test against an installed cluster.
+e2e-test-authz:
+	@cd tests && KAOS_AUTHZ_E2E=1 \
+		KAOS_AUTHZ_POLICY_CONFIGMAP=$(AUTHZ_POLICY_CONFIGMAP) \
+		KAOS_AUTHZ_POLICY_NAMESPACE=$(AUTHZ_POLICY_NAMESPACE) \
+		uv run pytest e2e/test_authz_policy_projection_e2e.py -v -s
+
+# Full local authorization E2E: load images, install, run the test.
+kind-e2e-authz: kind-load-aib-images kind-e2e-install-authz e2e-test-authz

--- a/operator/chart/templates/deployment.yaml
+++ b/operator/chart/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       {{- include "chart.selectorLabels" . | nindent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        checksum/config: {{ include (print $.Template.BasePath "/operator-configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -62,12 +62,14 @@ data:
   SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX: {{ .credentialSecretPrefix | quote }}
   {{- end }}
   {{- if .adminUrl }}
-  # Identity projection: when an admin URL is set the operator registers agents,
-  # mints per-agent credential Secrets, and projects services/permission sets
-  # into the broker admin API.
+  # Broker identity projection: when an admin URL is set the operator registers
+  # agents, mints per-agent credential Secrets, and (unless the external
+  # off-switch is selected) projects services/permission sets into the broker
+  # admin API.
   AIB_ADMIN_URL: {{ .adminUrl | quote }}
   AIB_PRINCIPAL: {{ .adminPrincipal | default "kaos-operator" | quote }}
   AIB_PRINCIPAL_HEADER: {{ .adminPrincipalHeader | default "X-Remote-User" | quote }}
+  {{- end }}
   {{- with .projection }}
   {{- if .namespaces }}
   AUTHZ_PROJECTION_NAMESPACES: {{ .namespaces | quote }}
@@ -79,7 +81,6 @@ data:
   {{- if and .name .namespace }}
   AUTHZ_POLICY_CONFIGMAP_NAME: {{ .name | quote }}
   AUTHZ_POLICY_CONFIGMAP_NAMESPACE: {{ .namespace | quote }}
-  {{- end }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -114,6 +114,9 @@ data:
   {{- if and .gatewayRouting .gatewayRouting.enabled }}
   SECURITY_GATEWAY_ROUTING_ENABLED: "true"
   {{- end }}
+  {{- if and .strictGatewayApi .strictGatewayApi.enabled }}
+  SECURITY_STRICT_GATEWAY_API_ENABLED: "true"
+  {{- end }}
   {{- end }}
   # Global telemetry configuration (defaults for all components)
   {{- if .Values.telemetry.enabled }}

--- a/operator/chart/tests/render_authz_modes.sh
+++ b/operator/chart/tests/render_authz_modes.sh
@@ -77,6 +77,20 @@ out="$(render \
 expect "ext_authz extension" "$out" 'SECURITY_AUTHORIZATION_GATEWAY_EXTENSION:\s*"ext_authz"'
 expect "ext_authz url" "$out" 'SECURITY_AGENT_AUTH_EXT_AUTHZ_URL:\s*"http://authz:9000"'
 
+# The controller-manager pod carries a config checksum so that changes to the
+# operator ConfigMap (e.g. enabling agent auth) roll the pod automatically.
+default_out="$(render)"
+expect "config checksum annotation present" "$default_out" 'checksum/config:\s*[0-9a-f]{64}'
+default_sum="$(grep -oE 'checksum/config:\s*[0-9a-f]{64}' <<<"$default_out" | grep -oE '[0-9a-f]{64}')"
+changed_out="$(render --set security.agentAuth.adminUrl=http://aib:8000/api)"
+changed_sum="$(grep -oE 'checksum/config:\s*[0-9a-f]{64}' <<<"$changed_out" | grep -oE '[0-9a-f]{64}')"
+if [[ "$default_sum" != "$changed_sum" ]]; then
+	echo "ok   - config checksum changes when the ConfigMap changes"
+else
+	echo "FAIL - config checksum did not change when the ConfigMap changed"
+	FAIL=1
+fi
+
 if [[ "$FAIL" -ne 0 ]]; then
 	echo "chart authorization render tests FAILED"
 	exit 1

--- a/operator/chart/tests/render_authz_modes.sh
+++ b/operator/chart/tests/render_authz_modes.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Renders the operator chart across the authorization mode combinations and
+# asserts the operator ConfigMap carries the expected settings for each mode.
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FAIL=0
+
+render() {
+	helm template t "$CHART_DIR" "$@" 2>/dev/null
+}
+
+# assert PATTERN present in the rendered output for a described case
+expect() {
+	local desc="$1" out="$2" pattern="$3"
+	if grep -qE "$pattern" <<<"$out"; then
+		echo "ok   - $desc"
+	else
+		echo "FAIL - $desc (missing: $pattern)"
+		FAIL=1
+	fi
+}
+
+# assert PATTERN absent from the rendered output
+refute() {
+	local desc="$1" out="$2" pattern="$3"
+	if grep -qE "$pattern" <<<"$out"; then
+		echo "FAIL - $desc (unexpected: $pattern)"
+		FAIL=1
+	else
+		echo "ok   - $desc"
+	fi
+}
+
+# Default install: no authorization provider is rendered.
+out="$(render)"
+refute "default omits authorization provider" "$out" 'SECURITY_AUTHORIZATION_PROVIDER'
+
+# KAOS provider, automated policy data source, with a policy ConfigMap target.
+out="$(render \
+	--set security.agentAuth.authorization.provider=kaos \
+	--set security.agentAuth.authorization.policyDataSource=automated \
+	--set security.agentAuth.projection.policyConfigMap.name=kaos-authz-policy \
+	--set security.agentAuth.projection.policyConfigMap.namespace=aib-system)"
+expect "kaos provider set" "$out" 'SECURITY_AUTHORIZATION_PROVIDER:\s*"kaos"'
+expect "automated data source" "$out" 'SECURITY_AUTHORIZATION_POLICY_DATA_SOURCE:\s*"automated"'
+expect "policy configmap name" "$out" 'AUTHZ_POLICY_CONFIGMAP_NAME:\s*"kaos-authz-policy"'
+expect "policy configmap namespace" "$out" 'AUTHZ_POLICY_CONFIGMAP_NAMESPACE:\s*"aib-system"'
+
+# KAOS provider, operator-rego override (admin authors the grant data).
+out="$(render \
+	--set security.agentAuth.authorization.provider=kaos \
+	--set security.agentAuth.authorization.policyDataSource=manual \
+	--set security.agentAuth.authorization.policyRegoOverride=true)"
+expect "rego override set" "$out" 'SECURITY_AUTHORIZATION_POLICY_REGO_OVERRIDE:\s*"true"'
+expect "manual data source" "$out" 'SECURITY_AUTHORIZATION_POLICY_DATA_SOURCE:\s*"manual"'
+
+# Broker provider, external off-switch.
+out="$(render \
+	--set security.agentAuth.authorization.provider=aib \
+	--set security.agentAuth.authorization.policyDataSource=external \
+	--set security.agentAuth.adminUrl=http://aib:8000/api)"
+expect "aib provider set" "$out" 'SECURITY_AUTHORIZATION_PROVIDER:\s*"aib"'
+expect "external data source" "$out" 'SECURITY_AUTHORIZATION_POLICY_DATA_SOURCE:\s*"external"'
+expect "broker admin url" "$out" 'AIB_ADMIN_URL:\s*"http://aib:8000/api"'
+
+# Verified agent JWT verification mode.
+out="$(render \
+	--set security.agentAuth.authorization.provider=kaos \
+	--set security.agentAuth.authorization.agentJwtVerification=verified)"
+expect "verified jwt mode" "$out" 'SECURITY_AUTHORIZATION_AGENT_JWT_VERIFICATION:\s*"verified"'
+
+# ext_authz enforcement extension.
+out="$(render \
+	--set security.agentAuth.authorization.gatewayExtension=ext_authz \
+	--set security.agentAuth.extAuthzUrl=http://authz:9000)"
+expect "ext_authz extension" "$out" 'SECURITY_AUTHORIZATION_GATEWAY_EXTENSION:\s*"ext_authz"'
+expect "ext_authz url" "$out" 'SECURITY_AGENT_AUTH_EXT_AUTHZ_URL:\s*"http://authz:9000"'
+
+if [[ "$FAIL" -ne 0 ]]; then
+	echo "chart authorization render tests FAILED"
+	exit 1
+fi
+echo "chart authorization render tests PASSED"

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -186,6 +186,15 @@ security:
   # only application path between workloads.
   gatewayRouting:
     enabled: false
+  # strictGatewayApi turns on gateway-only strict traffic: it enables
+  # NetworkPolicy isolation and gateway-routed URLs together, independently of
+  # whether any authorization enforcement hook (extAuthzUrl/extProcUrl) is set.
+  # Use it to make the Envoy Gateway the only application path between workloads
+  # as a standalone posture. It overrides the networkPolicy.enabled escape hatch.
+  # Enforcement of the generated NetworkPolicy still requires a CNI that enforces
+  # it (e.g. Calico; the default kindnet does not). Off by default.
+  strictGatewayApi:
+    enabled: false
   # tls configures HTTPS termination on the Gateway's external boundary. When
   # mode is empty, only the HTTP listener is created and behavior is unchanged.
   tls:

--- a/operator/controllers/authz_projection_controller.go
+++ b/operator/controllers/authz_projection_controller.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kaosv1alpha1 "github.com/axsaucedo/kaos/operator/api/v1alpha1"
@@ -42,18 +43,20 @@ type AuthzProjectionReconciler struct {
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
-// SetupWithManager registers the controller, watching the three KAOS kinds and
-// funnelling every event to the sentinel request so bursts coalesce into one full
-// reconcile.
+// SetupWithManager registers the controller. Every watched-resource change funnels
+// to the sentinel request so bursts coalesce into a single whole-world reconcile.
+// A generation-changed predicate filters out status-only updates and periodic
+// resyncs, so the projection only recomputes when a spec that feeds it changes.
 func (r *AuthzProjectionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	toSentinel := handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []reconcile.Request {
 		return []reconcile.Request{authzSentinel}
 	})
+	specChanged := builder.WithPredicates(predicate.GenerationChangedPredicate{})
 	return builder.ControllerManagedBy(mgr).
 		Named(authzProjectionControllerName).
-		Watches(&kaosv1alpha1.Agent{}, toSentinel).
-		Watches(&kaosv1alpha1.MCPServer{}, toSentinel).
-		Watches(&kaosv1alpha1.ModelAPI{}, toSentinel).
+		Watches(&kaosv1alpha1.Agent{}, toSentinel, specChanged).
+		Watches(&kaosv1alpha1.MCPServer{}, toSentinel, specChanged).
+		Watches(&kaosv1alpha1.ModelAPI{}, toSentinel, specChanged).
 		Complete(r)
 }
 

--- a/operator/internal/authz/adapters/projector_aib.go
+++ b/operator/internal/authz/adapters/projector_aib.go
@@ -76,28 +76,33 @@ type AIBAdmin interface {
 
 // BrokerProjector applies authorization state to the identity broker.
 type BrokerProjector struct {
-	Client       client.Client
-	Scheme       *runtime.Scheme
-	AIB          AIBAdmin
-	SecretPrefix string
-	Prune        bool
+	Client             client.Client
+	Scheme             *runtime.Scheme
+	AIB                AIBAdmin
+	SecretPrefix       string
+	Prune              bool
+	BindPermissionSets bool
 }
 
 // Apply registers services, permission sets, agents and credential Secrets.
 func (p *BrokerProjector) Apply(ctx context.Context, desired projection.DesiredState) error {
 	logger := log.FromContext(ctx)
-	serviceIDs, err := p.applyServices(ctx, desired)
-	if err != nil {
-		return err
-	}
-	permissionSetIDs, err := p.applyPermissionSets(ctx, desired, serviceIDs)
-	if err != nil {
-		return err
+	var serviceIDs, permissionSetIDs map[string]string
+	var err error
+	if p.BindPermissionSets {
+		serviceIDs, err = p.applyServices(ctx, desired)
+		if err != nil {
+			return err
+		}
+		permissionSetIDs, err = p.applyPermissionSets(ctx, desired, serviceIDs)
+		if err != nil {
+			return err
+		}
 	}
 
 	var minted, failed int
 	for _, agent := range desired.Agents {
-		did, agentErr := p.reconcileAgent(ctx, agent, permissionSetIDs)
+		did, agentErr := p.reconcileAgent(ctx, agent, permissionSetIDs, p.BindPermissionSets)
 		if agentErr != nil {
 			failed++
 			logger.Error(agentErr, "agent reconcile failed", "agent", agent.ExternalID())
@@ -108,7 +113,7 @@ func (p *BrokerProjector) Apply(ctx context.Context, desired projection.DesiredS
 		}
 	}
 
-	if p.Prune {
+	if p.Prune && p.BindPermissionSets {
 		if err := p.prune(ctx, serviceIDs, permissionSetIDs, desired); err != nil {
 			logger.Error(err, "prune pass failed")
 		}
@@ -153,14 +158,16 @@ func (p *BrokerProjector) applyPermissionSets(ctx context.Context, desired proje
 	return ids, nil
 }
 
-func (p *BrokerProjector) reconcileAgent(ctx context.Context, agent projection.DesiredAgent, permissionSetIDs map[string]string) (bool, error) {
+func (p *BrokerProjector) reconcileAgent(ctx context.Context, agent projection.DesiredAgent, permissionSetIDs map[string]string, bindSets bool) (bool, error) {
 	bound := make([]string, 0, len(agent.PermissionSetNames))
-	for _, name := range agent.PermissionSetNames {
-		id, ok := permissionSetIDs[name]
-		if !ok {
-			return false, fmt.Errorf("permission set unavailable: %s", name)
+	if bindSets {
+		for _, name := range agent.PermissionSetNames {
+			id, ok := permissionSetIDs[name]
+			if !ok {
+				return false, fmt.Errorf("permission set unavailable: %s", name)
+			}
+			bound = append(bound, id)
 		}
-		bound = append(bound, id)
 	}
 
 	agentID, err := p.AIB.CreateOrGet(ctx, "agents", "display_name", agent.ExternalID(), AgentBody(agent, bound))

--- a/operator/internal/authz/adapters/projector_aib_test.go
+++ b/operator/internal/authz/adapters/projector_aib_test.go
@@ -19,13 +19,18 @@ import (
 // fakeAIB is an in-memory AIBAdmin recording created records and minted creds.
 type fakeAIB struct {
 	created map[string][]string
+	listed  map[string][]map[string]any
 	minted  int
 	deleted int
 }
 
-func newFakeAIB() *fakeAIB { return &fakeAIB{created: map[string][]string{}} }
+func newFakeAIB() *fakeAIB {
+	return &fakeAIB{created: map[string][]string{}, listed: map[string][]map[string]any{}}
+}
 
-func (f *fakeAIB) List(context.Context, string) ([]map[string]any, error) { return nil, nil }
+func (f *fakeAIB) List(_ context.Context, collection string) ([]map[string]any, error) {
+	return f.listed[collection], nil
+}
 
 func (f *fakeAIB) CreateOrGet(_ context.Context, collection, _, matchValue string, _ map[string]any) (string, error) {
 	f.created[collection] = append(f.created[collection], matchValue)
@@ -215,4 +220,42 @@ func TestBrokerProjectorExternalOffSwitchProjectsIdentityOnly(t *testing.T) {
 	if admin.deleted != 0 {
 		t.Fatalf("prune deleted %d records in off-switch mode", admin.deleted)
 	}
+}
+
+func TestBrokerProjectorPruneIsGatedByAuthorizationProjection(t *testing.T) {
+	staleService := map[string]any{"id": "svc-stale", "client_id": "kaos-mcpserver-demo-stale"}
+
+	t.Run("automated broker mode prunes stale records", func(t *testing.T) {
+		scheme := newTestScheme(t)
+		admin := newFakeAIB()
+		admin.listed["services"] = []map[string]any{staleService}
+		p := &BrokerProjector{
+			Client: fake.NewClientBuilder().WithScheme(scheme).Build(), Scheme: scheme, AIB: admin,
+			SecretPrefix: "kaos-aib", Prune: true, BindPermissionSets: true,
+		}
+
+		if err := p.Apply(context.Background(), projection.DesiredState{}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		if admin.deleted == 0 {
+			t.Fatal("expected prune to delete the stale record in automated mode")
+		}
+	})
+
+	t.Run("external off-switch never prunes even with prune enabled", func(t *testing.T) {
+		scheme := newTestScheme(t)
+		admin := newFakeAIB()
+		admin.listed["services"] = []map[string]any{staleService}
+		p := &BrokerProjector{
+			Client: fake.NewClientBuilder().WithScheme(scheme).Build(), Scheme: scheme, AIB: admin,
+			SecretPrefix: "kaos-aib", Prune: true, BindPermissionSets: false,
+		}
+
+		if err := p.Apply(context.Background(), projection.DesiredState{}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		if admin.deleted != 0 {
+			t.Fatalf("prune deleted %d records despite the off-switch", admin.deleted)
+		}
+	})
 }

--- a/operator/internal/authz/adapters/projector_aib_test.go
+++ b/operator/internal/authz/adapters/projector_aib_test.go
@@ -46,7 +46,7 @@ func TestBrokerProjectorMintsCredentialSecret(t *testing.T) {
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent).Build()
 	admin := newFakeAIB()
-	p := &BrokerProjector{Client: c, Scheme: scheme, AIB: admin, SecretPrefix: "kaos-aib", Prune: false}
+	p := &BrokerProjector{Client: c, Scheme: scheme, AIB: admin, SecretPrefix: "kaos-aib", Prune: false, BindPermissionSets: true}
 	desired := projection.Project([]projection.Resource{resourceFromAgent(agent)})
 
 	if err := p.Apply(context.Background(), desired); err != nil {

--- a/operator/internal/authz/adapters/projector_aib_test.go
+++ b/operator/internal/authz/adapters/projector_aib_test.go
@@ -20,6 +20,7 @@ import (
 type fakeAIB struct {
 	created map[string][]string
 	minted  int
+	deleted int
 }
 
 func newFakeAIB() *fakeAIB { return &fakeAIB{created: map[string][]string{}} }
@@ -31,7 +32,10 @@ func (f *fakeAIB) CreateOrGet(_ context.Context, collection, _, matchValue strin
 	return collection + ":" + matchValue, nil
 }
 
-func (f *fakeAIB) Delete(context.Context, string, string) (bool, error) { return false, nil }
+func (f *fakeAIB) Delete(context.Context, string, string) (bool, error) {
+	f.deleted++
+	return true, nil
+}
 
 func (f *fakeAIB) MintCredentials(context.Context, string) (aib.Credentials, error) {
 	f.minted++
@@ -174,5 +178,41 @@ func TestAdminBodiesCarryNoApprovalStatus(t *testing.T) {
 		if len(entry) != 2 || entry["requirement_type"] != "mandatory" {
 			t.Fatalf("binding entry = %v", entry)
 		}
+	}
+}
+
+func TestBrokerProjectorExternalOffSwitchProjectsIdentityOnly(t *testing.T) {
+	scheme := newTestScheme(t)
+	agent := &kaosv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "demo", Name: "researcher"},
+		Spec:       kaosv1alpha1.AgentSpec{MCPServers: []string{"github"}, ModelAPI: "gpt"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent).Build()
+	admin := newFakeAIB()
+	p := &BrokerProjector{Client: c, Scheme: scheme, AIB: admin, SecretPrefix: "kaos-aib", Prune: true, BindPermissionSets: false}
+	desired := projection.Project([]projection.Resource{resourceFromAgent(agent), {
+		Kind: projection.MCPServer.ResourceKind, Namespace: "demo", Name: "github",
+	}})
+
+	if err := p.Apply(context.Background(), desired); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if admin.minted != 1 {
+		t.Fatalf("minted = %d, want 1", admin.minted)
+	}
+	if len(admin.created["agents"]) != 1 {
+		t.Fatalf("agents created = %v, want 1", admin.created["agents"])
+	}
+	secret := &corev1.Secret{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo", Name: "kaos-aib-researcher"}, secret); err != nil {
+		t.Fatalf("expected credential secret: %v", err)
+	}
+	if len(admin.created["services"]) != 0 || len(admin.created["permission-sets"]) != 0 {
+		t.Fatalf("authorization projected in off-switch: services=%v permission-sets=%v",
+			admin.created["services"], admin.created["permission-sets"])
+	}
+	if admin.deleted != 0 {
+		t.Fatalf("prune deleted %d records in off-switch mode", admin.deleted)
 	}
 }

--- a/operator/internal/authz/adapters/projector_kaos.go
+++ b/operator/internal/authz/adapters/projector_kaos.go
@@ -16,11 +16,12 @@ const authzManagedBy = "kaos-operator-authz"
 
 // ConfigMapProjector applies authorization policy and grant data to a ConfigMap.
 type ConfigMapProjector struct {
-	Client     client.Client
-	Name       string
-	Namespace  string
-	JWKSURI    string
-	JWKSClient *http.Client
+	Client         client.Client
+	Name           string
+	Namespace      string
+	JWKSURI        string
+	JWKSClient     *http.Client
+	WriteGrantData bool
 }
 
 // Apply renders the authorization policy and projected grant data and applies
@@ -29,18 +30,22 @@ func (p *ConfigMapProjector) Apply(ctx context.Context, desired projection.Desir
 	if p.Name == "" || p.Namespace == "" {
 		return nil
 	}
-	grants := projection.GrantData(desired)
-	var jwks map[string]any
-	if p.JWKSURI != "" {
-		fetched, err := authz.FetchJWKS(ctx, p.JWKSClient, p.JWKSURI)
+	data := map[string]string{authz.PolicyKey: authz.Policy()}
+	if p.WriteGrantData {
+		grants := projection.GrantData(desired)
+		var jwks map[string]any
+		if p.JWKSURI != "" {
+			fetched, err := authz.FetchJWKS(ctx, p.JWKSClient, p.JWKSURI)
+			if err != nil {
+				return err
+			}
+			jwks = fetched
+		}
+		dataDoc, err := authz.DataDocument(grants, jwks)
 		if err != nil {
 			return err
 		}
-		jwks = fetched
-	}
-	data, err := authz.ConfigMapData(grants, jwks)
-	if err != nil {
-		return err
+		data[authz.DataKey] = string(dataDoc)
 	}
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},

--- a/operator/internal/authz/adapters/projector_kaos_test.go
+++ b/operator/internal/authz/adapters/projector_kaos_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -104,4 +105,32 @@ func TestConfigMapProjectorInjectsJWKSInVerifiedMode(t *testing.T) {
 
 func contains(s, sub string) bool {
 	return strings.Contains(s, sub)
+}
+
+func TestConfigMapProjectorLeavesBYOConfigMapUntouched(t *testing.T) {
+	scheme := newTestScheme(t)
+	agent := &kaosv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "demo", Name: "researcher"},
+		Spec:       kaosv1alpha1.AgentSpec{MCPServers: []string{"github"}},
+	}
+	byo := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "aib-system", Name: "kaos-authz-policy"},
+		Data: map[string]string{
+			"policy.rego": "package admin.owned\n",
+			"data.json":   `{"kaos":{"grants":{"admin":["x"]}}}`,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, byo).Build()
+	p := &ConfigMapProjector{Client: c}
+
+	if err := p.Apply(context.Background(), projection.Project([]projection.Resource{resourceFromAgent(agent)})); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	got := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "aib-system", Name: "kaos-authz-policy"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !reflect.DeepEqual(got.Data, byo.Data) {
+		t.Fatalf("operator clobbered admin ConfigMap: %v", got.Data)
+	}
 }

--- a/operator/internal/authz/adapters/projector_kaos_test.go
+++ b/operator/internal/authz/adapters/projector_kaos_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kaosv1alpha1 "github.com/axsaucedo/kaos/operator/api/v1alpha1"
@@ -132,5 +133,42 @@ func TestConfigMapProjectorLeavesBYOConfigMapUntouched(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.Data, byo.Data) {
 		t.Fatalf("operator clobbered admin ConfigMap: %v", got.Data)
+	}
+}
+
+func TestConfigMapProjectorRegoOverrideLeavesAdminDataUntouched(t *testing.T) {
+	scheme := newTestScheme(t)
+	agent := &kaosv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "demo", Name: "researcher"},
+		Spec:       kaosv1alpha1.AgentSpec{MCPServers: []string{"github"}},
+	}
+	adminData := `{"kaos":{"grants":{"kaos://agent/demo/researcher":["kaos://mcpserver/demo/other"]}}}`
+	adminCM := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "aib-system", Name: "kaos-authz-policy"},
+		Data:       map[string]string{"data.json": adminData},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent).Build()
+	if err := c.Patch(context.Background(), adminCM, client.Apply, client.FieldOwner("admin")); err != nil {
+		t.Fatalf("admin apply: %v", err)
+	}
+	p := &ConfigMapProjector{Client: c, Name: "kaos-authz-policy", Namespace: "aib-system", WriteGrantData: false}
+	desired := projection.Project([]projection.Resource{resourceFromAgent(agent)})
+
+	for i := 0; i < 2; i++ {
+		if err := p.Apply(context.Background(), desired); err != nil {
+			t.Fatalf("apply %d: %v", i, err)
+		}
+	}
+
+	got := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "aib-system", Name: "kaos-authz-policy"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Data["policy.rego"] == "" {
+		t.Fatalf("operator did not write policy.rego: %v", got.Data)
+	}
+	if got.Data["data.json"] != adminData {
+		t.Fatalf("operator clobbered admin-authored data.json: %q", got.Data["data.json"])
 	}
 }

--- a/operator/internal/authz/adapters/projector_kaos_test.go
+++ b/operator/internal/authz/adapters/projector_kaos_test.go
@@ -24,7 +24,7 @@ func TestConfigMapProjectorWritesPolicyConfigMap(t *testing.T) {
 		Spec:       kaosv1alpha1.AgentSpec{MCPServers: []string{"github"}},
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mcp, agent).Build()
-	p := &ConfigMapProjector{Client: c, Name: "kaos-authz-policy", Namespace: "aib-system"}
+	p := &ConfigMapProjector{Client: c, Name: "kaos-authz-policy", Namespace: "aib-system", WriteGrantData: true}
 	desired := projection.Project([]projection.Resource{resourceFromAgent(agent), {
 		Kind: projection.MCPServer.ResourceKind, Namespace: "demo", Name: "github",
 	}})
@@ -85,7 +85,7 @@ func TestConfigMapProjectorInjectsJWKSInVerifiedMode(t *testing.T) {
 	}
 	mcp := &kaosv1alpha1.MCPServer{ObjectMeta: metav1.ObjectMeta{Namespace: "demo", Name: "github"}}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, mcp).Build()
-	p := &ConfigMapProjector{Client: c, Name: "kaos-authz-policy", Namespace: "aib-system", JWKSURI: srv.URL}
+	p := &ConfigMapProjector{Client: c, Name: "kaos-authz-policy", Namespace: "aib-system", JWKSURI: srv.URL, WriteGrantData: true}
 	desired := projection.Project([]projection.Resource{resourceFromAgent(agent), {
 		Kind: projection.MCPServer.ResourceKind, Namespace: "demo", Name: "github",
 	}})

--- a/operator/internal/authz/data-schema.md
+++ b/operator/internal/authz/data-schema.md
@@ -1,0 +1,41 @@
+# KAOS authorization data schema (`data.json`)
+
+The enforcement policy (`policy.rego`) reads a single OPA data document from the
+policy ConfigMap key `data.json`. This document is a published contract: an admin
+authors it directly in the operator-rego mode, and the operator projects it in the
+automated mode. Both produce the same shape.
+
+```json
+{
+  "kaos": {
+    "grants": {
+      "<actor-id>": ["<resource-id>", "..."]
+    },
+    "jwks": {
+      "keys": [ { "kty": "RSA", "kid": "...", "n": "...", "e": "AQAB" } ]
+    }
+  }
+}
+```
+
+## `kaos.grants` (required)
+
+Maps an actor identity to the sorted, de-duplicated set of resource identities it
+may reach.
+
+- **Actor id** — the agent logical identity `kaos://agent/<namespace>/<name>`. It
+  is the `sub` claim of the agent (actor) token carried in the
+  `x-agent-authorization` header.
+- **Resource id** — the target logical identity `kaos://<slug>/<namespace>/<name>`
+  (`slug` is `mcpserver`, `modelapi`, or `agent`). It is matched against the
+  `x-kaos-target-resource` header the gateway stamps onto the request.
+
+A request is allowed only when the request's resource id is present in the
+granting array for the request's actor id.
+
+## `kaos.jwks` (optional)
+
+The IdP JSON Web Key Set used to verify the actor token signature. Its presence
+switches the policy from demo mode (decode without verifying, spoofable,
+non-production) to verified mode (`io.jwt.decode_verify` against these keys before
+trusting the `sub`). Omit it only in demo/non-production installs.

--- a/operator/internal/authz/policy_parity_test.rego
+++ b/operator/internal/authz/policy_parity_test.rego
@@ -1,0 +1,64 @@
+package aib.extproc.authz
+
+import rego.v1
+
+# Parity coverage: the enforcement policy answers "can user A reach resource X via
+# agent B" from one OPA input that carries all fact sources at once — the subject
+# identity (Authorization header), the actor identity (x-agent-authorization
+# header), and the requested resource (x-kaos-target-resource header) — evaluated
+# against the projected grant graph. The same input shape backs both providers;
+# only the grant facts differ in origin (KAOS-owned data here, broker
+# granted_permission_sets for the broker provider).
+
+# A demo-mode actor token (decoded, not verified) whose sub is the agent identity.
+actor_jwt := io.jwt.encode_sign(
+	{"alg": "HS256"},
+	{"sub": "kaos://agent/demo/researcher"},
+	{"kty": "oct", "k": "c2VjcmV0"},
+)
+
+# A subject (user) token present in the same request, proving the subject fact is
+# available alongside the actor and resource facts.
+subject_jwt := io.jwt.encode_sign(
+	{"alg": "HS256"},
+	{"sub": "user-alice@example.com"},
+	{"kty": "oct", "k": "c2VjcmV0"},
+)
+
+request_input(resource) := {"attributes": {"request": {"http": {"headers": {
+	"authorization": sprintf("Bearer %v", [subject_jwt]),
+	"x-agent-authorization": actor_jwt,
+	"x-kaos-target-resource": resource,
+}}}}}
+
+grants := {"kaos://agent/demo/researcher": ["kaos://mcpserver/demo/github"]}
+
+test_allows_when_actor_granted_resource if {
+	out := result with input as request_input("kaos://mcpserver/demo/github")
+		with data.kaos.grants as grants
+	out.action == "allow"
+}
+
+test_denies_when_actor_not_granted_resource if {
+	out := result with input as request_input("kaos://mcpserver/demo/secret")
+		with data.kaos.grants as grants
+	out.action == "deny"
+}
+
+test_denies_when_no_target_resource if {
+	out := result with input as {"attributes": {"request": {"http": {"headers": {
+		"authorization": sprintf("Bearer %v", [subject_jwt]),
+		"x-agent-authorization": actor_jwt,
+	}}}}}
+		with data.kaos.grants as grants
+	out.action == "deny"
+}
+
+test_denies_when_no_actor_token if {
+	out := result with input as {"attributes": {"request": {"http": {"headers": {
+		"authorization": sprintf("Bearer %v", [subject_jwt]),
+		"x-kaos-target-resource": "kaos://mcpserver/demo/github",
+	}}}}}
+		with data.kaos.grants as grants
+	out.action == "deny"
+}

--- a/operator/internal/authz/policy_rego_test.go
+++ b/operator/internal/authz/policy_rego_test.go
@@ -1,0 +1,37 @@
+package authz
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestPolicyRegoUnitTests runs the OPA rego unit tests for the enforcement policy
+// against a real OPA evaluation. It uses the opa binary from the OPA environment
+// variable or PATH and skips when neither is available, so it validates locally
+// and in any CI job that provides opa without failing environments that do not.
+func TestPolicyRegoUnitTests(t *testing.T) {
+	opa := os.Getenv("OPA")
+	if opa == "" {
+		found, err := exec.LookPath("opa")
+		if err != nil {
+			t.Skip("opa binary not found (set OPA or add opa to PATH to run policy tests)")
+		}
+		opa = found
+	}
+
+	policy, err := filepath.Abs("policy.rego")
+	if err != nil {
+		t.Fatalf("resolving policy path: %v", err)
+	}
+	tests, err := filepath.Abs("policy_parity_test.rego")
+	if err != nil {
+		t.Fatalf("resolving policy test path: %v", err)
+	}
+
+	out, err := exec.Command(opa, "test", policy, tests).CombinedOutput()
+	if err != nil {
+		t.Fatalf("opa test failed: %v\n%s", err, out)
+	}
+}

--- a/operator/internal/projection/projection.go
+++ b/operator/internal/projection/projection.go
@@ -1,12 +1,13 @@
-// Package projection turns KAOS resources into the desired Agentic Identity
-// Broker (AIB) state. It is pure (no I/O) so it can be unit tested without a
-// cluster or a broker.
+// Package projection turns KAOS resources into a provider-agnostic authorization
+// graph. It is pure (no I/O) so it can be unit tested without a cluster, and the
+// same graph feeds both projection sinks: the KAOS policy-data path (grant map
+// for OPA) and the broker path (services, permission sets and agents).
 //
-// Each edge target <ns>/<name> of kind <slug> becomes a synthetic AIB service
-// whose client_id is kaos-<slug>-<ns>-<name> exposing a single "call" scope.
-// Each requested edge Agent -> target becomes a permission set granting that
-// scope, and each Agent becomes a local AIB agent bound to the permission sets
-// for its requested edges. The resource an agent is authorized against is
+// Each edge target <ns>/<name> of kind <slug> becomes a synthetic service whose
+// client_id is kaos-<slug>-<ns>-<name> exposing a single "call" scope. Each
+// requested edge Agent -> target becomes a permission set granting that scope,
+// and each Agent becomes a projected agent bound to the permission sets for its
+// requested edges. The resource an agent is authorized against is
 // kaos://<slug>/<ns>/<name>, which is unique by construction.
 package projection
 
@@ -27,7 +28,8 @@ const (
 	permissionSetPrefix = "kaos:"
 )
 
-// EdgeKind is an edge target kind and the vocabulary used to encode it into AIB.
+// EdgeKind is an edge target kind and the vocabulary used to encode it into the
+// projected authorization graph.
 type EdgeKind struct {
 	Slug             string // identifier segment, e.g. "mcpserver" / "modelapi"
 	ResourceKind     string // KAOS resource kind, e.g. "MCPServer" / "ModelAPI"
@@ -77,7 +79,8 @@ func edgePermissionSetName(kind EdgeKind, namespace, name string) string {
 	return fmt.Sprintf("kaos:%s:%s:%s", kind.Slug, segment, CallScope)
 }
 
-// AgentExternalID is the stable external identity for a KAOS agent in AIB.
+// AgentExternalID is the stable external identity for a KAOS agent in the
+// projected authorization graph.
 func AgentExternalID(namespace, name string) string {
 	return ResolveLogicalID(AgentSlug, namespace, name)
 }
@@ -117,14 +120,14 @@ func IsValidAgentExternalID(externalID string) bool {
 	return true
 }
 
-// DesiredService is a synthetic AIB service projected from an edge target.
+// DesiredService is a synthetic service projected from an edge target.
 type DesiredService struct {
 	Namespace string
 	Name      string
 	Kind      EdgeKind
 }
 
-// ClientID is the synthetic broker client_id for the service.
+// ClientID is the synthetic client_id for the service.
 func (s DesiredService) ClientID() string {
 	return edgeServiceClientID(s.Kind, s.Namespace, s.Name)
 }
@@ -136,7 +139,7 @@ type DesiredPermissionSet struct {
 	Kind      EdgeKind
 }
 
-// Name is the broker permission-set name.
+// Name is the permission-set name.
 func (p DesiredPermissionSet) Name() string {
 	return edgePermissionSetName(p.Kind, p.Namespace, p.Target)
 }
@@ -154,29 +157,30 @@ func (p DesiredPermissionSet) ResourceID() string {
 	return ResolveLogicalID(p.Kind.Slug, p.Namespace, p.Target)
 }
 
-// DesiredAgent is a local AIB agent projected from a KAOS Agent and its edges.
+// DesiredAgent is a projected agent derived from a KAOS Agent and its edges.
 type DesiredAgent struct {
 	Namespace          string
 	Name               string
 	PermissionSetNames []string
 }
 
-// ExternalID is the stable external identity for the agent in AIB.
+// ExternalID is the stable external identity for the agent in the projected
+// authorization graph.
 func (a DesiredAgent) ExternalID() string {
 	return AgentExternalID(a.Namespace, a.Name)
 }
 
-// DesiredState is the full desired AIB state projected from KAOS resources.
+// DesiredState is the full authorization graph projected from KAOS resources.
 type DesiredState struct {
 	Services       []DesiredService
 	PermissionSets []DesiredPermissionSet
 	Agents         []DesiredAgent
 }
 
-// Project turns a list of KAOS resources into the desired AIB state. MCP server
-// edges, the model API edge and agent->agent access edges are all projected so
-// an agent is authorized against every external dependency and peer it declares.
-// Agents with no edges are skipped. Logical identity is always
+// Project turns a list of KAOS resources into the desired authorization graph.
+// MCP server edges, the model API edge and agent->agent access edges are all
+// projected so an agent is authorized against every external dependency and peer
+// it declares. Agents with no edges are skipped. Logical identity is always
 // kaos://<slug>/<ns>/<name>, so identities are unique by construction and need
 // no conflict resolution.
 func Project(resources []Resource) DesiredState {

--- a/operator/main.go
+++ b/operator/main.go
@@ -109,14 +109,29 @@ func main() {
 	// The authorization projection controller applies the configured provider.
 	// Provider "none" (default) leaves the operator without any projection.
 	if provider := security.GetConfig().AuthzProviderOrDefault(); provider != security.AuthzProviderNone {
+		cfg := security.GetConfig()
+		policyDataSource := cfg.PolicyDataSourceOrDefault()
+		regoOverride := cfg.PolicyRegoOverride
+
+		brokerProjection := provider == security.AuthzProviderAIB
+		brokerAuthorizationProjection := brokerProjection && policyDataSource != security.PolicyDataExternal
+		policyDataProjection := provider == security.AuthzProviderKAOS &&
+			(policyDataSource == security.PolicyDataAutomated || regoOverride)
+		writeGrantData := provider == security.AuthzProviderKAOS &&
+			policyDataSource == security.PolicyDataAutomated && !regoOverride
+		prune := getBoolWithDefault("AUTHZ_PROJECTION_PRUNE_ENABLED", true) && brokerAuthorizationProjection
+
 		var projector controllers.PolicyProjector
 		switch provider {
 		case security.AuthzProviderKAOS:
-			projector = &adapters.ConfigMapProjector{
-				Client:    mgr.GetClient(),
-				Name:      os.Getenv("AUTHZ_POLICY_CONFIGMAP_NAME"),
-				Namespace: os.Getenv("AUTHZ_POLICY_CONFIGMAP_NAMESPACE"),
-				JWKSURI:   security.GetConfig().AuthzJWKSURI(),
+			if policyDataProjection {
+				projector = &adapters.ConfigMapProjector{
+					Client:         mgr.GetClient(),
+					Name:           os.Getenv("AUTHZ_POLICY_CONFIGMAP_NAME"),
+					Namespace:      os.Getenv("AUTHZ_POLICY_CONFIGMAP_NAMESPACE"),
+					JWKSURI:        cfg.AuthzJWKSURI(),
+					WriteGrantData: writeGrantData,
+				}
 			}
 		case security.AuthzProviderAIB:
 			projector = &adapters.BrokerProjector{
@@ -128,8 +143,9 @@ func main() {
 					getEnvWithDefault("AIB_PRINCIPAL_HEADER", "X-Remote-User"),
 					getDurationWithDefault("AIB_REQUEST_TIMEOUT", 10*time.Second),
 				),
-				SecretPrefix: getEnvWithDefault("SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX", "kaos-aib"),
-				Prune:        getBoolWithDefault("AUTHZ_PROJECTION_PRUNE_ENABLED", true),
+				SecretPrefix:       getEnvWithDefault("SECURITY_AGENT_AUTH_CREDENTIAL_SECRET_PREFIX", "kaos-aib"),
+				Prune:              prune,
+				BindPermissionSets: brokerAuthorizationProjection,
 			}
 		}
 		if err = (&controllers.AuthzProjectionReconciler{

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -94,6 +94,15 @@ type Config struct {
 	// gateway to be the only application path between workloads.
 	GatewayRouting bool
 
+	// StrictGatewayAPI turns on gateway-only strict traffic
+	// (security.strictGatewayApi.enabled): NetworkPolicy isolation plus
+	// gateway-routed URLs, independent of whether any authorization enforcement
+	// hook is configured. It bundles the two because they are only useful
+	// together — isolation without routing breaks connectivity, routing without
+	// isolation is trivially bypassed. Default off; enforcement of the generated
+	// NetworkPolicy still requires a CNI that enforces it (e.g. Calico).
+	StrictGatewayAPI bool
+
 	// AuthzProvider selects which authorization provider the operator projects
 	// and enforces at the ext_proc OPA decision point
 	// (security.authorization.provider). "none" (default) means authorization
@@ -191,6 +200,7 @@ const (
 	envNetworkPolicyEgress    = "SECURITY_NETWORK_POLICY_EGRESS_ENABLED"
 	envGatewayHost            = "SECURITY_GATEWAY_HOST"
 	envGatewayRouting         = "SECURITY_GATEWAY_ROUTING_ENABLED"
+	envStrictGatewayAPI       = "SECURITY_STRICT_GATEWAY_API_ENABLED"
 	envAuthzProvider          = "SECURITY_AUTHORIZATION_PROVIDER"
 	envGatewayEnforcementExt  = "SECURITY_AUTHORIZATION_GATEWAY_EXTENSION"
 	envAgentJWTVerification   = "SECURITY_AUTHORIZATION_AGENT_JWT_VERIFICATION"
@@ -224,6 +234,7 @@ func GetConfig() Config {
 		NetworkPolicyEgress:              parseBoolEnv(envNetworkPolicyEgress),
 		GatewayHost:                      os.Getenv(envGatewayHost),
 		GatewayRouting:                   parseBoolEnv(envGatewayRouting),
+		StrictGatewayAPI:                 parseBoolEnv(envStrictGatewayAPI),
 		AuthzProvider:                    AuthzProvider(readEnumEnv(envAuthzProvider)),
 		AuthzGatewayEnforcementExtension: AuthzGatewayEnforcementExtension(readEnumEnv(envGatewayEnforcementExt)),
 		AgentJWTVerificationMode:         AgentJWTVerificationMode(readEnumEnv(envAgentJWTVerification)),
@@ -376,12 +387,13 @@ func (c Config) ExtProcEnabled() bool {
 }
 
 // NetworkPolicyEnabled reports whether the operator should generate a
-// NetworkPolicy for each protected workload. It requires security to be enabled
-// (any enforcement hook) and the escape hatch not to be set. When true, direct
-// workload-to-workload application traffic is denied so the Gateway cannot be
-// bypassed.
+// NetworkPolicy for each protected workload. It is true when strict gateway-only
+// traffic is requested (independent of any enforcement hook), or when security is
+// enabled (any enforcement hook) and the escape hatch is not set. When true,
+// direct workload-to-workload application traffic is denied so the Gateway cannot
+// be bypassed.
 func (c Config) NetworkPolicyEnabled() bool {
-	return c.SecurityEnabled() && !c.NetworkPolicyDisabled
+	return c.StrictGatewayAPI || (c.SecurityEnabled() && !c.NetworkPolicyDisabled)
 }
 
 // NetworkPolicyEgressEnabled reports whether generated NetworkPolicies should
@@ -415,12 +427,13 @@ func (c Config) OperatorNamespaceOrDefault() string {
 
 // GatewayRoutingEnabled reports whether the operator should inject gateway-routed
 // endpoint URLs into agents so internal agent->MCP/ModelAPI/peer traffic flows
-// through the gateway. It is off unless explicitly enabled. The actual gateway
-// host is resolved separately (explicit GatewayHost or the Gateway status
-// address); when no host can be resolved the controller falls back to direct
-// Service URLs so connectivity is never silently broken.
+// through the gateway. It is on when gateway routing is explicitly enabled or when
+// strict gateway-only traffic is requested (which bundles routing with isolation).
+// The actual gateway host is resolved separately (explicit GatewayHost or the
+// Gateway status address); when no host can be resolved the controller falls back
+// to direct Service URLs so connectivity is never silently broken.
 func (c Config) GatewayRoutingEnabled() bool {
-	return c.GatewayRouting
+	return c.GatewayRouting || c.StrictGatewayAPI
 }
 
 // ExtAuthzBackendRef parses the configured ext_authz host:port URL into the

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -307,20 +307,47 @@ func TestNetworkPolicyEnabled(t *testing.T) {
 		name       string
 		extAuthz   string
 		npDisabled bool
+		strict     bool
 		want       bool
 	}{
-		{"operational and not disabled", "svc:9191", false, true},
-		{"operational but disabled", "svc:9191", true, false},
-		{"not operational", "", false, false},
-		{"not operational and disabled", "", true, false},
+		{"operational and not disabled", "svc:9191", false, false, true},
+		{"operational but disabled", "svc:9191", true, false, false},
+		{"not operational", "", false, false, false},
+		{"not operational and disabled", "", true, false, false},
+		{"strict standalone without any hook", "", false, true, true},
+		{"strict overrides the escape hatch", "", true, true, true},
+		{"strict with operational", "svc:9191", false, true, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := Config{ExtAuthzURL: tc.extAuthz, NetworkPolicyDisabled: tc.npDisabled}
+			cfg := Config{ExtAuthzURL: tc.extAuthz, NetworkPolicyDisabled: tc.npDisabled, StrictGatewayAPI: tc.strict}
 			if got := cfg.NetworkPolicyEnabled(); got != tc.want {
 				t.Errorf("NetworkPolicyEnabled() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestGatewayRoutingEnabledWithStrict(t *testing.T) {
+	if !(Config{StrictGatewayAPI: true}).GatewayRoutingEnabled() {
+		t.Errorf("expected strict gateway API to enable gateway routing")
+	}
+	if !(Config{StrictGatewayAPI: true}).NetworkPolicyEnabled() {
+		t.Errorf("expected strict gateway API to enable NetworkPolicy standalone")
+	}
+	if (Config{}).GatewayRoutingEnabled() {
+		t.Errorf("expected gateway routing off with no flags")
+	}
+}
+
+func TestGetConfigReadsStrictGatewayAPI(t *testing.T) {
+	t.Setenv("SECURITY_STRICT_GATEWAY_API_ENABLED", "true")
+	cfg := GetConfig()
+	if !cfg.StrictGatewayAPI {
+		t.Errorf("expected StrictGatewayAPI true")
+	}
+	if !cfg.NetworkPolicyEnabled() || !cfg.GatewayRoutingEnabled() {
+		t.Errorf("expected strict gateway API to enable NetworkPolicy and gateway routing standalone")
 	}
 }
 

--- a/operator/pkg/security/networkpolicy_test.go
+++ b/operator/pkg/security/networkpolicy_test.go
@@ -239,6 +239,29 @@ func TestReconcileNetworkPolicyCreatesWhenOperational(t *testing.T) {
 	}
 }
 
+func TestReconcileNetworkPolicyCreatesWhenStrictStandalone(t *testing.T) {
+	scheme := reconcileScheme(t)
+	owner := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcp-github", Namespace: "default", UID: "owner-uid"},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).Build()
+
+	// No enforcement hook is configured; the strict switch alone must still
+	// generate the bypass-prevention NetworkPolicy.
+	cfg := Config{StrictGatewayAPI: true}
+	params := NetworkPolicyParams{
+		Name: "mcp-github", Namespace: "default", PodSelector: mcpPodSelector(),
+	}
+	if err := ReconcileNetworkPolicy(context.Background(), cl, scheme, owner, params, cfg, logr.Discard()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &networkingv1.NetworkPolicy{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "mcp-github", Namespace: "default"}, got); err != nil {
+		t.Fatalf("expected NetworkPolicy to be created under strict standalone config: %v", err)
+	}
+}
+
 func TestReconcileNetworkPolicyNoopWhenNotEnabled(t *testing.T) {
 	scheme := reconcileScheme(t)
 	owner := &corev1.ConfigMap{

--- a/operator/tests/e2e/test_authz_policy_projection_e2e.py
+++ b/operator/tests/e2e/test_authz_policy_projection_e2e.py
@@ -1,0 +1,176 @@
+"""End-to-end test for the KAOS-owned authorization policy projection.
+
+Validates the Model-1 authorization path where the operator projects KAOS
+resources into a single policy ConfigMap that the enforcement engine (OPA in
+ext_proc) mounts:
+
+1. The operator's authorization projection controller renders a static
+   ``policy.rego`` and, in the default ``automated`` policy-data source, a
+   ``data.json`` grant graph keyed on each agent's logical identity.
+2. Repeated reconciles are idempotent: the rego is stable and the grant data
+   keeps every projected agent, proving the projection never clobbers prior
+   grants as new agents appear.
+
+This test is opt-in: it requires a cluster installed with the KAOS
+authorization provider and the policy ConfigMap projection target
+(``--authz-provider kaos --policy-data-source automated
+--policy-configmap-name ... --policy-configmap-namespace ...``); see the
+``kind-e2e-authz`` make target. It is skipped unless ``KAOS_AUTHZ_E2E`` is set
+so the default E2E suite, which runs without authorization, is unaffected.
+"""
+
+import json
+import os
+import time
+
+import pytest
+from sh import kubectl
+
+from e2e.conftest import (
+    create_custom_resource,
+    create_modelapi_resource,
+    create_agent_resource,
+    wait_for_deployment,
+    wait_for_modelapi_ready,
+)
+
+POLICY_CONFIGMAP_NAME = os.environ.get(
+    "KAOS_AUTHZ_POLICY_CONFIGMAP", "kaos-authz-policy"
+)
+POLICY_CONFIGMAP_NAMESPACE = os.environ.get(
+    "KAOS_AUTHZ_POLICY_NAMESPACE", "kaos-system"
+)
+
+pytestmark = [
+    pytest.mark.aib,
+    pytest.mark.skipif(
+        not os.environ.get("KAOS_AUTHZ_E2E"),
+        reason="authorization projection e2e requires a KAOS-authz install; "
+        "set KAOS_AUTHZ_E2E=1",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def authz_namespace():
+    """Create an isolated namespace for the authorization projection e2e."""
+    namespace = f"e2e-authz-{int(time.time()) % 100000}"
+    kubectl("create", "namespace", namespace)
+    yield namespace
+    try:
+        kubectl("delete", "namespace", namespace, "--wait=false")
+    except Exception:
+        pass
+
+
+def _get_policy_configmap() -> dict:
+    out = kubectl(
+        "get",
+        "configmap",
+        POLICY_CONFIGMAP_NAME,
+        "-n",
+        POLICY_CONFIGMAP_NAMESPACE,
+        "-o",
+        "json",
+    )
+    return json.loads(str(out))
+
+
+def _wait_for_policy_key(key: str, timeout: int = 180) -> dict:
+    """Poll until the policy ConfigMap exists and carries the named key."""
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            cm = _get_policy_configmap()
+            if key in cm.get("data", {}):
+                return cm
+        except Exception as exc:  # ConfigMap not created yet
+            last_err = exc
+        time.sleep(3)
+    raise TimeoutError(
+        f"policy ConfigMap key {key!r} not projected after {timeout}s "
+        f"(last error: {last_err})"
+    )
+
+
+def _grant_subjects(cm: dict) -> dict:
+    """Return the data.kaos.grants map from the projected data.json key."""
+    data_json = cm.get("data", {}).get("data.json", "")
+    assert data_json, "policy ConfigMap missing data.json"
+    parsed = json.loads(data_json)
+    return parsed.get("kaos", {}).get("grants", {})
+
+
+def test_operator_projects_and_maintains_policy_configmap(authz_namespace: str):
+    """The operator renders the policy ConfigMap and keeps grants across agents."""
+    namespace = authz_namespace
+    modelapi_name = "authz-mock-proxy"
+    first_agent = "authz-agent-a"
+    second_agent = "authz-agent-b"
+
+    # A LiteLLM proxy ModelAPI gives the agents a backend so they can roll out.
+    modelapi_spec = create_modelapi_resource(namespace, modelapi_name)
+    create_custom_resource(modelapi_spec, namespace)
+    wait_for_deployment(namespace, f"modelapi-{modelapi_name}", timeout=180)
+    wait_for_modelapi_ready(namespace, modelapi_name, timeout=180)
+
+    create_custom_resource(
+        create_agent_resource(
+            namespace=namespace,
+            modelapi_name=modelapi_name,
+            mcpserver_names=[],
+            agent_name=first_agent,
+        ),
+        namespace,
+    )
+
+    # 1. The operator must render the static rego and the grant data.
+    cm = _wait_for_policy_key("policy.rego")
+    assert cm["data"]["policy.rego"].strip(), "policy.rego is empty"
+    cm = _wait_for_policy_key("data.json")
+    rego_before = cm["data"]["policy.rego"]
+
+    def _has_agent(agent_name: str, timeout: int = 180) -> dict:
+        deadline = time.time() + timeout
+        last = None
+        while time.time() < deadline:
+            current = _get_policy_configmap()
+            grants = _grant_subjects(current)
+            key = f"kaos://agent/{namespace}/{agent_name}"
+            if any(agent_name in k for k in grants) or key in grants:
+                return current
+            last = list(grants.keys())
+            time.sleep(3)
+        raise TimeoutError(
+            f"agent {agent_name} not present in projected grants after {timeout}s "
+            f"(last grant keys: {last})"
+        )
+
+    _has_agent(first_agent)
+
+    # 2. Adding a second agent must extend the grant data without dropping the
+    #    first agent and without rewriting the static policy.
+    create_custom_resource(
+        create_agent_resource(
+            namespace=namespace,
+            modelapi_name=modelapi_name,
+            mcpserver_names=[],
+            agent_name=second_agent,
+        ),
+        namespace,
+    )
+    _has_agent(second_agent)
+
+    final = _get_policy_configmap()
+    grants = _grant_subjects(final)
+    present = {k for k in grants}
+    assert any(
+        first_agent in k for k in present
+    ), f"first agent grant dropped after second reconcile (keys={present})"
+    assert any(
+        second_agent in k for k in present
+    ), f"second agent grant missing (keys={present})"
+    assert (
+        final["data"]["policy.rego"] == rego_before
+    ), "static policy.rego changed across reconciles"


### PR DESCRIPTION
## Overview

Builds on #263 (coarse OPA-in-ext_proc authorization) to add operator-driven **authorization modes and enablement**: a single flag-gated projection controller derives what to render from the configured provider, policy-data source, and rego-override, so operators can pick automated, manual (operator-rego), bring-your-own, or external policy management without adapter/strategy indirection.

Stacked on top of #263 (`feat/opa-extproc-authorization`), which is stacked on #260.

## Highlights

- **Providers**: `none` / `kaos` / `aib` select the authorization backend; projection paths are gated on the provider so a disabled provider renders nothing.
- **Policy-data source modes** derived from config: automated (CRD-projected grants + rego), manual (operator-rego), and external (admin-owned), plus a rego-override switch for BYO policy.
- **No-clobber SSA**: per-key field ownership means the operator never overwrites admin-provided `data.json`; BYO ConfigMap and operator-rego paths are covered.
- **Broker off-switch**: with the broker external, projection degrades to identity-only.
- **CLI enablement**: `kaos system install` gains authorization flags to configure provider/mode at install time.
- **Verification/CI**: OPA rego parity is evaluated against real OPA in CI; opt-in policy-projection e2e asserts stable grant projection across reconciles.
- **Docs**: new authorization guide covering providers, modes, verification, and the published policy-data schema.

## Validation

- Go unit tests (with OPA installed) — green in CI.
- Python + CLI dry-run tests — green.
- E2E (all shards) — green.

## Generated changelog

10 commits; see the commit list on the PR.
