### PR TITLE
fix(cli): wait for agent port-forward readiness

### DIFF
--- a/kaos-cli/kaos_cli/agent/invoke.py
+++ b/kaos-cli/kaos_cli/agent/invoke.py
@@ -53,14 +53,25 @@ def invoke_command(
 
     signal.signal(signal.SIGINT, lambda s, f: (cleanup(), sys.exit(0)))
 
-    time.sleep(2)
-
-    if pf_process.poll() is not None:
-        stderr = pf_process.stderr.read().decode() if pf_process.stderr else ""
-        typer.echo(f"Error: Port-forward failed: {stderr}", err=True)
-        sys.exit(1)
-
     try:
+        last_error = "port-forward did not become ready"
+        for _ in range(90):
+            if pf_process.poll() is not None:
+                stderr = pf_process.stderr.read().decode() if pf_process.stderr else ""
+                typer.echo(f"Error: Port-forward failed: {stderr}", err=True)
+                sys.exit(1)
+            try:
+                health = httpx.get(f"http://localhost:{port}/health", timeout=2.0)
+                if health.status_code == 200:
+                    break
+                last_error = f"HTTP {health.status_code}"
+            except httpx.HTTPError as exc:
+                last_error = str(exc)
+            time.sleep(1)
+        else:
+            typer.echo(f"Error: Could not connect to Agent: {last_error}", err=True)
+            sys.exit(1)
+
         typer.echo(f"Sending message: {message}")
 
         try:
@@ -122,6 +133,7 @@ def invoke_command(
                     )
         except httpx.ConnectError:
             typer.echo("Error: Could not connect to Agent", err=True)
+            sys.exit(1)
         except Exception as e:
             typer.echo(f"Error: {e}", err=True)
     finally:

--- a/kaos-cli/tests/test_agent_invoke.py
+++ b/kaos-cli/tests/test_agent_invoke.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+import httpx
+
+from kaos_cli.agent.invoke import invoke_command
+
+
+class FakeProcess:
+    stderr = None
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        pass
+
+    def wait(self):
+        pass
+
+
+def test_invoke_waits_for_delayed_port_forward(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "subprocess.run", lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="8000")
+    )
+    monkeypatch.setattr("subprocess.Popen", lambda *args, **kwargs: FakeProcess())
+    monkeypatch.setattr("signal.signal", lambda *args: None)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    attempts = 0
+
+    def get(_url, **_kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise httpx.ConnectError("not ready")
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx, "get", get)
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda *args, **kwargs: httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "ready"}}]},
+        ),
+    )
+
+    invoke_command("test-agent", "test-ns", "hello", 19001, False)
+
+    assert attempts == 3
+    assert "ready" in capsys.readouterr().out


### PR DESCRIPTION
## What changed

- wait for the Agent port-forward health endpoint before invoking it instead of sleeping for a fixed two seconds
- fail with a non-zero exit when the Agent remains unreachable
- add a regression test covering delayed port-forward readiness

## Why

The memory blog end-to-end run on KIND reproduced `Error: Could not connect to Agent` when `kubectl port-forward` needed longer than two seconds to become usable. The existing fixed delay made invocation timing-dependent and also returned exit code zero for a connection failure.

## Impact

`kaos agent invoke` now tolerates slow cluster/API startup while retaining a bounded readiness window and reports connection failures correctly to scripts.

## Validation

- `cd kaos-cli && uv run pytest tests/ -q` — 114 passed
- live KIND invocation succeeded while the bound MemoryStore was absent, confirming the soft-degradation path
