### PR TITLE
Require gateway enforcement for user authentication

### DIFF
--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -37,7 +37,7 @@ Agent and user identity are selected independently:
 | `--agent-auth-enabled` | `service-account`, `aib`, `keycloak` | `service-account` |
 | `--user-auth-enabled` | `keycloak`, `none` | `keycloak` |
 
-With neither flag, security stays disabled. When either flag is present, the unspecified plane uses its default. `--user-auth-enabled none` disables the user plane. Enabled security includes the PDP, automated policy projection, internal gateway routing, and NetworkPolicy generation.
+With neither flag, security stays disabled. When either flag is present, the unspecified plane uses its default. `--user-auth-enabled none` disables the user plane. Enabled user authentication also enables strict Gateway API mode, which includes internal gateway routing and NetworkPolicy isolation; all authentication presets include the PDP and automated policy projection.
 
 The former presets map to the new flags as follows:
 

--- a/docs/security/walkthrough-user-identity.md
+++ b/docs/security/walkthrough-user-identity.md
@@ -4,7 +4,7 @@ The user identity plane carries the human subject independently of the agent act
 
 ## Gateway verification
 
-When `security.userAuth.issuer` is configured, the operator adds a `user` JWT provider to each protected gateway `SecurityPolicy`. The provider reads the standard header:
+When `security.userAuth.issuer` is configured, `security.strictGatewayApi.enabled=true` is required so direct workload routing cannot bypass the gateway. Strict mode includes gateway-routed internal URLs and NetworkPolicy isolation. The operator adds a `user` JWT provider to each protected gateway `SecurityPolicy`. The provider reads the standard header:
 
 ```http
 Authorization: Bearer <keycloak-user-jwt>

--- a/kaos-cli/kaos_cli/install.py
+++ b/kaos-cli/kaos_cli/install.py
@@ -1238,6 +1238,7 @@ def _expand_auth_flags(agent_mode: str, user_mode: str, namespace: str) -> dict:
         **base,
         "identity_provider": identity_provider,
         "user_auth": user_mode == "keycloak",
+        "gateway_api_strict": user_mode == "keycloak",
     }
     if agent_mode == "keycloak":
         result.update(

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -1647,6 +1647,7 @@ class TestAuthWiring:
             "policy_configmap_namespace": "kaos-system",
             "identity_provider": "aib",
             "user_auth": True,
+            "gateway_api_strict": True,
         }
 
     def test_expand_auth_flags_keycloak_oidc(self):
@@ -1667,6 +1668,7 @@ class TestAuthWiring:
             "oidc_registration_secret_name": "kaos-oidc-registration",
             "oidc_registration_secret_key": "token",
             "user_auth": True,
+            "gateway_api_strict": True,
         }
 
     def test_expand_auth_flags_kaos_internal(self):
@@ -1684,6 +1686,7 @@ class TestAuthWiring:
             "policy_configmap_namespace": "kaos-system",
             "identity_provider": "serviceaccount",
             "user_auth": False,
+            "gateway_api_strict": False,
         }
 
     def test_expand_auth_flags_aib_only(self):
@@ -1701,6 +1704,7 @@ class TestAuthWiring:
             "policy_configmap_namespace": "kaos-system",
             "identity_provider": "aib",
             "user_auth": False,
+            "gateway_api_strict": False,
         }
 
     @pytest.mark.parametrize(
@@ -1738,6 +1742,7 @@ class TestAuthWiring:
                     "security.userAuth.issuer=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos",
                     "security.userAuth.audience=kaos",
                     "security.gatewayRouting.enabled=true",
+                    "security.strictGatewayApi.enabled=true",
                 },
                 False,
                 True,
@@ -1780,6 +1785,7 @@ class TestAuthWiring:
                     "security.userAuth.issuer=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos",
                     "security.userAuth.audience=kaos",
                     "security.gatewayRouting.enabled=true",
+                    "security.strictGatewayApi.enabled=true",
                 },
                 True,
                 True,
@@ -1802,6 +1808,7 @@ class TestAuthWiring:
                     "security.userAuth.issuer=http://keycloak.keycloak.svc.cluster.local:8080/realms/kaos",
                     "security.userAuth.audience=kaos",
                     "security.gatewayRouting.enabled=true",
+                    "security.strictGatewayApi.enabled=true",
                 },
                 False,
                 True,

--- a/operator/chart/templates/operator-configmap.yaml
+++ b/operator/chart/templates/operator-configmap.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.security.userAuth.issuer (not .Values.security.strictGatewayApi.enabled) }}
+{{- fail "security.userAuth.issuer requires security.strictGatewayApi.enabled=true; strict mode enforces security.gatewayRouting.enabled and security.networkPolicy.enabled" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/chart/tests/render_authz_modes.sh
+++ b/operator/chart/tests/render_authz_modes.sh
@@ -40,6 +40,25 @@ refute "disabled PDP does not enable operator enforcement" "$out" 'SECURITY_PDP_
 expect "ServiceAccount identity is default" "$out" 'SECURITY_AGENT_AUTH_IDENTITY_PROVIDER:\s*"serviceaccount"'
 expect "gateway JWT is optional by default" "$out" 'SECURITY_AGENT_AUTH_GATEWAY_JWT_OPTIONAL:\s*"true"'
 
+if unguarded_user_auth="$(helm template t "$CHART_DIR" \
+	--set security.userAuth.issuer=https://users.example.test 2>&1)"; then
+	echo "FAIL - user auth without strict gateway enforcement was accepted"
+	FAIL=1
+elif grep -q 'security.userAuth.issuer requires security.strictGatewayApi.enabled=true' <<<"$unguarded_user_auth"; then
+	echo "ok   - user auth without strict gateway enforcement rejected clearly"
+else
+	echo "FAIL - user auth enforcement error was unclear"
+	FAIL=1
+fi
+
+out="$(render \
+	--set security.userAuth.issuer=https://users.example.test \
+	--set security.strictGatewayApi.enabled=true \
+	--set security.gatewayRouting.enabled=false \
+	--set security.networkPolicy.enabled=false)"
+expect "strict gateway enforcement permits user auth" "$out" 'SECURITY_USER_AUTH_ISSUER:\s*"https://users.example.test"'
+expect "strict gateway enforcement reaches operator" "$out" 'SECURITY_STRICT_GATEWAY_API_ENABLED:\s*"true"'
+
 out="$(render --set security.agentAuth.gatewayJwtOptional=false)"
 expect "gateway JWT can be blocking" "$out" 'SECURITY_AGENT_AUTH_GATEWAY_JWT_OPTIONAL:\s*"false"'
 
@@ -195,6 +214,7 @@ out="$(render \
 	--set security.agentAuth.issuer=https://keycloak.example/realms/kaos \
 	--set security.agentAuth.projection.policyConfigMap.name=kaos-authz-policy \
 	--set security.agentAuth.projection.policyConfigMap.namespace=default \
+	--set security.strictGatewayApi.enabled=true \
 	--set security.userAuth.issuer=https://keycloak.example/realms/kaos)"
 expect "token exchange feature gate" "$out" 'TOKEN_EXCHANGE_ENABLED:\s*"true"'
 expect "exchange AIB admin URL" "$out" 'TOKEN_EXCHANGE_AIB_ADMIN_URL:\s*"http://aib:14000/api"'
@@ -215,6 +235,7 @@ if incompatible_exchange="$(helm template t "$CHART_DIR" \
 	--set security.agentAuth.identity.provider=serviceaccount \
 	--set security.agentAuth.projection.policyConfigMap.name=kaos-authz-policy \
 	--set security.agentAuth.projection.policyConfigMap.namespace=default \
+	--set security.strictGatewayApi.enabled=true \
 	--set security.userAuth.issuer=https://keycloak.example/realms/kaos 2>&1)"; then
 	echo "FAIL - service-account token exchange posture was accepted"
 	FAIL=1

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -179,7 +179,8 @@ security:
   # userAuth configures the human user identity provider (e.g. Keycloak) whose
   # subject tokens are verified at the gateway alongside agent actor tokens. When
   # issuer is unset, no user jwt provider is generated (agent-only/autonomous
-  # installs); the block is independent of agentAuth.
+  # installs). A non-empty issuer requires strictGatewayApi so verification cannot
+  # be bypassed through direct workload routing; the block is independent of agentAuth.
   userAuth:
     # issuer is the user-auth OIDC issuer URL. Example:
     # http://keycloak.kaos-system.svc.cluster.local:8080/realms/kaos

--- a/operator/main.go
+++ b/operator/main.go
@@ -73,8 +73,14 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	startupSecurityConfig := security.GetConfig()
+	if err := startupSecurityConfig.Validate(); err != nil {
+		setupLog.Error(err, "invalid security configuration")
+		os.Exit(1)
+	}
+
 	restConfig := ctrl.GetConfigOrDie()
-	if security.GetConfig().ServiceAccountIdentityEnabled() {
+	if startupSecurityConfig.ServiceAccountIdentityEnabled() {
 		issuerKeys, discoveryErr := authz.DiscoverServiceAccountIssuer(context.Background(), restConfig)
 		if discoveryErr != nil {
 			setupLog.Error(discoveryErr, "unable to discover Kubernetes ServiceAccount issuer")

--- a/operator/pkg/security/config.go
+++ b/operator/pkg/security/config.go
@@ -294,6 +294,14 @@ func (c Config) UserPlaneEnabled() bool {
 	return Configured(c.UserIssuer)
 }
 
+// Validate rejects security configurations that could bypass user authentication.
+func (c Config) Validate() error {
+	if c.UserPlaneEnabled() && !c.StrictGatewayAPI {
+		return fmt.Errorf("%s requires %s=true; strict mode provides %s and overrides %s", envUserIssuer, envStrictGatewayAPI, envGatewayRouting, envNetworkPolicyDisabled)
+	}
+	return nil
+}
+
 // SecurityEnabled reports whether gateway authorization enforcement is configured.
 func (c Config) SecurityEnabled() bool {
 	return c.IsOperational()

--- a/operator/pkg/security/config_test.go
+++ b/operator/pkg/security/config_test.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -89,6 +90,34 @@ func TestUserPlaneEnabled(t *testing.T) {
 	}
 	if (Config{UserIssuer: "  "}).UserPlaneEnabled() {
 		t.Fatal("expected whitespace-only user issuer to leave the user plane disabled")
+	}
+}
+
+func TestValidateUserAuthRequiresStrictGatewayAPI(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{name: "user auth disabled", config: Config{}},
+		{name: "strict gateway enabled", config: Config{UserIssuer: "https://users.example", StrictGatewayAPI: true}},
+		{name: "strict overrides network policy disable", config: Config{UserIssuer: "https://users.example", StrictGatewayAPI: true, NetworkPolicyDisabled: true}},
+		{name: "user auth without enforcement", config: Config{UserIssuer: "https://users.example"}, wantErr: true},
+		{name: "routing alone is insufficient", config: Config{UserIssuer: "https://users.example", GatewayRouting: true}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "SECURITY_USER_AUTH_ISSUER requires SECURITY_STRICT_GATEWAY_API_ENABLED=true") {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- reject Helm user-auth configuration unless strict Gateway API enforcement is enabled
- fail operator startup when `SECURITY_USER_AUTH_ISSUER` is configured without strict enforcement
- make CLI user-auth presets enable strict mode and document the requirement
- cover chart failure/pass cases and operator validation behavior

Strict Gateway API is the single required signal because it already makes gateway routing and NetworkPolicy generation effective, including when their raw values are disabled.

## Verification

- `make test-chart`
- `helm lint chart`
- violating Helm render fails with the expected value names
- default and user-auth preset Helm renders pass
- `go test . ./pkg/security`
- `make test-unit` (Go 1.26 toolchain; 45/45 integration specs pass)
- `make generate manifests` leaves the worktree clean
- `kaos-cli`: 127 tests pass

Closes #284
