### PR TITLE
feat(memory): scope agent memory per OIDC user

### DIFF
--- a/docs/operator/memory-architecture.md
+++ b/docs/operator/memory-architecture.md
@@ -48,12 +48,25 @@ Every operation carries a **scope** that selects long-term read visibility and e
 
 | `scope` | Long-term read filter | Isolation boundary |
 |---------|-----------------------|--------------------|
-| `agent` (default) | `agent_id = <agent identity>` | every fact contributed by this agent |
+| `agent` (default) | OIDC off: `agent_id = <agent identity>`; OIDC on: `agent_id = <agent identity>` AND `user_id = <principal>` | this agent's pool, partitioned per user when OIDC is enabled |
 | `user` | `user_id = <principal>` | every fact this user contributed through any agent or session |
 | `group` | `user_id = "*"` plus `kaos_group = <store group>` | every attributed fact on the same `MemoryStore` |
 | `session` | `user_id = "*"` plus `kaos_run = <session id>` | facts attributed to one conversation/run |
 
 The `user_id = "*"` entry is Mem0 2.0.10's required wildcard convention for filtering by custom metadata; KAOS pins and regression-tests that behavior. Group membership is metadata, never a synthetic agent identity: `agent_id` always contains the real contributing agent. The group value comes from the active vector collection binding (`KAOS_MEMORY_LOCAL_COLLECTION` or `KAOS_MEMORY_EXTERNAL_COLLECTION`, default `kaos_memory`). That signal is always present even when telemetry is disabled, and the `MemoryStore` itself is the physical group boundary, so the collection name only needs to be stable within that store.
+
+### OIDC-conditional agent scope
+
+Agent scope follows one static cluster mode; it does not change based on whether an individual request happens to carry a principal.
+
+| Cluster mode | `agent` owner | Missing principal |
+|--------------|---------------|-------------------|
+| OIDC user identity enabled (`SecurityEnabled()` plus a configured user issuer) | `{agent_id, user_id}` | fail closed before recall or write |
+| OIDC user identity disabled | `{agent_id}` | allowed; no user key participates in the agent read partition |
+
+The operator injects `MEMORY_USER_SCOPING=required` into memory-configured agent pods only in the first mode. The gateway verifies the user JWT and projects its `sub` claim into a reserved header; the runtime resolves that subject as the principal and propagates it over subsequent agent hops. `user` scope continues to require a principal, while `group` remains the deliberate cross-user publication surface.
+
+Autonomous execution uses the same rule without an exception. The loop's agent bearer self-subjects the run, so its owner is `{agent_id, agent-as-user}`. For a hybrid agent, this means autonomous findings are private to the loop and are not recalled into a human user's agent partition; making those findings human-visible is an explicit publication at `group` level.
 
 Design choices:
 
@@ -65,7 +78,7 @@ Design choices:
 - **Enforcement is fail-closed at the service.** Scope is derived **server-side** from the authenticated agent identity and request context — never trusted from model- or tool-supplied arguments. An operation that cannot resolve a usable owner key fails rather than querying an unscoped store. Because the vector providers pre-filter during the query, a tenant's relevant memories are never dropped by an unfiltered nearest-neighbour window.
 - **Erasure fans out synchronously across tiers.** User and agent long-term erasure use Mem0's native entity deletion. Session and group erasure use wildcard-qualified custom filters, falling back to filtered id listing plus per-id deletion where the pinned Mem0 version lacks filtered deletion. Pre-existing alpha records without compound attribution cannot be reached by a newly available user-level erasure; there is no data migration.
 
-Cross-agent (A2A) delegation scope propagation and admin cross-user erasure depend on per-request principal propagation from the identity track and are deferred.
+Gateway-derived principals propagate automatically over cross-agent (A2A) delegation. Administrative cross-user erasure remains deferred.
 
 ## Deployment topology
 

--- a/kaos-memory/kaos_memory/app.py
+++ b/kaos-memory/kaos_memory/app.py
@@ -347,6 +347,10 @@ def create_app(service: MemoryService, request_concurrency: int = 8) -> FastAPI:
     @app.post("/v1/recall", response_model=RecallResponse)
     async def recall(req: RecallRequest) -> RecallResponse:
         """Synchronous recall: assemble long-term facts and short-term context for a scope."""
+        if not req.scope.is_complete():
+            return JSONResponse(
+                {"error": f"incomplete {req.scope.level.value} scope"}, status_code=400
+            )
         return await _offload(lambda: app.state.memory.recall(req))
 
     @app.post("/v1/write", response_model=WriteResponse)

--- a/kaos-memory/kaos_memory/app.py
+++ b/kaos-memory/kaos_memory/app.py
@@ -345,7 +345,7 @@ def create_app(service: MemoryService, request_concurrency: int = 8) -> FastAPI:
         return JSONResponse(result, status_code=code)
 
     @app.post("/v1/recall", response_model=RecallResponse)
-    async def recall(req: RecallRequest) -> RecallResponse:
+    async def recall(req: RecallRequest) -> RecallResponse | JSONResponse:
         """Synchronous recall: assemble long-term facts and short-term context for a scope."""
         if not req.scope.is_complete():
             return JSONResponse(

--- a/kaos-memory/kaos_memory/contract.py
+++ b/kaos-memory/kaos_memory/contract.py
@@ -57,6 +57,7 @@ class Scope(BaseModel):
     principal: Optional[str] = None
     agent_client_id: Optional[str] = None
     session_id: Optional[str] = None
+    user_scoping_required: bool = False
 
     @model_validator(mode="after")
     def _normalise(self) -> "Scope":
@@ -70,7 +71,9 @@ class Scope(BaseModel):
     def is_complete(self) -> bool:
         """Whether the field required by ``level`` is present (a usable owner key exists)."""
         if self.level is ScopeLevel.AGENT:
-            return self.agent_client_id is not None
+            return self.agent_client_id is not None and (
+                not self.user_scoping_required or self.principal is not None
+            )
         if self.level is ScopeLevel.USER:
             return self.principal is not None
         if self.level is ScopeLevel.SESSION:

--- a/kaos-memory/kaos_memory/contract.py
+++ b/kaos-memory/kaos_memory/contract.py
@@ -81,15 +81,19 @@ class Scope(BaseModel):
         return True  # GROUP always resolves to the reserved owner.
 
     def owner_kwargs(self) -> Dict[str, Any]:
-        """Return the single Mem0 entity owner selected by this scope.
+        """Return the Mem0 entity owner keys selected by this scope.
 
-        Entity-scoped operations use one of ``user_id`` / ``agent_id`` / ``run_id``.
-        Group scope has no synthetic entity owner and raises instead of mapping to
-        a sentinel.
+        Entity-scoped operations normally use one of ``user_id`` / ``agent_id`` /
+        ``run_id``. Required user-scoped agent operations use both user and agent.
+        Group scope has no synthetic entity owner and raises instead of mapping to a sentinel.
         """
         if self.level is ScopeLevel.AGENT:
             if self.agent_client_id is None:
                 raise ValueError("agent scope requires agent_client_id")
+            if self.user_scoping_required:
+                if self.principal is None:
+                    raise ValueError("user-scoped agent scope requires principal")
+                return {"user_id": self.principal, "agent_id": self.agent_client_id}
             return {"agent_id": self.agent_client_id}
         if self.level is ScopeLevel.USER:
             if self.principal is None:
@@ -139,6 +143,10 @@ class Scope(BaseModel):
         if self.level is ScopeLevel.AGENT:
             if self.agent_client_id is None:
                 raise ValueError("agent scope requires agent_client_id")
+            if self.user_scoping_required:
+                if self.principal is None:
+                    raise ValueError("user-scoped agent scope requires principal")
+                return {"user_id": self.principal, "agent_id": self.agent_client_id}
             return {"agent_id": self.agent_client_id}
         if self.level is ScopeLevel.SESSION:
             if self.session_id is None:

--- a/kaos-memory/kaos_memory/pydantic_ai/adapters.py
+++ b/kaos-memory/kaos_memory/pydantic_ai/adapters.py
@@ -18,6 +18,7 @@ importable without the framework when only :func:`scope_from_deps` is needed.
 from __future__ import annotations
 
 import json
+import os
 from typing import Any, List, Optional, Tuple, Union
 
 from kaos_memory.contract import Scope, ScopeLevel
@@ -47,16 +48,26 @@ def scope_from_deps(
     resolved_level = level if isinstance(level, ScopeLevel) else ScopeLevel(str(level))
     security_context = getattr(deps, "security_context", None) or {}
     agent_client_id = agent_identity or security_context.get("actor") or None
+    principal = security_context.get("principal") or None
+    user_scoping_required = (
+        resolved_level is ScopeLevel.AGENT
+        and os.environ.get("MEMORY_USER_SCOPING", "").strip().lower() == "required"
+    )
     if resolved_level is ScopeLevel.AGENT and not agent_client_id:
         raise ValueError(
             "AGENT memory scope requires a stable agent identity; refusing to "
             "operate on an ambiguously-owned agent partition"
         )
+    if user_scoping_required and not principal:
+        raise ValueError(
+            "AGENT memory scope requires an authenticated principal when user scoping is required"
+        )
     return Scope(
         level=resolved_level,
-        principal=security_context.get("principal") or None,
+        principal=principal,
         agent_client_id=agent_client_id,
         session_id=getattr(deps, "session_id", None) or None,
+        user_scoping_required=user_scoping_required,
     )
 
 

--- a/kaos-memory/tests/test_mem0_contract.py
+++ b/kaos-memory/tests/test_mem0_contract.py
@@ -155,6 +155,25 @@ def test_single_entity_filters_retrieve_compound_records_without_leakage(mem0):
     assert "u1 a2" not in _texts(agent_hits)
 
 
+def test_two_entity_filter_requires_matching_user_and_agent(mem0):
+    memory, _ = mem0
+    _add_raw(memory, "u1 a1", user_id="u1", agent_id="a1")
+    _add_raw(memory, "u2 a1", user_id="u2", agent_id="a1")
+    _add_raw(memory, "u1 a2", user_id="u1", agent_id="a2")
+
+    filters = Scope(
+        level=ScopeLevel.AGENT,
+        principal="u1",
+        agent_client_id="a1",
+        user_scoping_required=True,
+    ).search_filters()
+    searched = memory.search("equal query", filters=filters, top_k=10, threshold=0.0)
+    listed = memory.get_all(filters=filters, top_k=100)
+
+    assert _texts(searched) == {"u1 a1"}
+    assert _texts(listed) == {"u1 a1"}
+
+
 def test_cross_session_dedup_consolidates_compound_record(mem0):
     memory, llm = mem0
     llm.fact = "same durable preference"

--- a/kaos-memory/tests/test_recall.py
+++ b/kaos-memory/tests/test_recall.py
@@ -137,6 +137,23 @@ def test_user_recall_without_session_returns_long_term_and_empty_conversation(tm
     assert body["degraded"] is False
 
 
+def test_recall_rejects_incomplete_scope_before_fail_soft_recall(tmp_path):
+    response = _client(_FakeLongTerm(), _short_term(tmp_path)).post(
+        "/v1/recall",
+        json={
+            "scope": {
+                "level": "agent",
+                "principal": "alice",
+                "user_scoping_required": True,
+            },
+            "query": "anything",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"error": "incomplete agent scope"}
+
+
 def test_conversation_round_trips_across_recall_scopes_without_session_leakage(tmp_path):
     short_term = ShortTermStore(
         "local",

--- a/kaos-memory/tests/test_scope.py
+++ b/kaos-memory/tests/test_scope.py
@@ -20,6 +20,17 @@ def test_required_agent_scope_is_incomplete_without_user():
     assert scope.is_complete() is False
 
 
+def test_required_agent_maps_to_user_and_agent_filter():
+    scope = Scope(
+        level=ScopeLevel.AGENT,
+        principal="alice",
+        agent_client_id="agent-a",
+        user_scoping_required=True,
+    )
+    assert scope.search_filters() == {"user_id": "alice", "agent_id": "agent-a"}
+    assert scope.owner_kwargs() == {"user_id": "alice", "agent_id": "agent-a"}
+
+
 def test_user_maps_to_user_id():
     scope = Scope(level=ScopeLevel.USER, principal="alice")
     assert scope.owner_kwargs() == {"user_id": "alice"}

--- a/kaos-memory/tests/test_scope.py
+++ b/kaos-memory/tests/test_scope.py
@@ -11,6 +11,15 @@ def test_agent_maps_to_agent_id():
     assert scope.search_filters() == {"agent_id": "agent-a"}
 
 
+def test_required_agent_scope_is_incomplete_without_user():
+    scope = Scope(
+        level=ScopeLevel.AGENT,
+        agent_client_id="agent-a",
+        user_scoping_required=True,
+    )
+    assert scope.is_complete() is False
+
+
 def test_user_maps_to_user_id():
     scope = Scope(level=ScopeLevel.USER, principal="alice")
     assert scope.owner_kwargs() == {"user_id": "alice"}

--- a/kaos-memory/tests/test_service_e2e.py
+++ b/kaos-memory/tests/test_service_e2e.py
@@ -20,7 +20,7 @@ from kaos_memory.config import (
     StorageConfig,
     ShortTermTierConfig,
 )
-from kaos_memory.stores import LongTermStore
+from kaos_memory.stores import LongTermStore, Scope
 from kaos_memory.app import MemoryService, create_app
 from kaos_memory.stores import ShortTermStore
 from tests._fakes import DeterministicEmbedder
@@ -113,6 +113,64 @@ def test_local_mode_end_to_end(tmp_path, span_exporter):
     storage = StorageConfig(type="local", local=LocalStorage(path=str(tmp_path / "lt")))
     service = _service(storage, str(tmp_path / "shortterm.db"))
     _drive_and_assert(service, span_exporter, str(tmp_path / "shortterm.db"))
+
+
+def test_user_forget_erases_compound_partition_across_all_tiers(tmp_path):
+    storage = StorageConfig(type="local", local=LocalStorage(path=str(tmp_path / "lt")))
+    longterm = LongTermStore(storage, OFFLINE, OFFLINE)
+    longterm._memory.embedding_model = DeterministicEmbedder()
+    short_term = ShortTermStore(
+        "local",
+        str(tmp_path / "shortterm.db"),
+        ShortTermTierConfig(token_budget=32, hard_event_cap=1, rolling_summary=True),
+        lambda prior, turns: (prior + " " + " ".join(text for _, text in turns)).strip(),
+        group=storage.resolved().collection_name,
+    )
+    service = MemoryService(
+        longterm=longterm, short_term=short_term, scheduler=lambda thunk: thunk()
+    )
+    client = TestClient(create_app(service))
+
+    alice = {
+        "level": "agent",
+        "principal": "alice",
+        "agent_client_id": "agent-a",
+        "session_id": "alice-session",
+        "user_scoping_required": True,
+    }
+    bob = {**alice, "principal": "bob", "session_id": "bob-session"}
+
+    for scope, owner in ((alice, "alice"), (bob, "bob")):
+        for content in (f"{owner} durable fact", f"{owner} recent turn"):
+            response = client.post(
+                "/v1/write",
+                json={"scope": scope, "role": "user", "content": content, "infer": False},
+            )
+            assert response.status_code in (200, 202)
+
+    alice_scope = Scope.model_validate(alice)
+    bob_scope = Scope.model_validate(bob)
+    assert "alice durable fact" in short_term.summary(alice_scope)
+    assert short_term.active_window(alice_scope) == [("user", "alice recent turn")]
+    assert "bob durable fact" in short_term.summary(bob_scope)
+    assert short_term.active_window(bob_scope) == [("user", "bob recent turn")]
+
+    def longterm_texts(user_id):
+        raw = longterm._memory.get_all(filters={"user_id": user_id}, top_k=100)
+        return {item["memory"] for item in raw["results"]}
+
+    assert longterm_texts("alice") == {"alice durable fact"}
+    assert longterm_texts("bob") == {"bob durable fact"}
+
+    forgotten = client.post("/v1/forget", json={"scope": {"level": "user", "principal": "alice"}})
+    assert forgotten.status_code == 200
+
+    assert longterm_texts("alice") == set()
+    assert short_term.summary(alice_scope) == ""
+    assert short_term.active_window(alice_scope) == []
+    assert longterm_texts("bob") == {"bob durable fact"}
+    assert "bob durable fact" in short_term.summary(bob_scope)
+    assert short_term.active_window(bob_scope) == [("user", "bob recent turn")]
 
 
 @pytest.mark.pgvector

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -775,6 +775,10 @@ func (r *AgentReconciler) constructEnvVars(agent *kaosv1alpha1.Agent, modelapi *
 	// Memory configuration
 	if agent.Spec.Config != nil && agent.Spec.Config.Memory != nil {
 		mem := agent.Spec.Config.Memory
+		secCfg := security.GetConfig()
+		if secCfg.SecurityEnabled() && strings.TrimSpace(secCfg.UserIssuer) != "" {
+			env = append(env, corev1.EnvVar{Name: "MEMORY_USER_SCOPING", Value: "required"})
+		}
 
 		enabled := true
 		if mem.Enabled != nil {

--- a/operator/controllers/agent_memory_user_scoping_test.go
+++ b/operator/controllers/agent_memory_user_scoping_test.go
@@ -1,0 +1,61 @@
+package controllers
+
+import (
+	"testing"
+
+	kaosv1alpha1 "github.com/axsaucedo/kaos/operator/api/v1alpha1"
+)
+
+func TestMemoryUserScopingEnvUsesUserSecurityMode(t *testing.T) {
+	t.Setenv("SECURITY_PDP_ENABLED", "true")
+	t.Setenv("SECURITY_USER_AUTH_ISSUER", "https://users.example")
+
+	agent := &kaosv1alpha1.Agent{}
+	agent.Spec.Config = &kaosv1alpha1.AgentConfig{Memory: &kaosv1alpha1.MemoryConfig{}}
+	model := &kaosv1alpha1.ModelAPI{}
+	env := (&AgentReconciler{}).constructEnvVars(
+		agent, model, nil, nil, "", "agent", "",
+	)
+
+	for _, item := range env {
+		if item.Name == "MEMORY_USER_SCOPING" && item.Value == "required" {
+			return
+		}
+	}
+	t.Fatal("memory-configured agent did not receive required user scoping")
+}
+
+func TestMemoryUserScopingEnvIsNotSetForAgentOnlySecurity(t *testing.T) {
+	t.Setenv("SECURITY_PDP_ENABLED", "true")
+	t.Setenv("SECURITY_AGENT_AUTH_ISSUER", "https://agents.example")
+
+	agent := &kaosv1alpha1.Agent{}
+	agent.Spec.Config = &kaosv1alpha1.AgentConfig{Memory: &kaosv1alpha1.MemoryConfig{}}
+	model := &kaosv1alpha1.ModelAPI{}
+	env := (&AgentReconciler{}).constructEnvVars(
+		agent, model, nil, nil, "", "agent", "",
+	)
+
+	for _, item := range env {
+		if item.Name == "MEMORY_USER_SCOPING" {
+			t.Fatalf("agent-only security unexpectedly enabled user scoping: %#v", item)
+		}
+	}
+}
+
+func TestMemoryUserScopingEnvRequiresSecurityEnforcement(t *testing.T) {
+	t.Setenv("SECURITY_USER_AUTH_ISSUER", "https://users.example")
+
+	agent := &kaosv1alpha1.Agent{}
+	agent.Spec.Config = &kaosv1alpha1.AgentConfig{Memory: &kaosv1alpha1.MemoryConfig{}}
+	model := &kaosv1alpha1.ModelAPI{}
+	env := (&AgentReconciler{}).constructEnvVars(
+		agent, model, nil, nil, "", "agent", "",
+	)
+
+	for _, item := range env {
+		if item.Name == "MEMORY_USER_SCOPING" {
+			t.Fatalf("unenforced user auth unexpectedly enabled user scoping: %#v", item)
+		}
+	}
+}

--- a/operator/pkg/security/securitypolicy_test.go
+++ b/operator/pkg/security/securitypolicy_test.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -281,8 +282,12 @@ func TestConstructSecurityPolicyEmitsBothJWTProviders(t *testing.T) {
 		t.Errorf("user provider should use default Authorization extraction, got explicit extractFrom")
 	}
 	userClaims, _, _ := unstructured.NestedSlice(user, "claimToHeaders")
-	if len(userClaims) != 2 {
-		t.Errorf("expected two user claimToHeaders, got %d", len(userClaims))
+	wantUserClaims := []interface{}{
+		map[string]interface{}{"claim": "sub", "header": "x-user-claim-sub"},
+		map[string]interface{}{"claim": "preferred_username", "header": "x-user-claim-username"},
+	}
+	if !reflect.DeepEqual(userClaims, wantUserClaims) {
+		t.Errorf("user claimToHeaders = %#v, want %#v", userClaims, wantUserClaims)
 	}
 }
 

--- a/pydantic-ai-server/kaos_identity/instrument.py
+++ b/pydantic-ai-server/kaos_identity/instrument.py
@@ -235,9 +235,9 @@ def _extract_inbound(
     request_id = headers.get(HEADER_REQUEST_ID) or f"req-{uuid.uuid4().hex[:16]}"
     session_id = headers.get(HEADER_SESSION_ID) or headers.get(_LEGACY_SESSION_HEADER)
 
-    principal = headers.get(HEADER_PRINCIPAL)
-    if not principal and principal_resolver is not None:
-        principal = principal_resolver(headers)
+    principal = principal_resolver(headers) if principal_resolver is not None else None
+    if not principal:
+        principal = headers.get(HEADER_PRINCIPAL)
     if not principal:
         principal = default_principal
 
@@ -306,9 +306,9 @@ def instrument_fastapi(
     Local runtime identity (``actor``/``actor_token``/``principal``) falls back to the
     ``AGENT_AUTH_IDENTITY`` / ``AGENT_AUTH_TOKEN`` / ``AGENT_AUTH_PRINCIPAL`` environment
     variables (provider-agnostic; populated by the operator from the configured broker). The
-    user principal is normally taken from the inbound ``x-principal`` header or the
-    ``principal_resolver``; the fixed ``principal`` is only a fallback for processes with
-    a constant trusted principal.
+    user principal is taken from the ``principal_resolver`` when it returns a verified
+    value, then from inbound ``x-principal``; the fixed ``principal`` is only a fallback
+    for processes with a constant trusted principal.
     """
     app.add_middleware(
         _PropagationMiddleware,

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -133,7 +133,7 @@ class AgentServer:
         self._agent_identity = settings.agent_identity or settings.security_actor or ""
         if task_manager_type == "local":
             setup_fn = self._mock_state.reset if self._mock_state else None
-            local_actor = self.settings.security_actor or f"kaos://agent/{self.settings.agent_name}"
+            local_actor = self._agent_identity or f"kaos://agent/{self.settings.agent_name}"
             self.task_manager: TaskManager = LocalTaskManager(
                 self._run_agent,
                 setup_fn=setup_fn,
@@ -151,7 +151,7 @@ class AgentServer:
         # Two-identity propagation: extract inbound user context at the
         # server boundary and inject the user subject + this agent's actor on outbound
         # A2A/MCP/ModelAPI calls. The SDK is not the enforcement boundary; it propagates.
-        local_actor = self.settings.security_actor or f"kaos://agent/{self.settings.agent_name}"
+        local_actor = self._agent_identity or f"kaos://agent/{self.settings.agent_name}"
         kaos_identity.instrument_fastapi(
             self.app,
             actor=local_actor,

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -99,6 +99,11 @@ def configure_logging(level: str = "INFO", otel_correlation: bool = False) -> No
 logger = logging.getLogger(__name__)
 
 
+def _gateway_user_principal(headers: Dict[str, str]) -> Optional[str]:
+    """Resolve the subject projected by the gateway's verified user JWT provider."""
+    return headers.get("x-user-claim-sub")
+
+
 class AgentServer:
     """AgentServer exposing OpenAI-compatible chat completions API."""
 
@@ -152,6 +157,11 @@ class AgentServer:
             actor=local_actor,
             actor_token=self.settings.security_actor_token or None,
             principal=self.settings.security_principal or None,
+            principal_resolver=(
+                _gateway_user_principal
+                if os.environ.get("MEMORY_USER_SCOPING", "").strip().lower() == "required"
+                else None
+            ),
         )
         # When no static actor token is configured, set up the managed actor-token
         # lifecycle: if broker credentials are mounted (AGENT_AUTH_CLIENT_ID/SECRET/

--- a/pydantic-ai-server/tests/helpers.py
+++ b/pydantic-ai-server/tests/helpers.py
@@ -28,6 +28,7 @@ def make_test_server(
     max_steps: int = 5,
     memory_context_limit: int = 6,
     task_manager_type: str = "none",
+    agent_identity: str = "",
 ) -> AgentServer:
     """Create an AgentServer for testing."""
     if memory is None:
@@ -60,6 +61,7 @@ def make_test_server(
         agent_description=description,
         agentic_loop_max_steps=max_steps,
         memory_context_limit=memory_context_limit,
+        agent_identity=agent_identity,
     )
 
     return AgentServer(

--- a/pydantic-ai-server/tests/test_autonomous.py
+++ b/pydantic-ai-server/tests/test_autonomous.py
@@ -208,6 +208,16 @@ class TestAutonomousLoop:
 
 
 class TestAutonomousIdentity:
+    def test_server_uses_canonical_agent_identity_for_autonomous_principal(self):
+        identity = "kaos://agent/memv2-final/autonomous-agent"
+        server = make_test_server(
+            name="autonomous-agent",
+            task_manager_type="local",
+            agent_identity=identity,
+        )
+
+        assert server.task_manager._autonomous_principal == identity
+
     @pytest.mark.asyncio
     async def test_self_subjects_with_current_actor_token_each_iteration(self, monkeypatch):
         snapshots = []

--- a/pydantic-ai-server/tests/test_autonomous.py
+++ b/pydantic-ai-server/tests/test_autonomous.py
@@ -216,6 +216,7 @@ class TestAutonomousIdentity:
             agent_identity=identity,
         )
 
+        assert isinstance(server.task_manager, LocalTaskManager)
         assert server.task_manager._autonomous_principal == identity
 
     @pytest.mark.asyncio

--- a/pydantic-ai-server/tests/test_kaos_identity_fastapi.py
+++ b/pydantic-ai-server/tests/test_kaos_identity_fastapi.py
@@ -71,6 +71,18 @@ def test_principal_resolver_used_when_no_inbound_principal():
     assert seen["principal"] == "resolved://user"
 
 
+def test_verified_principal_resolver_overrides_inbound_principal():
+    client = _make_app(
+        actor="kaos://agent/default/a",
+        principal_resolver=lambda headers: headers.get("x-verified-sub"),
+    )
+    seen = client.get(
+        "/seen",
+        headers={"x-principal": "spoofed-user", "x-verified-sub": "verified-user"},
+    ).json()
+    assert seen["principal"] == "verified-user"
+
+
 def test_env_defaults_used(monkeypatch):
     monkeypatch.setenv("AGENT_AUTH_IDENTITY", "kaos://agent/default/env")
     monkeypatch.setenv("AGENT_AUTH_TOKEN", "env-token")

--- a/pydantic-ai-server/tests/test_kaos_identity_wiring.py
+++ b/pydantic-ai-server/tests/test_kaos_identity_wiring.py
@@ -63,7 +63,10 @@ def test_required_user_scoping_resolves_and_propagates_gateway_subject(monkeypat
             "outbound": kaos_identity.to_headers().get("x-principal"),
         }
 
-    seen = TestClient(server.app).get("/identity-test", headers={"x-user-claim-sub": "oidc-alice"})
+    seen = TestClient(server.app).get(
+        "/identity-test",
+        headers={"x-user-claim-sub": "oidc-alice", "x-principal": "spoofed-bob"},
+    )
     assert seen.json() == {"principal": "oidc-alice", "outbound": "oidc-alice"}
 
 

--- a/pydantic-ai-server/tests/test_kaos_identity_wiring.py
+++ b/pydantic-ai-server/tests/test_kaos_identity_wiring.py
@@ -32,6 +32,7 @@ def test_server_wires_fastapi_and_httpx_instrumentation():
     assert mw is not None
     # Default local actor derives from the agent name.
     assert mw.kwargs["actor"] == "kaos://agent/researcher"
+    assert mw.kwargs["principal_resolver"] is None
     assert kaos_identity.instrument._httpx_patched is True
 
 
@@ -49,6 +50,34 @@ def test_request_through_server_runs_middleware_and_resets():
     assert resp.status_code == 200
     # Context is request-scoped and reset afterwards — no leak into the process.
     assert kaos_identity.current() == {}
+
+
+def test_required_user_scoping_resolves_and_propagates_gateway_subject(monkeypatch):
+    monkeypatch.setenv("MEMORY_USER_SCOPING", "required")
+    server = create_agent_server(_settings())
+
+    @server.app.get("/identity-test")
+    async def identity_test():
+        return {
+            "principal": kaos_identity.current().get("principal"),
+            "outbound": kaos_identity.to_headers().get("x-principal"),
+        }
+
+    seen = TestClient(server.app).get("/identity-test", headers={"x-user-claim-sub": "oidc-alice"})
+    assert seen.json() == {"principal": "oidc-alice", "outbound": "oidc-alice"}
+
+
+def test_gateway_subject_is_not_trusted_when_user_scoping_is_off():
+    server = create_agent_server(_settings())
+
+    @server.app.get("/identity-test-off")
+    async def identity_test_off():
+        return kaos_identity.current()
+
+    seen = TestClient(server.app).get(
+        "/identity-test-off", headers={"x-user-claim-sub": "untrusted-alice"}
+    )
+    assert "principal" not in seen.json()
 
 
 def test_security_context_excludes_raw_tokens():

--- a/pydantic-ai-server/tests/test_memory_contract.py
+++ b/pydantic-ai-server/tests/test_memory_contract.py
@@ -34,7 +34,11 @@ class TestMemoryScope:
             "principal": "alice",
             "agent_client_id": "agent-1",
             "session_id": "sess-1",
+            "user_scoping_required": False,
         }
+
+        required = MemoryScope.model_validate({**payload, "user_scoping_required": True})
+        assert required.user_scoping_required is True
 
     def test_scope_level_values(self):
         assert ScopeLevel.AGENT.value == "agent"

--- a/pydantic-ai-server/tests/test_scope_injection.py
+++ b/pydantic-ai-server/tests/test_scope_injection.py
@@ -8,6 +8,7 @@ exposes no way for request content to influence the scope.
 
 import inspect
 
+import kaos_identity
 import pytest
 
 from pais.memory import MemoryScope, ScopeLevel, scope_from_deps
@@ -59,6 +60,53 @@ class TestScopeFromDeps:
         deps = _deps(actor="agent-actor")
         scope = scope_from_deps(deps, level=ScopeLevel.AGENT)
         assert scope.agent_client_id == "agent-actor"
+
+    def test_required_agent_scope_fails_closed_without_principal(self, monkeypatch):
+        monkeypatch.setenv("MEMORY_USER_SCOPING", "required")
+        deps = _deps(actor="agent-actor")
+        with pytest.raises(ValueError, match="authenticated principal"):
+            scope_from_deps(deps, level=ScopeLevel.AGENT)
+
+    def test_required_agent_scope_marks_agent_and_user_partition(self, monkeypatch):
+        monkeypatch.setenv("MEMORY_USER_SCOPING", "required")
+        scope = scope_from_deps(
+            _deps(principal="alice", actor="agent-actor"),
+            level=ScopeLevel.AGENT,
+        )
+        assert scope.agent_client_id == "agent-actor"
+        assert scope.principal == "alice"
+        assert scope.user_scoping_required is True
+
+    def test_autonomous_principal_uses_uniform_required_partition(self, monkeypatch):
+        monkeypatch.setenv("MEMORY_USER_SCOPING", "required")
+        identity = "kaos://agent/default/researcher"
+        with kaos_identity.autonomous_identity_context("agent-token", identity):
+            deps = AgentDeps(
+                session_id="loop-1",
+                security_context=kaos_identity.security_context(),
+            )
+            scope = scope_from_deps(
+                deps,
+                level=ScopeLevel.AGENT,
+                agent_identity=identity,
+            )
+
+        assert scope.agent_client_id == identity
+        assert scope.principal == identity
+        assert scope.user_scoping_required is True
+
+    def test_agent_scope_keeps_compound_attribution_when_mode_is_off(self):
+        scope = scope_from_deps(
+            _deps(principal="alice", actor="agent-actor"),
+            level=ScopeLevel.AGENT,
+        )
+        assert scope.user_scoping_required is False
+        assert scope.write_kwargs() == {
+            "user_id": "alice",
+            "agent_id": "agent-actor",
+            "metadata": {"kaos_run": "sess-1"},
+        }
+        assert scope.owner_kwargs() == {"agent_id": "agent-actor"}
 
     def test_helper_takes_no_scope_argument(self):
         # The derivation must not accept caller/model-supplied scope: there is no


### PR DESCRIPTION
## Summary

- map the gateway-verified OIDC `sub` claim into the runtime principal and propagate it across outbound agent calls
- inject required user scoping only for memory-configured agents when security enforcement and a user issuer are both configured
- partition default agent memory by both agent and user in that mode, failing closed when the principal is missing
- preserve agent-only behavior when OIDC user identity is disabled and keep `group` as the deliberate cross-user publication surface
- cover two-key Mem0 reads and user erasure across long-, medium-, and short-term storage

## Security model

PR #285 requires configured user authentication to use strict gateway mode, which combines gateway-routed application URLs with NetworkPolicy isolation. The runtime therefore enables the gateway claim resolver only when the operator injects `MEMORY_USER_SCOPING=required` from `cfg.SecurityEnabled() && strings.TrimSpace(cfg.UserIssuer) != ""`; agent-only JWT configurations do not enable it.

Envoy's JWT authentication filter reserves every configured `claimToHeaders` name: an existing client value is replaced by the verified claim, and when the claim is absent the header is unavailable for another value ([Envoy JWT authentication documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/jwt_authn_filter.html#copy-validated-jwt-claims-to-http-request-headers-example)). The operator test pins `x-user-claim-sub` and `x-user-claim-username` as the exact projected headers. The verified resolver also takes precedence over inbound `x-principal`, while `x-principal` remains the fallback for an agent hop without a user claim header.

The bearer remains an opaque propagated credential; the runtime does not decode it or duplicate gateway verification.

## Behavior

| Cluster mode | Default agent memory filter | Missing principal |
|---|---|---|
| OIDC user identity enabled | `user_id = U AND agent_id = A` | rejected |
| OIDC user identity disabled | `agent_id = A` | allowed |

Autonomous loops use the same rule: their bearer self-subjects the loop, producing `{agent_id, agent-as-user}`. A hybrid agent's loop findings remain private until deliberately published at `group` level.

## Validation

- kaos-memory: `120 passed, 4 skipped`; Black and ty clean
- PAIS: `364 passed, 10 skipped`; Black and ty clean
- operator: `make generate manifests` clean; `make test-unit` passed, including `46/46` controller integration specs
- docs: VitePress build passed
- no local KIND validation was run; the automatically triggered E2E workflow was canceled to keep this change within unit/service scope

Stack base: `feat/memory-read-scope-policy` (#282), above `feat/memory-compound-attribution` (#280).
