### PR TITLE
Fix strict-gateway ModelAPI authentication and memory ingress

### DIFF
--- a/docs/operator/memorystore-crd.md
+++ b/docs/operator/memorystore-crd.md
@@ -96,7 +96,7 @@ The DSN is injected into the service as `KAOS_MEMORY_EXTERNAL_DSN` via a `secret
 
 ## Models
 
-Both `summarization` and `embedding` model references are required. Each points at a `ModelAPI` in the same namespace plus a concrete model name. The controller resolves the referenced ModelAPIs and holds the MemoryStore in `Pending` until they are `Ready`; the summarization endpoint (suffixed with `/v1`) becomes the service's model base URL. Models bind lazily at first use, so the store can reach `Ready` from storage reachability before any embedding or summarization call is made.
+Both `summarization` and `embedding` model references are required. Each points at a `ModelAPI` in the same namespace plus a concrete model name. The controller resolves the referenced ModelAPIs and holds the MemoryStore in `Pending` until they are `Ready`; the summarization ModelAPI's cluster-local Service endpoint (suffixed with `/v1`) becomes the service's model base URL. Generated ModelAPI NetworkPolicies admit same-namespace MemoryStore pods for this direct model traffic while other workload pods remain gateway-only. Models bind lazily at first use, so the store can reach `Ready` from storage reachability before any embedding or summarization call is made.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/operator/controllers/modelapi_controller.go
+++ b/operator/controllers/modelapi_controller.go
@@ -303,11 +303,12 @@ func (r *ModelAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			log.Error(err, "failed to reconcile SecurityPolicy")
 		}
 		if err := security.ReconcileNetworkPolicy(ctx, r.Client, r.Scheme, modelapi, security.NetworkPolicyParams{
-			Name:                routeName,
-			Namespace:           modelapi.Namespace,
-			PodSelector:         map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
-			Labels:              map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
-			AllowExternalEgress: true,
+			Name:                       routeName,
+			Namespace:                  modelapi.Namespace,
+			PodSelector:                map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
+			Labels:                     map[string]string{"app": "modelapi", "modelapi": modelapi.Name},
+			AllowedIngressPodSelectors: []map[string]string{{"app": "memorystore"}},
+			AllowExternalEgress:        true,
 		}, secCfg, log); err != nil {
 			log.Error(err, "failed to reconcile NetworkPolicy")
 		}

--- a/operator/pkg/security/networkpolicy.go
+++ b/operator/pkg/security/networkpolicy.go
@@ -36,6 +36,9 @@ type NetworkPolicyParams struct {
 	PodSelector map[string]string
 	// Labels are applied to the generated NetworkPolicy.
 	Labels map[string]string
+	// AllowedIngressPodSelectors admit same-namespace workload clients without
+	// opening direct access to every pod in the namespace.
+	AllowedIngressPodSelectors []map[string]string
 	// AllowExternalEgress permits provider-facing egress that cannot be enumerated
 	// by namespace. Set only for ModelAPI workloads that proxy to external LLMs.
 	AllowExternalEgress bool
@@ -59,6 +62,13 @@ func constructNetworkPolicy(params NetworkPolicyParams, cfg Config) *networkingv
 	// Avoid emitting a duplicate peer when the operator shares the gateway namespace.
 	if operatorNS != gatewayNS {
 		from = append(from, namespacePeer(operatorNS))
+	}
+	for _, selector := range params.AllowedIngressPodSelectors {
+		if len(selector) > 0 {
+			from = append(from, networkingv1.NetworkPolicyPeer{
+				PodSelector: &metav1.LabelSelector{MatchLabels: selector},
+			})
+		}
 	}
 
 	policyTypes := []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}

--- a/operator/pkg/security/networkpolicy_test.go
+++ b/operator/pkg/security/networkpolicy_test.go
@@ -99,6 +99,26 @@ func TestConstructNetworkPolicyDefaultNamespaces(t *testing.T) {
 	}
 }
 
+func TestConstructNetworkPolicyAllowsSameNamespacePods(t *testing.T) {
+	np := constructNetworkPolicy(NetworkPolicyParams{
+		Name:                       "modelapi-openai",
+		Namespace:                  "default",
+		PodSelector:                map[string]string{"app": "modelapi"},
+		AllowedIngressPodSelectors: []map[string]string{{"app": "memorystore"}},
+	}, Config{ExtAuthzURL: "svc:9191"})
+
+	peers := np.Spec.Ingress[0].From
+	if len(peers) != 3 {
+		t.Fatalf("expected gateway, operator, and MemoryStore peers, got %d", len(peers))
+	}
+	if got := peers[2].PodSelector; got == nil || got.MatchLabels["app"] != "memorystore" {
+		t.Fatalf("expected same-namespace app=memorystore peer, got %#v", got)
+	}
+	if peers[2].NamespaceSelector != nil {
+		t.Fatalf("same-namespace peer must not select every pod in a namespace")
+	}
+}
+
 func TestConstructNetworkPolicyEgressRules(t *testing.T) {
 	cfg := Config{
 		ExtAuthzURL:         "aib-ext-authz.aib-system.svc.cluster.local:9191",

--- a/pydantic-ai-server/kaos_identity/instrument.py
+++ b/pydantic-ai-server/kaos_identity/instrument.py
@@ -353,14 +353,18 @@ def suppress_instrumentation() -> Iterator[None]:
 def _inject_request_headers(request: Any) -> None:
     """Merge the current context's propagation headers into an outbound request.
 
-    Strictly **additive**: a header already present on the request (for example the
-    ModelAPI/LLM provider's own ``Authorization`` API key) is never overwritten. When the
-    request-local context carries no actor token but a managed actor-token lifecycle is
-    active (see :func:`kaos_identity.instrument_agent_identity`), this agent's minted actor token is
-    injected so each hop authenticates as itself even without a static token.
+    Additive except for PAIS's ``Bearer not-needed`` no-auth sentinel, which is replaced
+    by the propagated subject. Real ModelAPI/LLM provider API keys remain untouched. When
+    the request-local context carries no actor token but a managed actor-token lifecycle
+    is active (see :func:`kaos_identity.instrument_agent_identity`), this agent's minted
+    actor token is injected so each hop authenticates as itself without a static token.
     """
     for header, value in ctx.to_headers().items():
-        if header not in request.headers:
+        placeholder_subject = (
+            header == HEADER_SUBJECT_TOKEN
+            and request.headers.get(header, "").strip().lower() == "bearer not-needed"
+        )
+        if header not in request.headers or placeholder_subject:
             request.headers[header] = value
     if HEADER_ACTOR_TOKEN not in request.headers:
         token = _managed_actor_token()
@@ -384,7 +388,11 @@ async def _inject_request_headers_async(request: Any) -> None:
     Acquires the managed actor token without blocking the event loop on a refresh.
     """
     for header, value in ctx.to_headers().items():
-        if header not in request.headers:
+        placeholder_subject = (
+            header == HEADER_SUBJECT_TOKEN
+            and request.headers.get(header, "").strip().lower() == "bearer not-needed"
+        )
+        if header not in request.headers or placeholder_subject:
             request.headers[header] = value
     if HEADER_ACTOR_TOKEN not in request.headers:
         from . import identity

--- a/pydantic-ai-server/tests/test_kaos_identity_httpx.py
+++ b/pydantic-ai-server/tests/test_kaos_identity_httpx.py
@@ -99,6 +99,22 @@ async def test_does_not_overwrite_existing_authorization():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_replaces_no_auth_placeholder_with_subject():
+    route = respx.post("http://modelapi/v1/chat/completions").respond(200)
+    kaos_identity.ctx.update({"subject_token": "user-token", "actor_token": "actor-token"})
+    async with httpx.AsyncClient() as client:
+        await client.post(
+            "http://modelapi/v1/chat/completions",
+            headers={"Authorization": "Bearer not-needed"},
+        )
+
+    sent = route.calls.last.request.headers
+    assert sent["authorization"] == "Bearer user-token"
+    assert sent["x-agent-authorization"] == "Bearer actor-token"
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_empty_context_injects_nothing():
     route = respx.get("http://downstream/ping").respond(200)
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## Summary

- replace PAIS's `Bearer not-needed` sentinel with the request-local subject token while preserving real provider credentials
- allow same-namespace MemoryStore pods to reach ModelAPI Services through generated NetworkPolicies
- document the direct MemoryStore-to-ModelAPI path and cover both fixes with regressions

## Validation

- pydantic-ai-server: 366 passed, 10 skipped; Black and ty pass
- kaos-memory: 121 passed, 4 skipped; Black and ty pass
- operator: all packages pass, including 46 controller integration specs; `go vet ./...` passes
- docs: VitePress build passes