### PR TITLE
ci: run PR checks against any base branch

### DIFF
--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -2,7 +2,6 @@ name: Docs Lint
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'docs/**'
       - 'examples/**'

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -2,7 +2,6 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'operator/**'
       - 'pydantic-ai-server/**'

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -2,7 +2,6 @@ name: Go Tests
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'operator/**'
       - '.github/workflows/go-tests.yaml'

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -2,7 +2,6 @@ name: Python Tests
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'pydantic-ai-server/**'
       - 'kaos-cli/**'

--- a/.github/workflows/subtree-check.yaml
+++ b/.github/workflows/subtree-check.yaml
@@ -2,7 +2,6 @@ name: Subtree Sync Check
 
 on:
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Stacked PRs (e.g. #291, #292) target feature branches and got no CI because every `pull_request` trigger was filtered to `branches: [main]`. This drops the base-branch filter on the five affected workflows (kaos-ui-tests already had none): checks now run for PRs against any base. `pull_request` never fires for tags, and `push` triggers keep their main/tag filters, so release workflows are unaffected and nothing runs twice.