### PR TITLE
feat(samples): ship the memory sample's AccessGrant

### DIFF
--- a/operator/config/samples/7-memory-agent.yaml
+++ b/operator/config/samples/7-memory-agent.yaml
@@ -115,3 +115,22 @@ spec:
       clientParams:
         tokenBudget: 64
         rollingSummary: true
+
+---
+# Who may use the memory agents: the "researchers" group. Entry through the
+# gateway is deny-by-default; this grant is what admits verified group members.
+apiVersion: kaos.tools/v1alpha1
+kind: AccessGrant
+metadata:
+  name: researchers-to-memory-agents
+spec:
+  subjects:
+    - kind: Group
+      name: researchers
+  resources:
+    - kind: Agent
+      name: user-assistant
+    - kind: Agent
+      name: session-assistant
+    - kind: Agent
+      name: agent-bot


### PR DESCRIPTION
The 7-memory-agent sample deploys three agents behind a deny-by-default gateway but shipped no AccessGrant, so on a secured cluster every user invoke was denied until a grant was created by hand (as the blog capture had to do). Ships a researchers-group grant for the three agents; inert without access control. CLI sample tests green (152).