### PR TITLE
feat(memory): recall ergonomics and three-level read-scope model

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,7 +96,7 @@ tmp/                       # Local work files (gitignored)
 ```
 
 ## CRDs Overview
-- **Agent**: AI agent with model API, MCP tools, sub-agent delegation, autonomous (self-looping) execution, and memory binding (`config.memory`: `agent`/`user`/`group`/`session` scope, tools, failureMode, clientParams)
+- **Agent**: AI agent with model API, MCP tools, sub-agent delegation, autonomous (self-looping) execution, and memory binding (`config.memory`: maxReadScope, tools, failureMode, clientParams)
 - **MCPServer**: MCP tool server with runtime-based architecture (python-string, fastmcp-codemode, pctx-codemode, kubernetes, slack, custom)
 - **ModelAPI**: LLM proxy (LiteLLM) or hosted (Ollama) mode
 - **MemoryStore**: central memory service backing long-term semantic memory (local or external pgvector storage; external defaults to 2 replicas + PDB; summarization/embedding model refs; `--pgvector-memory-enabled` installs dev Postgres)

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -406,23 +406,22 @@ Inspect or erase a central `MemoryStore` through a temporary Kubernetes port-for
 
 ### kaos memory recall
 
-Use `--query` for semantic recall or `--all` for a complete scoped list. Add `--short-term` to include the current session's verbatim window and rolling summary.
+Without a query the command lists the selected tiers. Add `--long-term-query`/`-q` for semantic long-term recall. `--include` is repeatable and comma-separated, defaults to all tiers, and accepts `a|all|s|short-term|m|medium-term|l|long-term`.
 
 ```bash
-kaos memory recall --store support-memory --scope session --session SESSION_ID --query TEXT [OPTIONS]
-kaos memory recall --store support-memory --scope agent --agent AGENT --all [OPTIONS]
+kaos memory recall --store support-memory --scope session --session SESSION_ID -q TEXT [OPTIONS]
+kaos memory recall --store support-memory --scope store --include l [OPTIONS]
 ```
 
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--store` | | MemoryStore name; optional when exactly one exists |
-| `--scope` | | `session`, `agent`, `user`, or `group` (required) |
+| `--scope` | | `session`, `agent`, `user`, or `store` (required) |
 | `--session` | | Session ID; required only for session scope |
 | `--agent` | | Agent name; required only for agent scope |
 | `--user` | | User principal; required only for user scope. A username with a cached `kaos auth login` session resolves to its verified subject; anything else passes through verbatim |
-| `--query` | | Semantic query; mutually exclusive with `--all` |
-| `--all` | | List every long-term record visible at the scope |
-| `--short-term` | | Include conversational tiers when the scope carries a session |
+| `--long-term-query` | `-q` | Semantic query; without it the command uses the list endpoint |
+| `--include` | | Selected tiers; repeat or comma-separate aliases. Defaults to all |
 | `--top-k` | | Maximum semantic results (default: 10) |
 | `--namespace` | `-n` | Kubernetes namespace |
 | `--json` | | Output JSON |
@@ -435,7 +434,7 @@ Erase every long-term record and attributed conversational session at a scope. T
 
 ```bash
 kaos memory forget --store support-memory --scope user --user alice [-n NAMESPACE]
-kaos memory forget --store support-memory --scope group --yes
+kaos memory forget --store support-memory --scope store --yes
 ```
 
 ---
@@ -460,7 +459,7 @@ kaos memorystore create NAME --modelapi MODELAPI [OPTIONS]
 | `--embedding-model` | | `text-embedding-3-small` | Embedding model |
 | `--short-term-token-budget` | | | Token budget, rendered as `KAOS_MEMORY_TOKEN_BUDGET` on this CRD version |
 | `--medium-term-enabled` | | false | Enable rolling summaries through `KAOS_MEMORY_ROLLING_SUMMARY` |
-| `--default-read-scope` | | | Default read scope |
+| `--max-read-scope` | | | Store read-scope ceiling: `session`, `agent`, or `user` |
 | `--failure-mode` | | | Default failure mode: `soft` or `strict` |
 | `--namespace` | `-n` | current | Target namespace |
 | `--dry-run` | | false | Print YAML instead of creating |

--- a/docs/examples/memory.md
+++ b/docs/examples/memory.md
@@ -60,8 +60,8 @@ We deploy the reusable `memory` sample: one `ModelAPI`, the local-mode `support-
 The important part is the agent's `config.memory` block:
 
 - `memoryStore: support-memory` binds all three agents to the store.
-- `user-assistant` uses `defaultReadScope: user`; `session-assistant` keeps the session fallback.
-- `agent-bot` states `defaultReadScope: agent` and exposes no explicit memory tools.
+- `user-assistant` uses `maxReadScope: user`; `session-assistant` uses `maxReadScope: session`.
+- `agent-bot` states `maxReadScope: agent` and exposes no explicit memory tools.
 - The store tunes its tiers with typed fields: a small `shortTerm.tokenBudget` makes conversational compaction easy to exercise, and `mediumTerm.enabled` turns on the rolling digest that folds the overflow.
 
 `DEBUG_MOCK_RESPONSES` makes the agent return a canned reply instead of calling the model, so the run is deterministic.
@@ -112,10 +112,10 @@ kill "$AGENT_PF" 2>./tmp/null || true
 
 ## Step 4: Verify the Agent Wrote to the Store
 
-Now we confirm the integration through `kaos memory`. `--all` uses the store's faithful list path, while session scope and `--short-term` return the same conversation's rolling summary and verbatim window:
+Now we confirm the integration through `kaos memory`. With no query the command uses the list path, and the default `--include all` returns the same conversation's rolling summary and verbatim window:
 
 ```bash
-kaos memory recall --store support-memory --scope session --session memory-session-1 --all --short-term -n "$NAMESPACE" --json > ./tmp/recall-session1.json
+kaos memory recall --store support-memory --scope session --session memory-session-1 -n "$NAMESPACE" --json > ./tmp/recall-session1.json
 cat ./tmp/recall-session1.json
 ```
 
@@ -123,7 +123,7 @@ cat ./tmp/recall-session1.json
 import json
 
 recall = json.load(open("./tmp/recall-session1.json"))
-recent = [tuple(pair) for pair in recall["short_term"]["recent"]]
+recent = [tuple(pair) for pair in recall["short_term"]["window"]]
 print("Stored turns:", recent)
 
 assert ("user", "My favourite deployment port is 8080") in recent
@@ -135,12 +135,12 @@ print("SUCCESS: the agent persisted the conversation to the MemoryStore")
 Recall a different session directly. Its verbatim conversational window starts empty because conversational tiers are always session-keyed:
 
 ```bash
-kaos memory recall --store support-memory --scope session --session memory-session-2 --all --short-term -n "$NAMESPACE" --json > ./tmp/recall-session2.json
+kaos memory recall --store support-memory --scope session --session memory-session-2 -n "$NAMESPACE" --json > ./tmp/recall-session2.json
 ```
 
 ```python
 recall = json.load(open("./tmp/recall-session2.json"))
-recent = [tuple(pair) for pair in recall["short_term"]["recent"]]
+recent = [tuple(pair) for pair in recall["short_term"]["window"]]
 print("Session 2 window:", recent)
 
 assert recent == []
@@ -154,7 +154,7 @@ Both assistants set `tools: read`. Memory always applies the **automatic baselin
 | Setting | Tools exposed | Arguments | The model can… |
 |---------|---------------|-----------|----------------|
 | _(unset)_ | none | — | rely purely on automatic recall/persist |
-| `read` | `search_memory` | `query`, required entitled `level` | look facts up at `session`, `agent`, `user`, or `group` when configured |
+| `read` | `search_memory` | `query`, required entitled `level` | look facts up at every level through `maxReadScope` |
 | `write` | `save_memory` | `content` | save a durable fact with server-derived attribution |
 | `all` | both | as above | save and search on demand |
 
@@ -162,10 +162,10 @@ Both assistants set `tools: read`. Memory always applies the **automatic baselin
 
 ## Scopes
 
-Reads are partitioned by scope through `defaultReadScope` and `readScopes`; writes attach every verified contributor without a level:
+Reads are partitioned by scope through `maxReadScope`; writes attach every verified contributor without a level:
 
 - `session` — one conversation only.
-- `group` — extracted facts are shared by every agent and session on the store; raw turns remain session-local.
+- `store` — the whole-store administrative view; unavailable to agent actor requests.
 - `user` — all sessions for an authenticated principal.
 - `agent` — only this specific agent.
 

--- a/docs/operator/agent-crd.md
+++ b/docs/operator/agent-crd.md
@@ -43,8 +43,7 @@ spec:
       enabled: true           # Enable/disable memory (default: true)
       type: remote            # "remote" (bound MemoryStore) or "local" (pod-local)
       memoryStore: shared-memory  # MemoryStore in the same namespace (remote)
-      defaultReadScope: user  # Automatic recall level; defaults to store, then session
-      readScopes: [user, agent] # Levels offered to search_memory
+      maxReadScope: user  # Automatic recall level and search_memory ceiling
       tools: all              # Expose memory tools: all | read | write
       failureMode: soft       # Override store default: soft | strict
       clientParams:
@@ -233,8 +232,7 @@ config:
     enabled: true               # Enable/disable memory (default: true)
     type: remote                # "remote" or "local" (derived from memoryStore when omitted)
     memoryStore: shared-memory  # MemoryStore in the same namespace (required for remote)
-    defaultReadScope: user      # Automatic recall scope; defaults to store, then session
-    readScopes: [user, agent]   # search_memory entitlements; defaults to defaultReadScope
+    maxReadScope: user      # Automatic recall scope and search_memory ceiling
     tools: all                  # Expose memory tools: all | read | write
     failureMode: soft           # Override store default write/forget mode: soft | strict
     clientParams:
@@ -247,9 +245,8 @@ config:
 | `enabled` | bool | `true` | Enable memory; when `false`, uses a no-op memory implementation |
 | `type` | string | derived | `remote` (bound MemoryStore) or `local` (pod-local short-term). Derived from `memoryStore` presence when omitted |
 | `memoryStore` | string | — | Name of a MemoryStore in the same namespace. Required for `remote`; forbidden for `local` |
-| `defaultReadScope` | string | store `defaultReadScope`, then `session` | Single level used by automatic recall: `agent`, `user`, `group`, or `session` |
-| `readScopes` | string[] | `[defaultReadScope]` | Levels exposed through the required `level` argument of `search_memory` |
-| `tools` | string | — | Explicit memory tools on top of automatic recall/write: `all` (save + search), `read` (search), `write` (save). Requires a `memoryStore`; multiple `readScopes` require `read` or `all` |
+| `maxReadScope` | string | store `maxReadScope`, then `session` | Automatic recall scope and maximum `search_memory` level: `session`, `agent`, or `user` |
+| `tools` | string | — | Explicit memory tools on top of automatic recall/write: `all` (save + search), `read` (search), `write` (save). Requires a `memoryStore` |
 | `failureMode` | string | store default | Override the store's write/forget failure mode: `soft` (tolerate) or `strict` (surface errors) |
 | `clientParams.tokenBudget` | int | runtime default | Cap on the verbatim short-term window replayed, in tokens |
 | `clientParams.rollingSummary` | bool | `true` | Maintain a rolling summary of evicted turns |
@@ -257,14 +254,14 @@ config:
 **Memory read scope (multi-tenancy):**
 - `agent` (default) — memory is isolated to this single agent; each agent identity owns its own store partition.
 - `user` — memory is keyed by the calling principal, so any agent bound to the same store shares that user's memory across sessions. Requires a `memoryStore`.
-- `group` — a single common partition read/written by every agent bound to the store. Requires a `memoryStore`; the store defines the group.
+- `store` — the whole store, available only to actor-free administrative requests.
 - `session` — memory is scoped to an individual conversation/session and not carried across sessions.
 
-**Read-scope policy:** `defaultReadScope` controls the one long-term filter used by automatic recall. `readScopes` is the entitlement list for `search_memory(query, level)`. Writes have no level: the runtime attaches every verified identity and the service enforces cluster posture. User read configuration is rejected when the cluster has no user identity.
+**Read-scope policy:** `maxReadScope` controls automatic recall and exposes every `search_memory(query, level)` level from `session` through that ceiling. It cannot exceed the bound store's ceiling. Writes have no level: the runtime attaches every verified identity and the service enforces cluster posture. User read configuration is rejected when the cluster has no user identity.
 
 **Remote memory:**
 - Set `type: remote` and reference a ready MemoryStore via `memoryStore`.
-- The operator injects `MEMORY_STORE_ENDPOINT`, resolved `MEMORY_DEFAULT_READ_SCOPE`, comma-separated `MEMORY_READ_SCOPES`, posture requirements, and a qualified `AGENT_IDENTITY` (`kaos://agent/<namespace>/<name>`) into the agent container.
+- The operator injects `MEMORY_STORE_ENDPOINT`, resolved `MEMORY_MAX_READ_SCOPE`, posture requirements, and a qualified `AGENT_IDENTITY` (`kaos://agent/<namespace>/<name>`) into the agent container.
 - Binding is degraded-aware for a running agent: if the store later becomes missing or not-ready it does not block serving — the agent reports a `MemoryDegraded` status condition and falls back to its local short-term window. Initial creation is gated, though: with `waitForDependencies` enabled (default) the agent stays `Waiting` until the bound store is Ready, so it never starts up degraded.
 
 **When to disable memory:**

--- a/docs/operator/memory-architecture.md
+++ b/docs/operator/memory-architecture.md
@@ -37,7 +37,7 @@ A remote-memory agent layers three tiers behind one client. KAOS owns the two co
 
 Design choices:
 
-- **The short-term window is session-scoped only.** Every window and digest key combines the stable store group with the session id; agent and principal identities are deliberately excluded, so a run written by an agent can be recalled through any entitled scope using the same session id. A missing session id fails rather than falling back to a shared owner window. User-, agent-, or store-wide verbatim windows would interleave concurrent conversations, so cross-session continuity is served by long-term facts instead of merging live turns. In particular, `scope: group` does not share raw turns across sessions; cross-agent sharing flows through extracted long-term facts. The window is bounded by a configurable **token budget** (with a hard event-count safety cap), not by turn count.
+- **The short-term window is session-scoped only.** Every window and digest key combines the stable internal store key with the session id. A principal-bound session read must also match the attribution index; mismatch returns empty. A missing session id fails rather than falling back to a shared owner window. The window is bounded by a configurable **token budget** (with a hard event-count safety cap), not by turn count.
 - **The medium-term digest stays out of Mem0.** Mem0 decomposes input into atomic, individually revisable facts for vector retrieval, whereas a rolling digest is a coherent narrative that should be injected directly at recall time. Indexing it into Mem0 would shred narrative continuity into fragments and pollute vector search, so the digest is a relational, append-only, versioned row and Mem0 receives only the raw evicted turns.
 - **Short-term is never on Redis and never in Mem0.** It is a cheap append-and-read-window operation co-located with the long-term store (a SQLite table beside embedded Chroma in `local` mode; a plain table on the same Postgres that backs pgvector in `external` mode).
 - **Folding and extraction are always off the write path.** The active window is computed lazily on read; when a compaction trigger is crossed, older turns fold into the digest and the raw turns are handed to Mem0 for long-term extraction — all as background work, never blocking the response.
@@ -50,10 +50,10 @@ Reads and erasure carry a **scope** selecting long-term visibility. Writes inste
 
 | `scope` | Long-term read filter | Isolation boundary |
 |---------|-----------------------|--------------------|
-| `agent` (default) | OIDC off: `agent_id = <agent identity>`; OIDC on: `agent_id = <agent identity>` AND `user_id = <principal>` | this agent's pool, partitioned per user when OIDC is enabled |
+| `session` | `kaos_run = <session id>` AND `user_id = <principal>` when present | one principal-bound conversation |
+| `agent` | `agent_id = <agent identity>` AND `user_id = <principal>` when present | this agent's memory of the verified context |
 | `user` | `user_id = <principal>` | every fact this user contributed through any agent or session |
-| `group` | `user_id = "*"` plus `kaos_group = <store group>` | every attributed fact on the same `MemoryStore` |
-| `session` | `user_id = "*"` plus `kaos_run = <session id>` | facts attributed to one conversation/run |
+| `store` | `user_id = "*"` plus `kaos_group = <store group>` | whole-store administrative view |
 
 The `user_id = "*"` entry is Mem0 2.0.10's required wildcard convention for filtering by custom metadata; KAOS pins and regression-tests that behavior. Group membership is metadata, never a synthetic agent identity: `agent_id` always contains the real contributing agent. The group value comes from the active vector collection binding (`KAOS_MEMORY_LOCAL_COLLECTION` or `KAOS_MEMORY_EXTERNAL_COLLECTION`, default `kaos_memory`). That signal is always present even when telemetry is disabled, and the `MemoryStore` itself is the physical group boundary, so the collection name only needs to be stable within that store.
 
@@ -68,17 +68,17 @@ Identity requirements follow one static cluster posture; agents cannot weaken or
 
 The operator injects `MEMORY_REQUIRE_PRINCIPAL=true` when secured user identity is enabled and `MEMORY_REQUIRE_AGENT_IDENTITY=true` whenever security is enabled. It projects equivalent `KAOS_MEMORY_*` settings into the MemoryStore pod, whose write check is authoritative. The runtime repeats the checks as defence in depth. Admin CLI recall and forget remain trusted in-cluster read/erasure paths and do not require agent identity.
 
-Autonomous execution uses the same rule without an exception. The loop's agent bearer self-subjects the run, so its owner is `{agent_id, agent-as-user}`. For a hybrid agent, this means autonomous findings are private to the loop and are not recalled into a human user's agent partition; making those findings human-visible is an explicit publication at `group` level.
+Autonomous execution uses the same rule without an exception. The loop's agent bearer self-subjects the run, so its owner is `{agent_id, agent-as-user}`.
 
 Design choices:
 
-- **The store is the group.** A logical group is the set of agents bound to the same `MemoryStore`; there is no separate group CRD. The four scope levels express per-agent, per-user, per-group, and per-session memory.
+- **The store view is administrative.** Requests carrying an agent actor header cannot use `store`; actor-free port-forward requests may inspect it.
 - **Isolation strength is chosen by how many stores you deploy.** The default is a shared store with scope filtering; deploying one `MemoryStore` per tenant gives **physical** isolation (data is not co-located), so a filtering defect cannot leak across tenants. No isolation-mode field exists.
 - **Scope selects long-term visibility, not write ownership.** A user-level read is deliberately broad: it returns everything that principal contributed through any agent and session. Compound attribution lets narrower agent/session reads and user/agent erasure reach the same physical fact without duplicating it.
-- **Conversational tiers are always per-session.** The verbatim window and medium-term digest use `kaos_group:<store group>|run:<session id>`; without a configured group an embedded store uses `run:<session id>`. The group is the consistent tenant component supplied by the service on both write and recall, while the unguessable run id is the capability that addresses one window through the scoped service and its network/RBAC boundary. Agent and principal identities live in a separate erasure index rather than the conversational key, so changing the recall scope cannot change the physical session partition. `scope: user` does not create a user-wide conversational window. Session forget deletes one key; user, agent, and group forget use the erasure index to delete every attributed session.
-- **Agent configuration is read-only.** `defaultReadScope` selects baseline recall and resolves Agent → MemoryStore → `session`; `readScopes` limits `search_memory`. Writes, including `save_memory`, carry attribution without a level.
+- **Conversational tiers are always per-session.** The verbatim window and medium-term digest use `kaos_group:<store group>|run:<session id>`; principal attribution is checked separately on reads. Session forget deletes one key; user, agent, and store forget use the erasure index.
+- **Agent configuration is read-only.** `maxReadScope` selects baseline recall and caps `search_memory`; it cannot exceed the MemoryStore ceiling. Writes, including `save_memory`, carry attribution without a level.
 - **Enforcement is fail-closed at the service.** Scope is derived **server-side** from the authenticated agent identity and request context — never trusted from model- or tool-supplied arguments. An operation that cannot resolve a usable owner key fails rather than querying an unscoped store. Because the vector providers pre-filter during the query, a tenant's relevant memories are never dropped by an unfiltered nearest-neighbour window.
-- **Erasure fans out synchronously across tiers.** User and agent long-term erasure use Mem0's native entity deletion. Session and group erasure use wildcard-qualified custom filters, falling back to filtered id listing plus per-id deletion where the pinned Mem0 version lacks filtered deletion. Pre-existing alpha records without compound attribution cannot be reached by a newly available user-level erasure; there is no data migration.
+- **Erasure fans out synchronously across tiers.** User and agent long-term erasure use Mem0's native entity deletion. Session and store erasure use wildcard-qualified custom filters, falling back to filtered id listing plus per-id deletion where needed.
 
 Gateway-derived principals propagate automatically over cross-agent (A2A) delegation. Administrative cross-user erasure remains deferred.
 
@@ -95,9 +95,9 @@ Gateway-derived principals propagate automatically over cross-agent (A2A) delega
 
 ## Control plane
 
-The `MemoryStore` CRD describes infrastructure, model bindings, extraction/failure defaults, and the store-wide default read scope. The two model roles reference an existing `ModelAPI`: `summarization` drives extraction and digest generation; `embedding` drives the vector index.
+The `MemoryStore` CRD describes infrastructure, model bindings, extraction/failure defaults, and the store-wide maximum read scope. The two model roles reference an existing `ModelAPI`: `summarization` drives extraction and digest generation; `embedding` drives the vector index.
 
-The Agent memory block selects a store and configures reads with `defaultReadScope`, `readScopes`, and tools. Enabling memory recalls before each run and flushes level-less attributed turns afterward.
+The Agent memory block selects a store and configures reads with `maxReadScope` and tools. Enabling memory recalls before each run and flushes level-less attributed turns afterward.
 
 Binding is fail-closed and degradation-aware:
 

--- a/docs/operator/memorystore-crd.md
+++ b/docs/operator/memorystore-crd.md
@@ -79,9 +79,9 @@ spec:
   # "soft" tolerates memory-write failures; "strict" surfaces them as errors.
   defaultFailureMode: soft
 
-  # Default read scope for agents that omit config.memory.defaultReadScope.
+  # Maximum read scope for every bound agent.
   # When omitted, agents fall back to "agent".
-  defaultReadScope: agent
+  maxReadScope: agent
 ```
 
 ## Storage Modes
@@ -169,7 +169,7 @@ The `shortTerm`, `mediumTerm`, and `longTerm` blocks tune the three memory tiers
 | `longTerm.extraction.systemPrompt` | string | built-in | Fact-extraction prompt override |
 | `requestConcurrency` | int | `8` | Bounded request executor size |
 | `defaultFailureMode` | string | `soft` | Default write/forget failure mode for bound agents (`soft` or `strict`) |
-| `defaultReadScope` | string | `session` | Default automatic read scope for bound agents: `agent`, `user`, `group`, or `session`; an Agent `config.memory.defaultReadScope` overrides it |
+| `maxReadScope` | string | `agent` | Maximum read scope for bound agents: `session`, `agent`, or `user` |
 
 ## Status
 
@@ -191,7 +191,7 @@ When ready, the store exposes an endpoint of the form `http://memorystore-<name>
 
 **Failure mode and degradation.** The store's `defaultFailureMode` (`soft` by default) governs how write and forget failures surface to bound agents. Under `soft`, a memory-write failure is tolerated: the agent's turn proceeds and the write is retried in the background. Under `strict`, the failure is surfaced as an error. Recall is always best-effort regardless of mode — if the long-term tier is unavailable, recall degrades to the short-term window rather than failing the turn. An individual Agent can override the store default in its `config.memory.failureMode`.
 
-**Default read scope.** `defaultReadScope` supplies the automatic recall level for bound agents that omit their own value. Resolution is Agent `defaultReadScope`, then store `defaultReadScope`, then `session`.
+**Maximum read scope.** `maxReadScope` is the store-owner ceiling. An Agent's `config.memory.maxReadScope` cannot exceed it; when omitted, the agent inherits the store ceiling.
 
 **Provisioning a development database.** For local development, `kaos system install --pgvector-memory-enabled` provisions a pgvector Postgres in the install namespace and writes a `kaos-memory-pgvector` connection Secret, ready to reference from an `external`-mode store's `connectionSecretRef`. This is a development convenience — production deployments point `connectionSecretRef` at a managed pgvector database.
 
@@ -212,7 +212,7 @@ spec:
     memory:
       type: remote
       memoryStore: shared-memory
-      defaultReadScope: user
+      maxReadScope: user
       tools: all
 ```
 

--- a/docs/operator/overview.md
+++ b/docs/operator/overview.md
@@ -173,7 +173,7 @@ The operator translates CRD fields to container environment variables:
 | `config.memory.enabled` | `MEMORY_ENABLED` |
 | `config.memory.type` | `MEMORY_TYPE` |
 | MemoryStore endpoint (remote only) | `MEMORY_STORE_ENDPOINT` |
-| `config.memory.defaultReadScope` | `MEMORY_DEFAULT_READ_SCOPE` |
+| `config.memory.maxReadScope` | `MEMORY_MAX_READ_SCOPE` |
 | `config.memory.tools` | `MEMORY_TOOLS` |
 | `config.memory.failureMode` | `MEMORY_FAILURE_MODE` |
 | `config.memory.clientParams.tokenBudget` | `MEMORY_SHORT_TERM_TOKEN_BUDGET` |

--- a/docs/python-framework/memory.md
+++ b/docs/python-framework/memory.md
@@ -21,8 +21,7 @@ The memory system provides session management and event storage for agents. It t
 | `MEMORY_MAX_SESSIONS` | `1000` | Max sessions (LocalMemory) |
 | `MEMORY_MAX_SESSION_EVENTS` | `500` | Max events per session (LocalMemory) |
 | `MEMORY_STORE_ENDPOINT` | - | Central memory-service URL (set by the operator when a MemoryStore is bound; selects `RemoteMemory`) |
-| `MEMORY_DEFAULT_READ_SCOPE` | `session` | Single scope used by automatic recall |
-| `MEMORY_READ_SCOPES` | `MEMORY_DEFAULT_READ_SCOPE` | Comma-separated entitlement list offered by `search_memory` |
+| `MEMORY_MAX_READ_SCOPE` | `session` | Automatic recall scope and maximum level offered by `search_memory` |
 | `MEMORY_TOOLS` | - | Additive explicit tools: `all`, `read`, or `write` |
 
 ### Via Agent CRD
@@ -34,8 +33,7 @@ spec:
       enabled: true
       type: remote            # "remote" (bound MemoryStore) or "local" (pod-local)
       memoryStore: shared-memory
-      defaultReadScope: user  # Automatic recall scope
-      readScopes: [user, agent] # search_memory entitlements
+      maxReadScope: user  # Automatic recall scope and search_memory ceiling
       tools: all              # all | read | write
       failureMode: soft       # soft | strict
 ```

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -36,8 +36,7 @@ Injected by the operator on memory-enabled agents. For the full model see [Memor
 | `MEMORY_ENABLED` | Enable/disable memory (uses NullMemory when disabled) | `true` |
 | `MEMORY_TYPE` | Backend: `local` (pod-local short-term) or `remote` (bound MemoryStore) | derived |
 | `MEMORY_STORE_ENDPOINT` | Memory service URL; injected only for `remote` (selects `RemoteMemory`) | — |
-| `MEMORY_DEFAULT_READ_SCOPE` | Automatic recall scope: `agent`, `user`, `group`, `session` | `session` |
-| `MEMORY_READ_SCOPES` | Comma-separated `search_memory` read entitlements | default read scope |
+| `MEMORY_MAX_READ_SCOPE` | Automatic recall scope and `search_memory` ceiling: `session`, `agent`, or `user` | `session` |
 | `MEMORY_REQUIRE_PRINCIPAL` | Require verified principal attribution on writes and narrow agent reads | posture-derived |
 | `MEMORY_REQUIRE_AGENT_IDENTITY` | Require stable agent attribution on writes | posture-derived |
 | `MEMORY_TOOLS` | Explicit memory tools: `all`, `read`, `write` (unset = none) | — |
@@ -141,8 +140,7 @@ The operator automatically sets these variables on agent pods:
 | `config.reasoningLoopMaxSteps` | `AGENTIC_LOOP_MAX_STEPS` |
 | `config.memory.enabled` | `MEMORY_ENABLED` |
 | `config.memory.type` | `MEMORY_TYPE` |
-| `config.memory.defaultReadScope` | `MEMORY_DEFAULT_READ_SCOPE` |
-| `config.memory.readScopes` | `MEMORY_READ_SCOPES` |
+| `config.memory.maxReadScope` | `MEMORY_MAX_READ_SCOPE` |
 | `config.memory.tools` | `MEMORY_TOOLS` |
 | `config.memory.failureMode` | `MEMORY_FAILURE_MODE` |
 | `config.memory.clientParams.tokenBudget` | `MEMORY_SHORT_TERM_TOKEN_BUDGET` |

--- a/examples/memory.ipynb
+++ b/examples/memory.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bb4f21b0",
+   "id": "3b66d6f1",
    "metadata": {},
    "source": [
     "# Agent Memory\n",
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6382ee7",
+   "id": "bcab9722",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c920a188",
+   "id": "1ff0e9d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab50b22c",
+   "id": "29bcd7c8",
    "metadata": {},
    "source": [
     "## Step 1: Deploy a Memory-Enabled Agent\n",
@@ -71,8 +71,8 @@
     "The important part is the agent's `config.memory` block:\n",
     "\n",
     "- `memoryStore: support-memory` binds all three agents to the store.\n",
-    "- `user-assistant` uses `defaultReadScope: user`; `session-assistant` keeps the session fallback.\n",
-    "- `agent-bot` states `defaultReadScope: agent` and exposes no explicit memory tools.\n",
+    "- `user-assistant` uses `maxReadScope: user`; `session-assistant` uses `maxReadScope: session`.\n",
+    "- `agent-bot` states `maxReadScope: agent` and exposes no explicit memory tools.\n",
     "- The store tunes its tiers with typed fields: a small `shortTerm.tokenBudget` makes conversational compaction easy to exercise, and `mediumTerm.enabled` turns on the rolling digest that folds the overflow.\n",
     "\n",
     "`DEBUG_MOCK_RESPONSES` makes the agent return a canned reply instead of calling the model, so the run is deterministic."
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "878976e3",
+   "id": "564e69a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c72e9424",
+   "id": "87815271",
    "metadata": {},
    "source": [
     "## Step 2: Wait for the Store and the Agent\n",
@@ -102,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0356e891",
+   "id": "f0d33643",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "928b6af1",
+   "id": "58639acd",
    "metadata": {},
    "source": [
     "The tool output shows the `session-assistant` has a `session`-only entitlement. On a cluster configured with user identity, run the same command for `user-assistant` to see `search_memory.parameters_json_schema.properties.level.enum` include `session`, `agent`, `user`, and `group`.\n",
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "961d5bd1",
+   "id": "016a0faf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,37 +157,37 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3617b84b",
+   "id": "84ce4415",
    "metadata": {},
    "source": [
     "## Step 4: Verify the Agent Wrote to the Store\n",
     "\n",
-    "Now we confirm the integration through `kaos memory`. `--all` uses the store's faithful list path, while session scope and `--short-term` return the same conversation's rolling summary and verbatim window:"
+    "Now we confirm the integration through `kaos memory`. With no query the command uses the list path, and the default `--include all` returns the same conversation's rolling summary and verbatim window:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3dfd2317",
+   "id": "4345ff78",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
-    "kaos memory recall --store support-memory --scope session --session memory-session-1 --all --short-term -n \"$NAMESPACE\" --json > ./tmp/recall-session1.json\n",
+    "kaos memory recall --store support-memory --scope session --session memory-session-1 -n \"$NAMESPACE\" --json > ./tmp/recall-session1.json\n",
     "cat ./tmp/recall-session1.json"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f488334",
+   "id": "48196f8f",
    "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
     "\n",
     "recall = json.load(open(\"./tmp/recall-session1.json\"))\n",
-    "recent = [tuple(pair) for pair in recall[\"short_term\"][\"recent\"]]\n",
+    "recent = [tuple(pair) for pair in recall[\"short_term\"][\"window\"]]\n",
     "print(\"Stored turns:\", recent)\n",
     "\n",
     "assert (\"user\", \"My favourite deployment port is 8080\") in recent\n",
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08ccfb3c",
+   "id": "98bcf2df",
    "metadata": {},
    "source": [
     "## Step 5: Session 2 — A Separate Conversational Window\n",
@@ -207,23 +207,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65d1248d",
+   "id": "86348c39",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
-    "kaos memory recall --store support-memory --scope session --session memory-session-2 --all --short-term -n \"$NAMESPACE\" --json > ./tmp/recall-session2.json"
+    "kaos memory recall --store support-memory --scope session --session memory-session-2 -n \"$NAMESPACE\" --json > ./tmp/recall-session2.json"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad3d0cc1",
+   "id": "bbf21f29",
    "metadata": {},
    "outputs": [],
    "source": [
     "recall = json.load(open(\"./tmp/recall-session2.json\"))\n",
-    "recent = [tuple(pair) for pair in recall[\"short_term\"][\"recent\"]]\n",
+    "recent = [tuple(pair) for pair in recall[\"short_term\"][\"window\"]]\n",
     "print(\"Session 2 window:\", recent)\n",
     "\n",
     "assert recent == []\n",
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c86a44aa",
+   "id": "73079373",
    "metadata": {},
    "source": [
     "## Enabling the Tools\n",
@@ -242,7 +242,7 @@
     "| Setting | Tools exposed | Arguments | The model can… |\n",
     "|---------|---------------|-----------|----------------|\n",
     "| _(unset)_ | none | — | rely purely on automatic recall/persist |\n",
-    "| `read` | `search_memory` | `query`, required entitled `level` | look facts up at `session`, `agent`, `user`, or `group` when configured |\n",
+    "| `read` | `search_memory` | `query`, required entitled `level` | look facts up at every level through `maxReadScope` |\n",
     "| `write` | `save_memory` | `content` | save a durable fact with server-derived attribution |\n",
     "| `all` | both | as above | save and search on demand |\n",
     "\n",
@@ -250,10 +250,10 @@
     "\n",
     "## Scopes\n",
     "\n",
-    "Reads are partitioned by scope through `defaultReadScope` and `readScopes`; writes attach every verified contributor without a level:\n",
+    "Reads are partitioned by scope through `maxReadScope`; writes attach every verified contributor without a level:\n",
     "\n",
     "- `session` — one conversation only.\n",
-    "- `group` — extracted facts are shared by every agent and session on the store; raw turns remain session-local.\n",
+    "- `store` — the whole-store administrative view; unavailable to agent actor requests.\n",
     "- `user` — all sessions for an authenticated principal.\n",
     "- `agent` — only this specific agent.\n",
     "\n",
@@ -297,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107d34e6",
+   "id": "470a39eb",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/kaos-cli/kaos_cli/agent/__init__.py
+++ b/kaos-cli/kaos_cli/agent/__init__.py
@@ -47,7 +47,9 @@ def build_agent(
         "agent:agent",
         help="Module:object target (default: agent:agent). No .py extension.",
     ),
-    image: str = typer.Option(..., "--image", "-i", help="Image name with tag (e.g. my-agent:latest)."),
+    image: str = typer.Option(
+        ..., "--image", "-i", help="Image name with tag (e.g. my-agent:latest)."
+    ),
     directory: str = typer.Option(".", "--dir", "-d", help="Source directory."),
     kind_load: bool = typer.Option(
         False, "--kind-load", help="Load image to KIND cluster."
@@ -94,7 +96,9 @@ def run_agent(
     ),
     host: str = typer.Option("0.0.0.0", "--host", help="Bind host."),
     port: int = typer.Option(8000, "--port", "-p", help="Bind port."),
-    reload: bool = typer.Option(False, "--reload", "-r", help="Auto-reload on changes."),
+    reload: bool = typer.Option(
+        False, "--reload", "-r", help="Auto-reload on changes."
+    ),
 ) -> None:
     """Run a Pydantic AI agent server locally."""
     run_command(target=target, host=host, port=port, reload=reload)
@@ -245,22 +249,25 @@ def deploy_agent_cmd(
         None, "--auto-interval", help="Seconds between autonomous iterations."
     ),
     task_max_iterations: int = typer.Option(
-        None, "--task-max-iterations", help="Max iterations for A2A async tasks (0=unlimited)."
+        None,
+        "--task-max-iterations",
+        help="Max iterations for A2A async tasks (0=unlimited).",
     ),
     task_max_runtime: int = typer.Option(
-        None, "--task-max-runtime", help="Max runtime in seconds for A2A async tasks (0=unlimited)."
+        None,
+        "--task-max-runtime",
+        help="Max runtime in seconds for A2A async tasks (0=unlimited).",
     ),
     task_max_tool_calls: int = typer.Option(
-        None, "--task-max-tool-calls", help="Max cumulative tool calls for A2A async tasks (0=unlimited)."
+        None,
+        "--task-max-tool-calls",
+        help="Max cumulative tool calls for A2A async tasks (0=unlimited).",
     ),
     memory_store: str = typer.Option(
         None, "--memory-store", help="MemoryStore reference."
     ),
-    memory_default_read_scope: str = typer.Option(
-        None, "--memory-default-read-scope", help="Default memory read scope."
-    ),
-    memory_read_scopes: str = typer.Option(
-        None, "--memory-read-scopes", help="Comma-separated allowed memory read scopes."
+    memory_max_read_scope: str = typer.Option(
+        None, "--memory-max-read-scope", help="Maximum memory read scope."
     ),
     memory_tools: str = typer.Option(
         None, "--memory-tools", help="Memory tools to expose: read, write, or all."
@@ -286,9 +293,7 @@ def deploy_agent_cmd(
         typer.echo("Error: --build requires --image to be set", err=True)
         sys.exit(1)
 
-    if not memory_store and any(
-        (memory_default_read_scope, memory_read_scopes, memory_tools)
-    ):
+    if not memory_store and any((memory_max_read_scope, memory_tools)):
         typer.echo(
             "Error: memory read scope and tools flags require --memory-store",
             err=True,
@@ -335,8 +340,7 @@ def deploy_agent_cmd(
         task_max_runtime=task_max_runtime,
         task_max_tool_calls=task_max_tool_calls,
         memory_store=memory_store,
-        memory_default_read_scope=memory_default_read_scope,
-        memory_read_scopes=memory_read_scopes,
+        memory_max_read_scope=memory_max_read_scope,
         memory_tools=memory_tools,
         wait=wait,
         wait_timeout=wait_timeout,
@@ -413,7 +417,7 @@ def status_agent(
     ),
 ) -> None:
     """Get agent status and capabilities via agent card.
-    
+
     Examples:
       kaos agent status my-agent
       kaos agent status my-agent --json
@@ -450,7 +454,7 @@ def memory_agent(
     ),
 ) -> None:
     """Get agent memory events.
-    
+
     Examples:
       kaos agent memory my-agent
       kaos agent memory my-agent --json

--- a/kaos-cli/kaos_cli/agent/deploy.py
+++ b/kaos-cli/kaos_cli/agent/deploy.py
@@ -57,8 +57,7 @@ def deploy_agent(
     task_max_runtime: int | None = None,
     task_max_tool_calls: int | None = None,
     memory_store: str | None = None,
-    memory_default_read_scope: str | None = None,
-    memory_read_scopes: str | None = None,
+    memory_max_read_scope: str | None = None,
     memory_tools: str | None = None,
     wait: bool = False,
     wait_timeout: int = DEFAULT_WAIT_TIMEOUT,
@@ -72,8 +71,19 @@ def deploy_agent(
     )
 
     # Add config section if description, instructions, telemetry, autonomous, or task budgets provided
-    has_task_budgets = task_max_iterations is not None or task_max_runtime is not None or task_max_tool_calls is not None
-    has_config = description or instructions or otel_endpoint or autonomous or has_task_budgets or memory_store
+    has_task_budgets = (
+        task_max_iterations is not None
+        or task_max_runtime is not None
+        or task_max_tool_calls is not None
+    )
+    has_config = (
+        description
+        or instructions
+        or otel_endpoint
+        or autonomous
+        or has_task_budgets
+        or memory_store
+    )
     if has_config:
         yaml_content += "  config:\n"
         if description:
@@ -106,18 +116,8 @@ def deploy_agent(
             yaml_content += "    memory:\n"
             yaml_content += "      type: remote\n"
             yaml_content += f"      memoryStore: {memory_store}\n"
-            if memory_default_read_scope:
-                yaml_content += f"      defaultReadScope: {memory_default_read_scope}\n"
-            if memory_read_scopes:
-                scopes = [
-                    scope.strip()
-                    for scope in memory_read_scopes.split(",")
-                    if scope.strip()
-                ]
-                if scopes:
-                    yaml_content += "      readScopes:\n"
-                    for scope in scopes:
-                        yaml_content += f"      - {scope}\n"
+            if memory_max_read_scope:
+                yaml_content += f"      maxReadScope: {memory_max_read_scope}\n"
             if memory_tools:
                 yaml_content += f"      tools: {memory_tools}\n"
 

--- a/kaos-cli/kaos_cli/memory/__init__.py
+++ b/kaos-cli/kaos_cli/memory/__init__.py
@@ -19,7 +19,7 @@ class ScopeChoice(str, Enum):
     SESSION = "session"
     AGENT = "agent"
     USER = "user"
-    GROUP = "group"
+    STORE = "store"
 
 
 class MemoryCLIError(RuntimeError):
@@ -40,10 +40,19 @@ def build_scope(
         raise ValueError(f"unknown memory scope: {level}")
 
     supplied = [name for name, value in owners.items() if value is not None]
-    if level == "group":
+    if level == "store":
         if supplied:
-            raise ValueError("group scope does not take an owner flag")
-        return {"level": "group"}
+            raise ValueError("store scope does not take an owner flag")
+        return {"level": "store"}
+
+    if level == "session" and supplied == ["session", "user"]:
+        if not session or not session.strip() or not user or not user.strip():
+            raise ValueError("--session and --user require non-empty values")
+        return {
+            "level": "session",
+            "session_id": session.strip(),
+            "principal": user.strip(),
+        }
 
     if supplied != [level]:
         flag = f"--{level}"
@@ -173,13 +182,15 @@ def _request(
 
 def _print_recall(data: dict[str, Any], scope: dict[str, str]) -> None:
     typer.echo(f"Scope: {json.dumps(scope, sort_keys=True)}")
-    facts = data.get("facts", [])
-    typer.echo(f"Long-term records: {len(facts)}")
-    for fact in facts:
-        typer.echo(f"  - {fact.get('memory', json.dumps(fact, sort_keys=True))}")
+    long_term = data.get("long_term")
+    if long_term is not None:
+        facts = long_term.get("facts", [])
+        typer.echo(f"Long-term records: {len(facts)}")
+        for fact in facts:
+            typer.echo(f"  - {fact.get('memory', json.dumps(fact, sort_keys=True))}")
 
     summary = (data.get("medium_term") or {}).get("summary", "")
-    recent = (data.get("short_term") or {}).get("recent", [])
+    recent = (data.get("short_term") or {}).get("window", [])
     if summary:
         typer.echo(f"Medium-term summary: {summary}")
     if recent:
@@ -209,7 +220,6 @@ def _scope_from_options(
         raise MemoryCLIError(str(exc)) from exc
 
 
-
 def _resolve_user(user: str | None) -> str | None:
     """Resolve a login username to its verified subject via the cached session.
 
@@ -233,13 +243,43 @@ def _resolve_user(user: str | None) -> str | None:
         except (KeyError, IndexError, ValueError, AttributeError, OSError):
             return user
         if sub:
-            typer.echo(f"Resolved user '{user}' to principal '{sub}' from the cached login.", err=True)
+            typer.echo(
+                f"Resolved user '{user}' to principal '{sub}' from the cached login.",
+                err=True,
+            )
             return sub
         return user
     return user
 
 
 app = typer.Typer(help="Inspect and erase central memory stores.", no_args_is_help=True)
+
+
+def parse_include(values: list[str] | None) -> list[str]:
+    """Expand repeatable, comma-separated recall tier aliases."""
+    aliases = {
+        "s": "short_term",
+        "short-term": "short_term",
+        "m": "medium_term",
+        "medium-term": "medium_term",
+        "l": "long_term",
+        "long-term": "long_term",
+    }
+    requested = values or ["all"]
+    tiers: list[str] = []
+    for value in requested:
+        for member in value.split(","):
+            member = member.strip().lower()
+            if member in {"a", "all"}:
+                expanded = ["short_term", "medium_term", "long_term"]
+            elif member in aliases:
+                expanded = [aliases[member]]
+            else:
+                raise MemoryCLIError(f"unknown --include value: {member or value}")
+            for tier in expanded:
+                if tier not in tiers:
+                    tiers.append(tier)
+    return tiers
 
 
 @app.command(name="recall")
@@ -249,10 +289,13 @@ def recall_memory(
     session: str = typer.Option(None, "--session", help="Session owner ID."),
     agent: str = typer.Option(None, "--agent", help="Agent owner name."),
     user: str = typer.Option(None, "--user", help="User principal owner."),
-    query: str = typer.Option(None, "--query", help="Semantic recall query."),
-    all_records: bool = typer.Option(False, "--all", help="List every scoped record."),
-    short_term: bool = typer.Option(
-        False, "--short-term", help="Include conversational memory tiers."
+    long_term_query: str = typer.Option(
+        None, "--long-term-query", "-q", help="Semantic long-term recall query."
+    ),
+    include: list[str] = typer.Option(
+        None,
+        "--include",
+        help="Tier: a|all|s|short-term|m|medium-term|l|long-term; repeat or comma-separate.",
     ),
     top_k: int = typer.Option(10, "--top-k", min=1, help="Maximum semantic results."),
     namespace: str = typer.Option(
@@ -262,10 +305,11 @@ def recall_memory(
 ) -> None:
     """Recall semantic or complete memory at one scope."""
     try:
-        if (query is None and not all_records) or (query is not None and all_records):
-            raise MemoryCLIError("exactly one of --query or --all is required")
-        if query is not None and not query.strip():
-            raise MemoryCLIError("--query requires non-empty text")
+        tiers = parse_include(include)
+        if long_term_query is not None and not long_term_query.strip():
+            raise MemoryCLIError("--long-term-query requires non-empty text")
+        if long_term_query is not None and "long_term" not in tiers:
+            raise MemoryCLIError("--long-term-query requires long-term in --include")
 
         user = _resolve_user(user)
         # Validate owner flags before consulting Kubernetes for the default namespace.
@@ -280,13 +324,13 @@ def recall_memory(
 
         payload: dict[str, Any] = {
             "scope": resolved_scope,
-            "include_short_term": short_term,
+            "include": tiers,
         }
-        if all_records:
-            path = "/v1/list"
-        else:
+        if long_term_query is not None:
             path = "/v1/recall"
-            payload.update({"query": query, "top_k": top_k})
+            payload.update({"query": long_term_query.strip(), "top_k": top_k})
+        else:
+            path = "/v1/list"
         data = _request("POST", path, payload, target, remote_port, resolved_namespace)
 
         if output_json:

--- a/kaos-cli/kaos_cli/memorystore/__init__.py
+++ b/kaos-cli/kaos_cli/memorystore/__init__.py
@@ -29,8 +29,8 @@ def create_memorystore_cmd(
     medium_term_enabled: bool = typer.Option(
         False, "--medium-term-enabled", help="Enable rolling medium-term summaries."
     ),
-    default_read_scope: str = typer.Option(
-        None, "--default-read-scope", help="Default memory read scope."
+    max_read_scope: str = typer.Option(
+        None, "--max-read-scope", help="Maximum memory read scope."
     ),
     failure_mode: str = typer.Option(
         None, "--failure-mode", help="Default failure mode: soft or strict."
@@ -55,7 +55,7 @@ def create_memorystore_cmd(
         embedding_model=embedding_model,
         short_term_token_budget=short_term_token_budget,
         medium_term_enabled=medium_term_enabled,
-        default_read_scope=default_read_scope,
+        max_read_scope=max_read_scope,
         failure_mode=failure_mode,
         namespace=namespace,
         dry_run=dry_run,

--- a/kaos-cli/kaos_cli/memorystore/create.py
+++ b/kaos-cli/kaos_cli/memorystore/create.py
@@ -15,7 +15,7 @@ def create_memorystore(
     embedding_model: str,
     short_term_token_budget: int | None,
     medium_term_enabled: bool,
-    default_read_scope: str | None,
+    max_read_scope: str | None,
     failure_mode: str | None,
     namespace: str | None,
     dry_run: bool,
@@ -41,8 +41,8 @@ spec:
       modelAPI: {modelapi}
       model: {embedding_model}
 """
-    if default_read_scope:
-        yaml_content += f"  defaultReadScope: {default_read_scope}\n"
+    if max_read_scope:
+        yaml_content += f"  maxReadScope: {max_read_scope}\n"
     if failure_mode:
         yaml_content += f"  defaultFailureMode: {failure_mode}\n"
     if short_term_token_budget is not None:

--- a/kaos-cli/tests/test_agent_tools.py
+++ b/kaos-cli/tests/test_agent_tools.py
@@ -33,7 +33,7 @@ def _mock_tools(monkeypatch):
                     "properties": {
                         "level": {
                             "type": "string",
-                            "enum": ["session", "agent", "group"],
+                            "enum": ["session", "agent", "store"],
                         }
                     },
                 },

--- a/kaos-cli/tests/test_cli_integration.py
+++ b/kaos-cli/tests/test_cli_integration.py
@@ -262,10 +262,8 @@ class TestAgentDeployDryRun:
                 "gpt-4o-mini",
                 "--memory-store",
                 "support-memory",
-                "--memory-default-read-scope",
+                "--memory-max-read-scope",
                 "user",
-                "--memory-read-scopes",
-                "session,agent,user,group",
                 "--memory-tools",
                 "read",
                 "--dry-run",
@@ -276,16 +274,14 @@ class TestAgentDeployDryRun:
         assert agent["spec"]["config"]["memory"] == {
             "type": "remote",
             "memoryStore": "support-memory",
-            "defaultReadScope": "user",
-            "readScopes": ["session", "agent", "user", "group"],
+            "maxReadScope": "user",
             "tools": "read",
         }
 
     @pytest.mark.parametrize(
         "flag,value",
         [
-            ("--memory-default-read-scope", "user"),
-            ("--memory-read-scopes", "session,user"),
+            ("--memory-max-read-scope", "user"),
             ("--memory-tools", "read"),
         ],
     )
@@ -538,7 +534,7 @@ class TestMemoryStoreCreateDryRun:
                 "--short-term-token-budget",
                 "64",
                 "--medium-term-enabled",
-                "--default-read-scope",
+                "--max-read-scope",
                 "user",
                 "--failure-mode",
                 "strict",
@@ -547,7 +543,7 @@ class TestMemoryStoreCreateDryRun:
         )
         assert result.exit_code == 0
         spec = yaml.safe_load(result.output)["spec"]
-        assert spec["defaultReadScope"] == "user"
+        assert spec["maxReadScope"] == "user"
         assert spec["defaultFailureMode"] == "strict"
         assert spec["shortTerm"] == {"tokenBudget": 64}
         assert spec["mediumTerm"] == {"enabled": True}
@@ -778,17 +774,15 @@ class TestSamples:
         assert {agent["spec"]["model"] for agent in agents.values()} == {"gpt-test"}
         user_memory = agents["user-assistant"]["spec"]["config"]["memory"]
         assert "scope" not in user_memory
-        assert user_memory["defaultReadScope"] == "user"
+        assert user_memory["maxReadScope"] == "user"
         assert user_memory["tools"] == "read"
-        assert user_memory["readScopes"] == ["session", "agent", "user", "group"]
         assert user_memory["clientParams"]["tokenBudget"] == 64
         session_memory = agents["session-assistant"]["spec"]["config"]["memory"]
         assert "scope" not in session_memory
         assert session_memory["tools"] == "read"
-        assert "defaultReadScope" not in session_memory
-        assert "readScopes" not in session_memory
+        assert session_memory["maxReadScope"] == "session"
         agent_memory = agents["agent-bot"]["spec"]["config"]["memory"]
-        assert agent_memory["defaultReadScope"] == "agent"
+        assert agent_memory["maxReadScope"] == "agent"
         assert "scope" not in agent_memory
         assert "tools" not in agent_memory
 
@@ -806,7 +800,7 @@ class TestSamples:
         assert store["spec"]["storage"]["type"] == "local"
         agent = next(d for d in docs if d["kind"] == "Agent")
         assert agent["spec"]["config"]["memory"]["memoryStore"] == "support-memory"
-        assert agent["spec"]["config"]["memory"]["defaultReadScope"] == "user"
+        assert agent["spec"]["config"]["memory"]["maxReadScope"] == "user"
         result = runner.invoke(
             app, ["samples", "deploy", "1-simple-echo-agent", "--dry-run"]
         )

--- a/kaos-cli/tests/test_memory_cli.py
+++ b/kaos-cli/tests/test_memory_cli.py
@@ -6,7 +6,12 @@ import pytest
 from typer.testing import CliRunner
 
 from kaos_cli.main import app
-from kaos_cli.memory import MemoryCLIError, build_scope, resolve_memory_store
+from kaos_cli.memory import (
+    MemoryCLIError,
+    build_scope,
+    parse_include,
+    resolve_memory_store,
+)
 
 runner = CliRunner()
 
@@ -24,7 +29,12 @@ runner = CliRunner()
             },
         ),
         ("user", {"user": "alice"}, {"level": "user", "principal": "alice"}),
-        ("group", {}, {"level": "group"}),
+        ("store", {}, {"level": "store"}),
+        (
+            "session",
+            {"session": "s1", "user": "alice"},
+            {"level": "session", "session_id": "s1", "principal": "alice"},
+        ),
     ],
 )
 def test_build_scope_matches_memory_contract(level, kwargs, expected):
@@ -37,7 +47,7 @@ def test_build_scope_matches_memory_contract(level, kwargs, expected):
         ("session", {}, "--session is required"),
         ("agent", {"user": "alice"}, "--agent is the only owner flag"),
         ("user", {"user": "alice", "session": "s1"}, "--user is the only owner flag"),
-        ("group", {"agent": "assistant"}, "group scope does not take"),
+        ("store", {"agent": "assistant"}, "store scope does not take"),
     ],
 )
 def test_build_scope_rejects_owner_mismatch(level, kwargs, message):
@@ -110,7 +120,10 @@ def test_recall_query_sends_qualified_agent_scope(monkeypatch):
             remote_port=remote_port,
             namespace=namespace,
         )
-        return {"facts": [{"memory": "known fact"}], "degraded": False}
+        return {
+            "long_term": {"facts": [{"memory": "known fact"}], "block": ""},
+            "degraded": False,
+        }
 
     monkeypatch.setattr("kaos_cli.memory._request", request)
 
@@ -123,11 +136,12 @@ def test_recall_query_sends_qualified_agent_scope(monkeypatch):
             "agent",
             "--agent",
             "assistant",
-            "--query",
+            "-q",
             "preferences",
             "--top-k",
             "4",
-            "--short-term",
+            "--include",
+            "s,l",
             "-n",
             "support",
             "--json",
@@ -135,14 +149,14 @@ def test_recall_query_sends_qualified_agent_scope(monkeypatch):
     )
 
     assert result.exit_code == 0
-    assert json.loads(result.output)["facts"] == [{"memory": "known fact"}]
+    assert json.loads(result.output)["long_term"]["facts"] == [{"memory": "known fact"}]
     assert captured["path"] == "/v1/recall"
     assert captured["payload"] == {
         "scope": {
             "level": "agent",
             "agent_client_id": "kaos://agent/support/assistant",
         },
-        "include_short_term": True,
+        "include": ["short_term", "long_term"],
         "query": "preferences",
         "top_k": 4,
     }
@@ -160,13 +174,16 @@ def test_recall_all_uses_list_path(monkeypatch):
 
     result = runner.invoke(
         app,
-        ["memory", "recall", "--scope", "group", "--all", "--json"],
+        ["memory", "recall", "--scope", "store", "--json"],
     )
 
     assert result.exit_code == 0
     assert captured == {
         "path": "/v1/list",
-        "payload": {"scope": {"level": "group"}, "include_short_term": False},
+        "payload": {
+            "scope": {"level": "store"},
+            "include": ["short_term", "medium_term", "long_term"],
+        },
     }
 
 
@@ -185,7 +202,7 @@ def test_recall_rejects_owner_mismatch_before_cluster_access(monkeypatch):
             "user",
             "--agent",
             "assistant",
-            "--query",
+            "-q",
             "x",
         ],
     )
@@ -221,11 +238,43 @@ def test_forget_yes_prints_result_and_degraded_is_failure(monkeypatch):
 
     result = runner.invoke(
         app,
-        ["memory", "forget", "--scope", "group", "--yes"],
+        ["memory", "forget", "--scope", "store", "--yes"],
     )
 
     assert result.exit_code == 1
     assert '{"forgotten": true, "degraded": true}' in result.output
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        (None, ["short_term", "medium_term", "long_term"]),
+        (["S,m", "long-term", "s"], ["short_term", "medium_term", "long_term"]),
+        (["a", "l"], ["short_term", "medium_term", "long_term"]),
+    ],
+)
+def test_parse_include_aliases_commas_repeats_and_dedupes(values, expected):
+    assert parse_include(values) == expected
+
+
+def test_parse_include_rejects_unknown_value():
+    with pytest.raises(MemoryCLIError, match="unknown --include value"):
+        parse_include(["archive"])
+
+
+def test_query_requires_long_term_include(monkeypatch):
+    monkeypatch.setattr(
+        "kaos_cli.memory._effective_namespace",
+        lambda namespace: pytest.fail("Kubernetes should not be consulted"),
+    )
+
+    result = runner.invoke(
+        app,
+        ["memory", "recall", "--scope", "store", "-q", "x", "--include", "s,m"],
+    )
+
+    assert result.exit_code == 1
+    assert "requires long-term" in result.output
 
 
 def test_forget_yes_returns_successful_service_result(monkeypatch):
@@ -247,7 +296,9 @@ def test_forget_yes_returns_successful_service_result(monkeypatch):
 def _fake_jwt(sub: str) -> str:
     import base64
 
-    payload = base64.urlsafe_b64encode(json.dumps({"sub": sub}).encode()).decode().rstrip("=")
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"sub": sub}).encode()).decode().rstrip("=")
+    )
     return f"header.{payload}.signature"
 
 
@@ -256,7 +307,9 @@ def test_resolve_user_substitutes_cached_login_sub(tmp_path, monkeypatch):
 
     config = tmp_path / ".kaos-config.yaml"
     config.write_text(
-        json.dumps({"sessions": {"alice": {"token": _fake_jwt("sub-123"), "active": True}}})
+        json.dumps(
+            {"sessions": {"alice": {"token": _fake_jwt("sub-123"), "active": True}}}
+        )
     )
     monkeypatch.chdir(tmp_path)
     assert _resolve_user("alice") == "sub-123"
@@ -266,7 +319,9 @@ def test_resolve_user_passes_through_unknown_and_raw_subs(tmp_path, monkeypatch)
     from kaos_cli.memory import _resolve_user
 
     config = tmp_path / ".kaos-config.yaml"
-    config.write_text(json.dumps({"sessions": {"alice": {"token": _fake_jwt("sub-123")}}}))
+    config.write_text(
+        json.dumps({"sessions": {"alice": {"token": _fake_jwt("sub-123")}}})
+    )
     monkeypatch.chdir(tmp_path)
     assert _resolve_user("bob") == "bob"
     assert _resolve_user("9dfcf3f2-7ec0-485d") == "9dfcf3f2-7ec0-485d"

--- a/kaos-memory/README.md
+++ b/kaos-memory/README.md
@@ -30,14 +30,16 @@ A `Scope` selects long-term read visibility and erasure. An `Attribution` write 
 
 | Scope level | Long-term read filter |
 | --- | --- |
-| `agent` | `agent_id = <real agent identity>` |
+| `agent` | `agent_id = <real agent identity>` and, when present, `user_id = <principal>` |
 | `user` | `user_id = <principal>`; includes everything that user contributed through any agent/session |
-| `session` | `user_id = "*"`, `kaos_run = <session id>` |
-| `group` | `user_id = "*"`, `kaos_group = <active collection name>` |
+| `session` | `kaos_run = <session id>` and, when present, `user_id = <principal>` |
+| `store` | `user_id = "*"`, `kaos_group = <active collection name>`; admin plane only |
 
-The wildcard is the pinned Mem0 2.0.10 convention required for custom-metadata filters. The group value is the configured local/external collection name because one `MemoryStore` is the physical group boundary; there is no synthetic agent sentinel. User/agent erasure uses native entity deletion, while session/group erasure filters custom attribution and deletes matching ids when Mem0 lacks a filtered-delete surface.
+The wildcard is the pinned Mem0 2.0.10 convention required for custom-metadata filters. The internal `kaos_group` value is the configured collection name because one `MemoryStore` is the physical boundary; there is no synthetic agent sentinel. User/agent erasure uses native entity deletion, while session/store erasure filters custom attribution and deletes matching ids when Mem0 lacks a filtered-delete surface.
 
-Short- and medium-term keys have the form `kaos_group:<store group>|run:<session id>` (or just `run:<session id>` without a configured group) for every scope. A missing session id fails loudly. The store group is the tenant boundary and the unguessable run id is the capability used through the scoped service and its network/RBAC boundary. A separate attribution index preserves user-, agent-, and group-level erasure without putting those identities into the session key. Group scope therefore shares extracted long-term facts across agents, not raw turns across sessions.
+Short- and medium-term keys have the form `kaos_group:<store group>|run:<session id>` (or just `run:<session id>` without a configured group). A principal-bound read must match the session's attribution; a mismatch returns empty. A separate attribution index preserves user-, agent-, and store-level erasure without putting those identities into the session key.
+
+Recall and list requests select tiers with `include: ["short_term", "medium_term", "long_term"]`. Responses contain only requested tier objects: `long_term.{facts,block}`, `medium_term.summary`, and `short_term.window`, plus top-level `degraded`.
 
 ## Development
 

--- a/kaos-memory/kaos_memory/app.py
+++ b/kaos-memory/kaos_memory/app.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Header
 from fastapi.responses import JSONResponse
 from opentelemetry import trace
 
@@ -38,6 +38,8 @@ from kaos_memory.contract import (
     ForgetRequest,
     ForgetResponse,
     ListRequest,
+    LongTermContext,
+    MemoryTier,
     MediumTermContext,
     RecallRequest,
     RecallResponse,
@@ -213,7 +215,7 @@ class MemoryService:
             span.set_attribute("kaos.memory.scope_level", req.scope.level.value)
             facts: list = []
             degraded = False
-            if self.long_term_enabled:
+            if MemoryTier.LONG_TERM in req.include and self.long_term_enabled:
                 top_k = req.top_k if req.top_k is not None else self.default_top_k
                 try:
                     facts = self.longterm.recall(req.scope, req.query, top_k=top_k)
@@ -221,8 +223,9 @@ class MemoryService:
                     degraded = True
 
             summary, recent = "", []
-            if req.include_short_term and req.scope.session_id is not None:
+            if MemoryTier.MEDIUM_TERM in req.include and req.scope.session_id is not None:
                 summary = self.short_term.summary(req.scope)
+            if MemoryTier.SHORT_TERM in req.include and req.scope.session_id is not None:
                 recent = self.short_term.active_window(
                     req.scope, token_budget=req.short_term_token_budget
                 )
@@ -231,10 +234,21 @@ class MemoryService:
             span.set_attribute("kaos.memory.fact_count", len(facts))
             block = assemble_block(facts)
             return RecallResponse(
-                facts=facts,
-                short_term=ShortTermContext(recent=recent),
-                medium_term=MediumTermContext(summary=summary),
-                block=block,
+                long_term=(
+                    LongTermContext(facts=facts, block=block)
+                    if MemoryTier.LONG_TERM in req.include
+                    else None
+                ),
+                short_term=(
+                    ShortTermContext(window=recent)
+                    if MemoryTier.SHORT_TERM in req.include
+                    else None
+                ),
+                medium_term=(
+                    MediumTermContext(summary=summary)
+                    if MemoryTier.MEDIUM_TERM in req.include
+                    else None
+                ),
                 degraded=degraded,
             )
 
@@ -244,15 +258,16 @@ class MemoryService:
             span.set_attribute("kaos.memory.scope_level", req.scope.level.value)
             facts: list = []
             degraded = False
-            if self.long_term_enabled:
+            if MemoryTier.LONG_TERM in req.include and self.long_term_enabled:
                 try:
                     facts = self.longterm.get_all(req.scope)
                 except Exception:
                     degraded = True
 
             summary, recent = "", []
-            if req.include_short_term and req.scope.session_id is not None:
+            if MemoryTier.MEDIUM_TERM in req.include and req.scope.session_id is not None:
                 summary = self.short_term.summary(req.scope)
+            if MemoryTier.SHORT_TERM in req.include and req.scope.session_id is not None:
                 recent = self.short_term.active_window(
                     req.scope, token_budget=req.short_term_token_budget
                 )
@@ -260,10 +275,21 @@ class MemoryService:
             span.set_attribute("kaos.memory.degraded", degraded)
             span.set_attribute("kaos.memory.fact_count", len(facts))
             return RecallResponse(
-                facts=facts,
-                short_term=ShortTermContext(recent=recent),
-                medium_term=MediumTermContext(summary=summary),
-                block=assemble_block(facts),
+                long_term=(
+                    LongTermContext(facts=facts, block=assemble_block(facts))
+                    if MemoryTier.LONG_TERM in req.include
+                    else None
+                ),
+                short_term=(
+                    ShortTermContext(window=recent)
+                    if MemoryTier.SHORT_TERM in req.include
+                    else None
+                ),
+                medium_term=(
+                    MediumTermContext(summary=summary)
+                    if MemoryTier.MEDIUM_TERM in req.include
+                    else None
+                ),
                 degraded=degraded,
             )
 
@@ -392,22 +418,30 @@ def create_app(
         code = 200 if result["ready"] else 503
         return JSONResponse(result, status_code=code)
 
-    @app.post("/v1/recall", response_model=RecallResponse)
-    async def recall(req: RecallRequest) -> RecallResponse | JSONResponse:
+    @app.post("/v1/recall", response_model=RecallResponse, response_model_exclude_none=True)
+    async def recall(
+        req: RecallRequest, x_actor: Optional[str] = Header(default=None)
+    ) -> RecallResponse | JSONResponse:
         """Synchronous recall: assemble long-term facts and short-term context for a scope."""
         if not req.scope.is_complete():
             return JSONResponse(
                 {"error": f"incomplete {req.scope.level.value} scope"}, status_code=400
             )
+        if x_actor and req.scope.level.value == "store":
+            return JSONResponse({"error": "store scope is admin-only"}, status_code=403)
         return await _offload(lambda: app.state.memory.recall(req))
 
-    @app.post("/v1/list", response_model=RecallResponse)
-    async def list_all(req: ListRequest) -> RecallResponse | JSONResponse:
+    @app.post("/v1/list", response_model=RecallResponse, response_model_exclude_none=True)
+    async def list_all(
+        req: ListRequest, x_actor: Optional[str] = Header(default=None)
+    ) -> RecallResponse | JSONResponse:
         """List all long-term records and conversation tiers visible at a scope."""
         if not req.scope.is_complete():
             return JSONResponse(
                 {"error": f"incomplete {req.scope.level.value} scope"}, status_code=400
             )
+        if x_actor and req.scope.level.value == "store":
+            return JSONResponse({"error": "store scope is admin-only"}, status_code=403)
         return await _offload(lambda: app.state.memory.list_all(req))
 
     @app.post("/v1/write", response_model=WriteResponse)
@@ -431,8 +465,14 @@ def create_app(
         return JSONResponse(result.model_dump(), status_code=202 if result.scheduled else 200)
 
     @app.post("/v1/forget", response_model=ForgetResponse)
-    async def forget(req: ForgetRequest) -> JSONResponse:
+    async def forget(
+        req: ForgetRequest, x_actor: Optional[str] = Header(default=None)
+    ) -> JSONResponse:
         """Erase a scope across both tiers."""
+        if x_actor and req.scope.level.value == "store":
+            return JSONResponse(
+                {"forgotten": False, "error": "store scope is admin-only"}, status_code=403
+            )
         try:
             result = await _offload(lambda: app.state.memory.forget(req))
         except Exception as exc:

--- a/kaos-memory/kaos_memory/client.py
+++ b/kaos-memory/kaos_memory/client.py
@@ -32,7 +32,7 @@ _TRACER_NAME = "kaos.memory"
 class ShortTermRecall:
     """Short-term tier slice of a recall: the verbatim active window, oldest first."""
 
-    recent: List[Tuple[str, str]] = field(default_factory=list)
+    window: List[Tuple[str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -40,6 +40,14 @@ class MediumTermRecall:
     """Medium-term tier slice of a recall: the rolling conversation digest."""
 
     summary: str = ""
+
+
+@dataclass
+class LongTermRecall:
+    """Long-term tier slice of a recall."""
+
+    facts: List[Dict[str, Any]] = field(default_factory=list)
+    block: str = ""
 
 
 @dataclass
@@ -57,23 +65,16 @@ class RecalledMemory:
     medium-term slices so existing call sites read a single field per tier.
     """
 
-    facts: List[Dict[str, Any]] = field(default_factory=list)
-    short_term: ShortTermRecall = field(default_factory=ShortTermRecall)
+    long_term: LongTermRecall = field(default_factory=LongTermRecall)
     medium_term: MediumTermRecall = field(default_factory=MediumTermRecall)
-    block: str = ""
+    short_term: ShortTermRecall = field(default_factory=ShortTermRecall)
     degraded: bool = False
 
     @property
-    def recent(self) -> List[Tuple[str, str]]:
-        return self.short_term.recent
-
-    @property
-    def summary(self) -> str:
-        return self.medium_term.summary
-
-    @property
     def is_empty(self) -> bool:
-        return not self.facts and not self.medium_term.summary and not self.short_term.recent
+        return (
+            not self.long_term.facts and not self.medium_term.summary and not self.short_term.window
+        )
 
 
 class MemoryServiceClient:
@@ -108,7 +109,7 @@ class MemoryServiceClient:
         query: str,
         *,
         top_k: int = 10,
-        include_short_term: bool = True,
+        include: Optional[List[str]] = None,
         token_budget: Optional[int] = None,
     ) -> RecalledMemory:
         tracer = trace_api.get_tracer(_TRACER_NAME)
@@ -120,7 +121,11 @@ class MemoryServiceClient:
                 "scope": scope.model_dump(mode="json"),
                 "query": query,
                 "top_k": top_k,
-                "include_short_term": include_short_term,
+                "include": (
+                    include
+                    if include is not None
+                    else ["short_term", "medium_term", "long_term"]
+                ),
             }
             if token_budget is not None:
                 payload["short_term_token_budget"] = token_budget
@@ -137,15 +142,17 @@ class MemoryServiceClient:
 
             short_term = data.get("short_term") or {}
             medium_term = data.get("medium_term") or {}
+            long_term = data.get("long_term") or {}
             recalled = RecalledMemory(
-                facts=data.get("facts", []),
-                short_term=ShortTermRecall(recent=[tuple(r) for r in short_term.get("recent", [])]),
+                long_term=LongTermRecall(
+                    facts=long_term.get("facts", []), block=long_term.get("block", "")
+                ),
                 medium_term=MediumTermRecall(summary=medium_term.get("summary", "")),
-                block=data.get("block", ""),
+                short_term=ShortTermRecall(window=[tuple(r) for r in short_term.get("window", [])]),
                 degraded=bool(data.get("degraded", False)),
             )
             span.set_attribute("kaos.memory.degraded", recalled.degraded)
-            span.set_attribute("kaos.memory.fact_count", len(recalled.facts))
+            span.set_attribute("kaos.memory.fact_count", len(recalled.long_term.facts))
             return recalled
 
     async def write(

--- a/kaos-memory/kaos_memory/client.py
+++ b/kaos-memory/kaos_memory/client.py
@@ -122,9 +122,7 @@ class MemoryServiceClient:
                 "query": query,
                 "top_k": top_k,
                 "include": (
-                    include
-                    if include is not None
-                    else ["short_term", "medium_term", "long_term"]
+                    include if include is not None else ["short_term", "medium_term", "long_term"]
                 ),
             }
             if token_budget is not None:

--- a/kaos-memory/kaos_memory/contract.py
+++ b/kaos-memory/kaos_memory/contract.py
@@ -30,14 +30,22 @@ class ScopeLevel(str, Enum):
 
     - ``AGENT``: only this agent (mapped to ``agent_id``).
     - ``USER``: all agents acting for a principal (mapped to ``user_id``).
-    - ``GROUP``: every agent on the store (mapped to the reserved group owner).
+    - ``STORE``: every memory on the store (admin plane only).
     - ``SESSION``: a single run/conversation (mapped to ``run_id``).
     """
 
+    SESSION = "session"
     AGENT = "agent"
     USER = "user"
-    GROUP = "group"
-    SESSION = "session"
+    STORE = "store"
+
+
+class MemoryTier(str, Enum):
+    """A recall response tier selected by the request."""
+
+    SHORT_TERM = "short_term"
+    MEDIUM_TERM = "medium_term"
+    LONG_TERM = "long_term"
 
 
 class Attribution(BaseModel):
@@ -91,7 +99,6 @@ class Scope(BaseModel):
     principal: Optional[str] = None
     agent_client_id: Optional[str] = None
     session_id: Optional[str] = None
-    user_scoping_required: bool = False
 
     @model_validator(mode="after")
     def _normalise(self) -> "Scope":
@@ -105,28 +112,24 @@ class Scope(BaseModel):
     def is_complete(self) -> bool:
         """Whether the field required by ``level`` is present (a usable owner key exists)."""
         if self.level is ScopeLevel.AGENT:
-            return self.agent_client_id is not None and (
-                not self.user_scoping_required or self.principal is not None
-            )
+            return self.agent_client_id is not None
         if self.level is ScopeLevel.USER:
             return self.principal is not None
         if self.level is ScopeLevel.SESSION:
             return self.session_id is not None
-        return True  # GROUP always resolves to the reserved owner.
+        return True  # STORE always resolves to the configured store filter.
 
     def owner_kwargs(self) -> Dict[str, Any]:
         """Return the Mem0 entity owner keys selected by this scope.
 
         Entity-scoped operations normally use one of ``user_id`` / ``agent_id`` /
         ``run_id``. Required user-scoped agent operations use both user and agent.
-        Group scope has no synthetic entity owner and raises instead of mapping to a sentinel.
+        Store scope has no synthetic entity owner and raises instead of mapping to a sentinel.
         """
         if self.level is ScopeLevel.AGENT:
             if self.agent_client_id is None:
                 raise ValueError("agent scope requires agent_client_id")
-            if self.user_scoping_required:
-                if self.principal is None:
-                    raise ValueError("user-scoped agent scope requires principal")
+            if self.principal is not None:
                 return {"user_id": self.principal, "agent_id": self.agent_client_id}
             return {"agent_id": self.agent_client_id}
         if self.level is ScopeLevel.USER:
@@ -137,7 +140,7 @@ class Scope(BaseModel):
             if self.session_id is None:
                 raise ValueError("session scope requires session_id")
             return {"run_id": self.session_id}
-        raise ValueError("group scope has no Mem0 entity owner")
+        raise ValueError("store scope has no Mem0 entity owner")
 
     def search_filters(self, group: Optional[str] = None) -> Dict[str, Any]:
         """Return the Mem0 ``filters`` dict for a search at this scope.
@@ -153,17 +156,18 @@ class Scope(BaseModel):
         if self.level is ScopeLevel.AGENT:
             if self.agent_client_id is None:
                 raise ValueError("agent scope requires agent_client_id")
-            if self.user_scoping_required:
-                if self.principal is None:
-                    raise ValueError("user-scoped agent scope requires principal")
+            if self.principal is not None:
                 return {"user_id": self.principal, "agent_id": self.agent_client_id}
             return {"agent_id": self.agent_client_id}
         if self.level is ScopeLevel.SESSION:
             if self.session_id is None:
                 raise ValueError("session scope requires session_id")
-            return {"user_id": "*", "kaos_run": self.session_id}
+            return {
+                "user_id": self.principal if self.principal is not None else "*",
+                "kaos_run": self.session_id,
+            }
         if not group:
-            raise ValueError("group scope requires the store group")
+            raise ValueError("store scope requires the store group")
         return {"user_id": "*", "kaos_group": group}
 
 
@@ -182,7 +186,7 @@ def scope_owner_key(scope: Scope, group: Optional[str] = None) -> str:
             raise ValueError("session scope requires session_id")
         return f"kaos_run:{scope.session_id}"
     if not group:
-        raise ValueError("group scope requires the store group")
+        raise ValueError("store scope requires the store group")
     return f"kaos_group:{group}"
 
 
@@ -213,7 +217,7 @@ class RecallRequest(BaseModel):
     scope: Scope
     query: str
     top_k: Optional[int] = None
-    include_short_term: bool = True
+    include: List[MemoryTier] = Field(default_factory=lambda: list(MemoryTier))
     short_term_token_budget: Optional[int] = None
 
 
@@ -221,7 +225,7 @@ class ListRequest(BaseModel):
     """List every long-term record visible at a scope, with optional conversation tiers."""
 
     scope: Scope
-    include_short_term: bool = True
+    include: List[MemoryTier] = Field(default_factory=lambda: list(MemoryTier))
     short_term_token_budget: Optional[int] = None
 
 
@@ -288,13 +292,20 @@ class ForgetResponse(BaseModel):
 class ShortTermContext(BaseModel):
     """The short-term tier slice of a recall response: the verbatim active window."""
 
-    recent: List[Tuple[str, str]] = Field(default_factory=list)
+    window: List[Tuple[str, str]] = Field(default_factory=list)
 
 
 class MediumTermContext(BaseModel):
     """The medium-term tier slice of a recall response: the rolling conversation digest."""
 
     summary: str = ""
+
+
+class LongTermContext(BaseModel):
+    """The long-term tier slice of a recall response."""
+
+    facts: List[Dict[str, Any]] = Field(default_factory=list)
+    block: str = ""
 
 
 class RecallResponse(BaseModel):
@@ -308,8 +319,7 @@ class RecallResponse(BaseModel):
     only the conversational tiers are present.
     """
 
-    facts: List[Dict[str, Any]] = Field(default_factory=list)
-    short_term: ShortTermContext = Field(default_factory=ShortTermContext)
-    medium_term: MediumTermContext = Field(default_factory=MediumTermContext)
-    block: str = ""
+    long_term: Optional[LongTermContext] = None
+    medium_term: Optional[MediumTermContext] = None
+    short_term: Optional[ShortTermContext] = None
     degraded: bool = False

--- a/kaos-memory/kaos_memory/pydantic_ai/adapters.py
+++ b/kaos-memory/kaos_memory/pydantic_ai/adapters.py
@@ -70,25 +70,16 @@ def scope_from_deps(
     security_context = getattr(deps, "security_context", None) or {}
     agent_client_id = agent_identity or security_context.get("actor") or None
     principal = security_context.get("principal") or None
-    user_scoping_required = (
-        resolved_level is ScopeLevel.AGENT
-        and os.environ.get("MEMORY_REQUIRE_PRINCIPAL", "").strip().lower() == "true"
-    )
     if resolved_level is ScopeLevel.AGENT and not agent_client_id:
         raise ValueError(
             "AGENT memory scope requires a stable agent identity; refusing to "
             "operate on an ambiguously-owned agent partition"
-        )
-    if user_scoping_required and not principal:
-        raise ValueError(
-            "AGENT memory scope requires an authenticated principal when user scoping is required"
         )
     return Scope(
         level=resolved_level,
         principal=principal,
         agent_client_id=agent_client_id,
         session_id=getattr(deps, "session_id", None) or None,
-        user_scoping_required=user_scoping_required,
     )
 
 

--- a/kaos-memory/kaos_memory/pydantic_ai/toolset.py
+++ b/kaos-memory/kaos_memory/pydantic_ai/toolset.py
@@ -53,7 +53,7 @@ _LEVEL_DESCRIPTIONS = {
     ScopeLevel.SESSION: "this conversation",
     ScopeLevel.AGENT: "this agent's durable experience",
     ScopeLevel.USER: "what is known about this user across agents",
-    ScopeLevel.GROUP: "knowledge shared across the group",
+    ScopeLevel.STORE: "all memory on the store",
 }
 
 
@@ -217,10 +217,10 @@ class MemoryToolset(AbstractToolset[Any]):
                 return "No query provided."
             scope = scope_from_deps(ctx.deps, level=level, agent_identity=self._identity)
             recalled = await memory.recall(scope, query)
-            if recalled.block:
-                return recalled.block
-            if recalled.facts:
-                return "\n".join(str(fact.get("memory", fact)) for fact in recalled.facts)
+            if recalled.long_term.block:
+                return recalled.long_term.block
+            if recalled.long_term.facts:
+                return "\n".join(str(fact.get("memory", fact)) for fact in recalled.long_term.facts)
             return "No relevant memories found."
 
         return f"Unknown memory tool: {name}"

--- a/kaos-memory/kaos_memory/stores.py
+++ b/kaos-memory/kaos_memory/stores.py
@@ -314,6 +314,8 @@ class ShortTermStore:
     ) -> List[Tuple[str, str]]:
         """Return the active verbatim window as ordered (role, content), within the budget."""
         key = scope_key(scope, self.group)
+        if not self._principal_matches(scope, key):
+            return []
         budget = token_budget if token_budget is not None else self.cfg.token_budget
         with self._lock:
             active = self._load_active_window_rows(key)
@@ -326,8 +328,23 @@ class ShortTermStore:
 
     def summary(self, scope: Scope) -> str:
         """Return the current medium-term summary text for the scope (empty if none)."""
+        key = scope_key(scope, self.group)
+        if not self._principal_matches(scope, key):
+            return ""
         with self._lock:
-            return self._load_summary(scope_key(scope, self.group))
+            return self._load_summary(key)
+
+    def _principal_matches(self, scope: Scope, key: str) -> bool:
+        """Return whether a principal-bound session belongs to that principal."""
+        if scope.principal is None:
+            return True
+        with self._lock:
+            row = self.db.execute(
+                "SELECT 1 FROM conversational_memory_attribution "
+                "WHERE scope_key = ? AND owner_key = ?",
+                (key, f"user_id:{scope.principal}"),
+            ).fetchone()
+        return row is not None
 
     def short_term_context(self, scope: Scope) -> Tuple[str, List[Tuple[str, str]]]:
         """Return (medium_term_summary, active_window) — the full short-term context for a run."""

--- a/kaos-memory/tests/test_client_service_failuremode.py
+++ b/kaos-memory/tests/test_client_service_failuremode.py
@@ -95,8 +95,8 @@ async def test_recall_degrades_over_http_when_longterm_fails(tmp_path):
     # Long-term failure degrades the result, but the request succeeds and the
     # verbatim short-term window still comes back for replay.
     assert recalled.degraded is True
-    assert recalled.facts == []
-    assert ("user", "the budget is 5000") in recalled.short_term.recent
+    assert recalled.long_term.facts == []
+    assert ("user", "the budget is 5000") in recalled.short_term.window
 
 
 @pytest.mark.asyncio

--- a/kaos-memory/tests/test_list.py
+++ b/kaos-memory/tests/test_list.py
@@ -79,7 +79,7 @@ def test_list_isolates_every_scope_and_returns_session_tiers(tmp_path, offline_m
             {"alice session one"},
         ),
         (
-            {"level": "group", "session_id": "session-1"},
+            {"level": "store", "session_id": "session-1"},
             {"alice session one", "bob session two"},
         ),
     ]
@@ -89,9 +89,9 @@ def test_list_isolates_every_scope_and_returns_session_tiers(tmp_path, offline_m
 
         assert response.status_code == 200
         body = response.json()
-        assert {fact["memory"] for fact in body["facts"]} == expected
-        assert "foreign store group" not in str(body["facts"])
-        assert body["short_term"]["recent"] == [["user", "alice recent turn"]]
+        assert {fact["memory"] for fact in body["long_term"]["facts"]} == expected
+        assert "foreign store group" not in str(body["long_term"]["facts"])
+        assert body["short_term"]["window"] == [["user", "alice recent turn"]]
         assert "bob recent turn" not in str(body["short_term"])
 
 

--- a/kaos-memory/tests/test_longterm.py
+++ b/kaos-memory/tests/test_longterm.py
@@ -94,13 +94,13 @@ def test_local_delete_session_uses_custom_attribution(tmp_path, offline_models):
 def test_local_delete_group_removes_store_group(tmp_path, offline_models):
     store = _local_store(tmp_path, offline_models)
     alice = Scope(
-        level=ScopeLevel.GROUP,
+        level=ScopeLevel.STORE,
         principal="alice",
         agent_client_id="agent-a",
         session_id="run-1",
     )
     bob = Scope(
-        level=ScopeLevel.GROUP,
+        level=ScopeLevel.STORE,
         principal="bob",
         agent_client_id="agent-b",
         session_id="run-2",
@@ -108,9 +108,9 @@ def test_local_delete_group_removes_store_group(tmp_path, offline_models):
     store.add(alice, "alice group fact", infer=False)
     store.add(bob, "bob group fact", infer=False)
 
-    store.delete_scope(Scope(level=ScopeLevel.GROUP))
+    store.delete_scope(Scope(level=ScopeLevel.STORE))
 
-    assert store.recall(Scope(level=ScopeLevel.GROUP), "group fact", top_k=10) == []
+    assert store.recall(Scope(level=ScopeLevel.STORE), "group fact", top_k=10) == []
 
 
 def test_agent_read_includes_same_agent_session_contribution(tmp_path, offline_models):
@@ -137,14 +137,14 @@ def test_agent_read_includes_same_agent_session_contribution(tmp_path, offline_m
 def test_group_read_uses_collection_attribution(tmp_path, offline_models):
     store = _local_store(tmp_path, offline_models)
     scope = Scope(
-        level=ScopeLevel.GROUP,
+        level=ScopeLevel.STORE,
         principal="alice",
         agent_client_id="agent-a",
         session_id="run-1",
     )
     store.add(scope, "group deployment fact", infer=False)
 
-    hits = store.recall(Scope(level=ScopeLevel.GROUP), "deployment", top_k=10)
+    hits = store.recall(Scope(level=ScopeLevel.STORE), "deployment", top_k=10)
 
     assert [hit["memory"] for hit in hits] == ["group deployment fact"]
 
@@ -332,7 +332,7 @@ def test_filtered_delete_falls_back_to_get_all_and_ids(tmp_path, offline_models,
     )
     store = LongTermStore(storage, offline_models["summarization"], offline_models["embedding"])
 
-    store.delete_scope(Scope(level=ScopeLevel.GROUP))
+    store.delete_scope(Scope(level=ScopeLevel.STORE))
 
     filters = {"user_id": "*", "kaos_group": "store-team"}
     assert calls == [

--- a/kaos-memory/tests/test_mem0_contract.py
+++ b/kaos-memory/tests/test_mem0_contract.py
@@ -115,7 +115,7 @@ def test_custom_session_and_group_erasure_uses_filtered_ids(mem0):
     store.delete_scope(Scope(level=ScopeLevel.SESSION, session_id="r1"))
     assert _texts(_all(memory)) == {"erase by group", "keep other group"}
 
-    store.delete_scope(Scope(level=ScopeLevel.GROUP))
+    store.delete_scope(Scope(level=ScopeLevel.STORE))
     assert _texts(_all(memory)) == {"keep other group"}
 
 
@@ -165,7 +165,6 @@ def test_two_entity_filter_requires_matching_user_and_agent(mem0):
         level=ScopeLevel.AGENT,
         principal="u1",
         agent_client_id="a1",
-        user_scoping_required=True,
     ).search_filters()
     searched = memory.search("equal query", filters=filters, top_k=10, threshold=0.0)
     listed = memory.get_all(filters=filters, top_k=100)

--- a/kaos-memory/tests/test_recall.py
+++ b/kaos-memory/tests/test_recall.py
@@ -56,7 +56,7 @@ def test_recall_surfaces_medium_term_digest(tmp_path):
     body = resp.json()
     assert body["medium_term"]["summary"] != ""
     # The digest is surfaced for message-history replay, not duplicated into the block.
-    assert "## Conversation summary" not in body["block"]
+    assert "## Conversation summary" not in body["long_term"]["block"]
     # The digest is separate from the verbatim window.
     assert "summary" not in body["short_term"]
 
@@ -78,11 +78,11 @@ def test_recall_returns_facts_and_short_term_context(tmp_path):
     body = resp.json()
     assert body["degraded"] is False
     # Native Mem0 fields pass through unmodified.
-    assert body["facts"][0]["score"] == 0.9
-    assert body["short_term"]["recent"] == [["user", "hello there"], ["assistant", "hi alice"]]
-    assert "alice prefers dark mode" in body["block"]
+    assert body["long_term"]["facts"][0]["score"] == 0.9
+    assert body["short_term"]["window"] == [["user", "hello there"], ["assistant", "hi alice"]]
+    assert "alice prefers dark mode" in body["long_term"]["block"]
     # The verbatim window is replayed as message history, not rendered into the block.
-    assert "## Recent turns" not in body["block"]
+    assert "## Recent turns" not in body["long_term"]["block"]
 
 
 def test_recall_degrades_to_short_term_only_on_longterm_failure(tmp_path):
@@ -101,11 +101,11 @@ def test_recall_degrades_to_short_term_only_on_longterm_failure(tmp_path):
     assert resp.status_code == 200
     body = resp.json()
     assert body["degraded"] is True
-    assert body["facts"] == []
+    assert body["long_term"]["facts"] == []
     # Long-term degraded: the block carries no facts, but the verbatim window survives
     # for message-history replay.
-    assert body["block"] == ""
-    assert ["user", "remember the budget is 5000"] in body["short_term"]["recent"]
+    assert body["long_term"]["block"] == ""
+    assert ["user", "remember the budget is 5000"] in body["short_term"]["window"]
 
 
 def test_recall_can_exclude_short_term(tmp_path):
@@ -113,12 +113,81 @@ def test_recall_can_exclude_short_term(tmp_path):
     longterm = _FakeLongTerm(facts=[{"memory": "fact one"}])
     resp = _client(longterm, short_term).post(
         "/v1/recall",
-        json={"scope": USER_SCOPE, "query": "x", "include_short_term": False},
+        json={"scope": USER_SCOPE, "query": "x", "include": ["long_term"]},
     )
     body = resp.json()
-    assert body["short_term"]["recent"] == []
-    assert "fact one" in body["block"]
-    assert "## Recent turns" not in body["block"]
+    assert "short_term" not in body
+    assert "medium_term" not in body
+    assert "fact one" in body["long_term"]["block"]
+    assert "## Recent turns" not in body["long_term"]["block"]
+
+
+def test_recall_rejects_unknown_include_tier(tmp_path):
+    response = _client(_FakeLongTerm(), _short_term(tmp_path)).post(
+        "/v1/recall",
+        json={"scope": USER_SCOPE, "query": "x", "include": ["archive"]},
+    )
+
+    assert response.status_code == 422
+
+
+def test_recall_omits_unrequested_tiers(tmp_path):
+    response = _client(_FakeLongTerm(), _short_term(tmp_path)).post(
+        "/v1/recall",
+        json={"scope": USER_SCOPE, "query": "x", "include": ["medium_term"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"medium_term": {"summary": ""}, "degraded": False}
+
+
+def test_session_conversation_read_is_bound_to_principal(tmp_path):
+    short_term = _short_term(tmp_path)
+    from kaos_memory.stores import Scope, ScopeLevel
+
+    short_term.add(
+        Scope(level=ScopeLevel.SESSION, principal="alice", session_id="s1"),
+        [("user", "alice secret")],
+    )
+    client = _client(_FakeLongTerm(), short_term)
+
+    matched = client.post(
+        "/v1/recall",
+        json={
+            "scope": {"level": "session", "principal": "alice", "session_id": "s1"},
+            "query": "x",
+        },
+    ).json()
+    mismatched = client.post(
+        "/v1/recall",
+        json={"scope": {"level": "session", "principal": "bob", "session_id": "s1"}, "query": "x"},
+    ).json()
+
+    assert matched["short_term"]["window"] == [["user", "alice secret"]]
+    assert mismatched["short_term"]["window"] == []
+    assert mismatched["medium_term"]["summary"] == ""
+
+
+def test_store_scope_is_admin_only_when_actor_header_is_present(tmp_path):
+    client = _client(_FakeLongTerm(), _short_term(tmp_path))
+    payload = {"scope": {"level": "store"}, "query": "x"}
+
+    assert client.post("/v1/recall", json=payload).status_code == 200
+    assert (
+        client.post("/v1/recall", json=payload, headers={"x-actor": "agent-a"}).status_code == 403
+    )
+    assert (
+        client.post(
+            "/v1/list", json={"scope": {"level": "store"}}, headers={"x-actor": "agent-a"}
+        ).status_code
+        == 403
+    )
+    assert (
+        client.post(
+            "/v1/forget", json={"scope": {"level": "store"}}, headers={"x-actor": "agent-a"}
+        ).status_code
+        == 403
+    )
 
 
 def test_user_recall_without_session_returns_long_term_and_empty_conversation(tmp_path):
@@ -131,8 +200,8 @@ def test_user_recall_without_session_returns_long_term_and_empty_conversation(tm
 
     assert response.status_code == 200
     body = response.json()
-    assert body["facts"] == [{"memory": "alice prefers dark mode"}]
-    assert body["short_term"]["recent"] == []
+    assert body["long_term"]["facts"] == [{"memory": "alice prefers dark mode"}]
+    assert body["short_term"]["window"] == []
     assert body["medium_term"]["summary"] == ""
     assert body["degraded"] is False
 
@@ -144,7 +213,6 @@ def test_recall_rejects_incomplete_scope_before_fail_soft_recall(tmp_path):
             "scope": {
                 "level": "agent",
                 "principal": "alice",
-                "user_scoping_required": True,
             },
             "query": "anything",
         },
@@ -195,7 +263,7 @@ def test_conversation_round_trips_across_recall_scopes_without_session_leakage(t
 
     for level_scope in (
         {**base_scope, "session_id": "session-1"},
-        {"level": "group", "session_id": "session-1"},
+        {"level": "store", "session_id": "session-1"},
     ):
         response = client.post(
             "/v1/recall",
@@ -204,12 +272,12 @@ def test_conversation_round_trips_across_recall_scopes_without_session_leakage(t
         assert response.status_code == 200
         body = response.json()
         assert "amber notebook" in body["medium_term"]["summary"]
-        assert body["short_term"]["recent"] == [["assistant", "noted amber notebook"]]
+        assert body["short_term"]["window"] == [["assistant", "noted amber notebook"]]
         assert "silver compass" not in str(body)
 
     assert "amber notebook" in recalled[0]["medium_term"]["summary"]
-    assert recalled[0]["short_term"]["recent"] == [["assistant", "noted amber notebook"]]
+    assert recalled[0]["short_term"]["window"] == [["assistant", "noted amber notebook"]]
     assert "silver compass" not in str(recalled[0])
     assert "silver compass" in recalled[1]["medium_term"]["summary"]
-    assert recalled[1]["short_term"]["recent"] == [["assistant", "noted silver compass"]]
+    assert recalled[1]["short_term"]["window"] == [["assistant", "noted silver compass"]]
     assert "amber notebook" not in str(recalled[1])

--- a/kaos-memory/tests/test_scope.py
+++ b/kaos-memory/tests/test_scope.py
@@ -12,21 +12,11 @@ def test_agent_maps_to_agent_id():
     assert scope.search_filters() == {"agent_id": "agent-a"}
 
 
-def test_required_agent_scope_is_incomplete_without_user():
-    scope = Scope(
-        level=ScopeLevel.AGENT,
-        agent_client_id="agent-a",
-        user_scoping_required=True,
-    )
-    assert scope.is_complete() is False
-
-
-def test_required_agent_maps_to_user_and_agent_filter():
+def test_agent_with_principal_maps_to_user_and_agent_filter():
     scope = Scope(
         level=ScopeLevel.AGENT,
         principal="alice",
         agent_client_id="agent-a",
-        user_scoping_required=True,
     )
     assert scope.search_filters() == {"user_id": "alice", "agent_id": "agent-a"}
     assert scope.owner_kwargs() == {"user_id": "alice", "agent_id": "agent-a"}
@@ -44,14 +34,14 @@ def test_session_maps_to_run_id():
     assert scope.search_filters() == {"user_id": "*", "kaos_run": "run-1"}
 
 
-def test_group_search_uses_wildcard_and_store_group():
-    scope = Scope(level=ScopeLevel.GROUP)
+def test_store_search_uses_wildcard_and_store_group():
+    scope = Scope(level=ScopeLevel.STORE)
     assert scope.search_filters("team-a") == {"user_id": "*", "kaos_group": "team-a"}
 
 
-def test_group_search_requires_store_group():
+def test_store_search_requires_store_group():
     with pytest.raises(ValueError, match="store group"):
-        Scope(level=ScopeLevel.GROUP).search_filters()
+        Scope(level=ScopeLevel.STORE).search_filters()
 
 
 def test_entity_scopes_yield_exactly_one_owner_key():
@@ -63,9 +53,9 @@ def test_entity_scopes_yield_exactly_one_owner_key():
         assert len(scope.owner_kwargs()) == 1
 
 
-def test_group_has_no_synthetic_entity_owner():
+def test_store_has_no_synthetic_entity_owner():
     with pytest.raises(ValueError, match="no Mem0 entity owner"):
-        Scope(level=ScopeLevel.GROUP).owner_kwargs()
+        Scope(level=ScopeLevel.STORE).owner_kwargs()
 
 
 def test_write_kwargs_carry_all_known_attribution():
@@ -110,7 +100,7 @@ def test_write_requires_an_entity_contributor():
             "run:run-1",
         ),
         (
-            Scope(level=ScopeLevel.GROUP, session_id="run-1"),
+            Scope(level=ScopeLevel.STORE, session_id="run-1"),
             "team-a",
             "kaos_group:team-a|run:run-1",
         ),
@@ -127,7 +117,7 @@ def test_scope_key_ignores_write_attribution_and_recall_level():
         agent_client_id="agent-a",
         session_id="run-1",
     )
-    group = Scope(level=ScopeLevel.GROUP, session_id="run-1")
+    group = Scope(level=ScopeLevel.STORE, session_id="run-1")
 
     expected = "kaos_group:team-a|run:run-1"
     assert scope_key(agent, "team-a") == expected
@@ -155,6 +145,6 @@ def test_empty_string_owner_is_treated_as_unset():
 
 
 def test_complete_flags():
-    assert Scope(level=ScopeLevel.GROUP).is_complete()
+    assert Scope(level=ScopeLevel.STORE).is_complete()
     assert Scope(level=ScopeLevel.USER, principal="p").is_complete()
     assert not Scope(level=ScopeLevel.SESSION).is_complete()

--- a/kaos-memory/tests/test_scope.py
+++ b/kaos-memory/tests/test_scope.py
@@ -34,6 +34,13 @@ def test_session_maps_to_run_id():
     assert scope.search_filters() == {"user_id": "*", "kaos_run": "run-1"}
 
 
+def test_session_long_term_filter_binds_principal_when_present():
+    scoped = Scope(level=ScopeLevel.SESSION, session_id="run-1", principal="alice")
+    assert scoped.search_filters() == {"user_id": "alice", "kaos_run": "run-1"}
+    anon = Scope(level=ScopeLevel.SESSION, session_id="run-1")
+    assert anon.search_filters() == {"user_id": "*", "kaos_run": "run-1"}
+
+
 def test_store_search_uses_wildcard_and_store_group():
     scope = Scope(level=ScopeLevel.STORE)
     assert scope.search_filters("team-a") == {"user_id": "*", "kaos_group": "team-a"}

--- a/kaos-memory/tests/test_service_e2e.py
+++ b/kaos-memory/tests/test_service_e2e.py
@@ -91,14 +91,14 @@ def _drive_and_assert(service: MemoryService, span_exporter, short_term_scope_ta
     assert r.status_code == 200
     body = r.json()
     assert body["degraded"] is False
-    assert any("us-east-1" in c for _, c in body["short_term"]["recent"])
-    assert isinstance(body["facts"], list)
+    assert any("us-east-1" in c for _, c in body["short_term"]["window"])
+    assert isinstance(body["long_term"]["facts"], list)
 
     # Forget: clears both tiers.
     f = client.post("/v1/forget", json={"scope": USER_SCOPE})
     assert f.status_code == 200
     after = client.post("/v1/recall", json={"scope": USER_SCOPE, "query": "cluster"})
-    assert after.json()["short_term"]["recent"] == []
+    assert after.json()["short_term"]["window"] == []
 
     names = {s.name for s in span_exporter.get_finished_spans()}
     assert {
@@ -136,7 +136,6 @@ def test_user_forget_erases_compound_partition_across_all_tiers(tmp_path):
         "principal": "alice",
         "agent_client_id": "agent-a",
         "session_id": "alice-session",
-        "user_scoping_required": True,
     }
     bob = {**alice, "principal": "bob", "session_id": "bob-session"}
 

--- a/kaos-memory/tests/test_shortterm.py
+++ b/kaos-memory/tests/test_shortterm.py
@@ -335,12 +335,12 @@ def test_group_delete_removes_all_group_sessions(tmp_path):
         _fake_summarizer,
         group="team-a",
     )
-    first = Scope(level=ScopeLevel.GROUP, session_id="run-a")
-    second = Scope(level=ScopeLevel.GROUP, session_id="run-b")
+    first = Scope(level=ScopeLevel.STORE, session_id="run-a")
+    second = Scope(level=ScopeLevel.STORE, session_id="run-b")
     store.add(first, [("user", "alpha")])
     store.add(second, [("user", "beta")])
 
-    store.delete(Scope(level=ScopeLevel.GROUP))
+    store.delete(Scope(level=ScopeLevel.STORE))
 
     assert store.active_window(first) == []
     assert store.active_window(second) == []

--- a/kaos-memory/tests/test_tier_settings.py
+++ b/kaos-memory/tests/test_tier_settings.py
@@ -93,12 +93,12 @@ def test_long_term_disabled_recall_returns_empty_facts_not_degraded(tmp_path):
     resp = client.post("/v1/recall", json={"scope": USER_SCOPE, "query": "preferences"})
     assert resp.status_code == 200
     body = resp.json()
-    assert body["facts"] == []
-    assert body["block"] == ""
+    assert body["long_term"]["facts"] == []
+    assert body["long_term"]["block"] == ""
     assert body["degraded"] is False
 
     resp = client.post("/v1/list", json={"scope": USER_SCOPE})
-    assert resp.json()["facts"] == [] and resp.json()["degraded"] is False
+    assert resp.json()["long_term"]["facts"] == [] and resp.json()["degraded"] is False
 
 
 def test_recall_uses_default_top_k_when_request_omits_it(tmp_path):

--- a/kaos-memory/tests/test_toolset.py
+++ b/kaos-memory/tests/test_toolset.py
@@ -40,16 +40,16 @@ def _ctx(deps) -> Any:
 @pytest.mark.asyncio
 async def test_search_schema_enum_matches_entitlements_with_usage_help():
     toolset = MemoryToolset(
-        [ScopeLevel.SESSION, ScopeLevel.USER, ScopeLevel.GROUP],
+        [ScopeLevel.SESSION, ScopeLevel.USER, ScopeLevel.STORE],
         expose_save=False,
     )
     tool = (await toolset.get_tools(_ctx(_Deps())))[SEARCH_MEMORY_TOOL]
     level = tool.tool_def.parameters_json_schema["properties"]["level"]
 
-    assert level["enum"] == ["session", "user", "group"]
+    assert level["enum"] == ["session", "user", "store"]
     assert "session = this conversation" in level["description"]
     assert "user = what is known about this user across agents" in level["description"]
-    assert "group = knowledge shared across the group" in level["description"]
+    assert "store = all memory on the store" in level["description"]
 
 
 @pytest.mark.asyncio
@@ -68,7 +68,7 @@ async def test_schema_rejects_out_of_enum_and_owner_arguments_before_handler():
     tool = (await toolset.get_tools(_ctx(_Deps())))[SEARCH_MEMORY_TOOL]
 
     with pytest.raises(ValidationError):
-        tool.args_validator.validate_python({"query": "tea", "level": "group"})
+        tool.args_validator.validate_python({"query": "tea", "level": "store"})
     with pytest.raises(ValidationError):
         tool.args_validator.validate_python({"query": "tea"})
     with pytest.raises(ValidationError):
@@ -85,7 +85,7 @@ async def test_handler_revalidates_entitlement():
     with pytest.raises(ValueError, match="not entitled"):
         await toolset.call_tool(
             SEARCH_MEMORY_TOOL,
-            {"query": "tea", "level": "group"},
+            {"query": "tea", "level": "store"},
             _ctx(deps),
             cast(Any, None),
         )

--- a/operator/api/v1alpha1/agent_types.go
+++ b/operator/api/v1alpha1/agent_types.go
@@ -74,10 +74,7 @@ type MemoryClientParams struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'remote' || has(self.memoryStore)",message="type 'remote' requires memoryStore to be set"
 // +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'local' || !has(self.memoryStore)",message="type 'local' must not set memoryStore"
 // +kubebuilder:validation:XValidation:rule="!has(self.tools) || has(self.memoryStore)",message="tools requires memoryStore to be set"
-// +kubebuilder:validation:XValidation:rule="!has(self.defaultReadScope) || !has(self.readScopes) || self.defaultReadScope in self.readScopes",message="defaultReadScope must be included in readScopes"
-// +kubebuilder:validation:XValidation:rule="!has(self.defaultReadScope) || self.defaultReadScope == 'session' || has(self.memoryStore)",message="non-session defaultReadScope requires memoryStore to be set"
-// +kubebuilder:validation:XValidation:rule="!has(self.readScopes) || self.readScopes.all(scope, scope == 'session') || has(self.memoryStore)",message="non-session readScopes require memoryStore to be set"
-// +kubebuilder:validation:XValidation:rule="!has(self.readScopes) || size(self.readScopes) <= 1 || (has(self.tools) && (self.tools == 'read' || self.tools == 'all'))",message="multiple readScopes require tools to be 'read' or 'all'"
+// +kubebuilder:validation:XValidation:rule="!has(self.maxReadScope) || self.maxReadScope == 'session' || has(self.memoryStore)",message="non-session maxReadScope requires memoryStore to be set"
 type MemoryConfig struct {
 	// Enabled controls whether memory is enabled (default: true).
 	// When disabled the runtime uses a no-op memory implementation.
@@ -97,17 +94,10 @@ type MemoryConfig struct {
 	// +kubebuilder:validation:Optional
 	MemoryStore string `json:"memoryStore,omitempty"`
 
-	// DefaultReadScope selects the single scope used by automatic recall. When
-	// omitted it resolves to the MemoryStore defaultReadScope, then session.
-	// +kubebuilder:validation:Enum=agent;user;group;session
+	// MaxReadScope caps automatic recall and the explicit search_memory tool.
+	// +kubebuilder:validation:Enum=session;agent;user
 	// +kubebuilder:validation:Optional
-	DefaultReadScope string `json:"defaultReadScope,omitempty"`
-
-	// ReadScopes lists the scope levels available to the explicit search_memory
-	// tool. When omitted it resolves to only DefaultReadScope.
-	// +kubebuilder:validation:items:Enum=agent;user;group;session
-	// +kubebuilder:validation:Optional
-	ReadScopes []string `json:"readScopes,omitempty"`
+	MaxReadScope string `json:"maxReadScope,omitempty"`
 
 	// ClientParams carries the minimal per-agent runtime memory knobs.
 	// +kubebuilder:validation:Optional

--- a/operator/api/v1alpha1/memorystore_types.go
+++ b/operator/api/v1alpha1/memorystore_types.go
@@ -269,11 +269,10 @@ type MemoryStoreSpec struct {
 	// +kubebuilder:default=soft
 	DefaultFailureMode string `json:"defaultFailureMode,omitempty"`
 
-	// DefaultReadScope is the store-wide default read scope for bound agents that
-	// do not set their own. When unset, session is used.
-	// +kubebuilder:validation:Enum=agent;user;group;session
-	// +kubebuilder:validation:Optional
-	DefaultReadScope string `json:"defaultReadScope,omitempty"`
+	// MaxReadScope caps read scope for every bound agent.
+	// +kubebuilder:validation:Enum=session;agent;user
+	// +kubebuilder:default=agent
+	MaxReadScope string `json:"maxReadScope,omitempty"`
 
 	// GatewayRoute configures Gateway API routing (timeout, etc.) for the memory
 	// service so agents reach it through the gateway data-plane rather than a

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -732,11 +732,6 @@ func (in *MemoryConfig) DeepCopyInto(out *MemoryConfig) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.ReadScopes != nil {
-		in, out := &in.ReadScopes, &out.ReadScopes
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.ClientParams != nil {
 		in, out := &in.ClientParams, &out.ClientParams
 		*out = new(MemoryClientParams)

--- a/operator/chart/crds/agent-crd.yaml
+++ b/operator/chart/crds/agent-crd.yaml
@@ -126,16 +126,6 @@ spec:
                             minimum: 0
                             type: integer
                         type: object
-                      defaultReadScope:
-                        description: |-
-                          DefaultReadScope selects the single scope used by automatic recall. When
-                          omitted it resolves to the MemoryStore defaultReadScope, then session.
-                        enum:
-                        - agent
-                        - user
-                        - group
-                        - session
-                        type: string
                       enabled:
                         default: true
                         description: |-
@@ -150,23 +140,19 @@ spec:
                         - soft
                         - strict
                         type: string
+                      maxReadScope:
+                        description: MaxReadScope caps automatic recall and the explicit
+                          search_memory tool.
+                        enum:
+                        - session
+                        - agent
+                        - user
+                        type: string
                       memoryStore:
                         description: |-
                           MemoryStore is the name of a MemoryStore in the same namespace providing the
                           long-term tier for this agent.
                         type: string
-                      readScopes:
-                        description: |-
-                          ReadScopes lists the scope levels available to the explicit search_memory
-                          tool. When omitted it resolves to only DefaultReadScope.
-                        items:
-                          enum:
-                          - agent
-                          - user
-                          - group
-                          - session
-                          type: string
-                        type: array
                       tools:
                         description: |-
                           Tools exposes explicit memory tools to the agent on top of the automatic
@@ -195,20 +181,9 @@ spec:
                       rule: '!has(self.type) || self.type != ''local'' || !has(self.memoryStore)'
                     - message: tools requires memoryStore to be set
                       rule: '!has(self.tools) || has(self.memoryStore)'
-                    - message: defaultReadScope must be included in readScopes
-                      rule: '!has(self.defaultReadScope) || !has(self.readScopes) ||
-                        self.defaultReadScope in self.readScopes'
-                    - message: non-session defaultReadScope requires memoryStore to
-                        be set
-                      rule: '!has(self.defaultReadScope) || self.defaultReadScope ==
-                        ''session'' || has(self.memoryStore)'
-                    - message: non-session readScopes require memoryStore to be set
-                      rule: '!has(self.readScopes) || self.readScopes.all(scope, scope
-                        == ''session'') || has(self.memoryStore)'
-                    - message: multiple readScopes require tools to be 'read' or 'all'
-                      rule: '!has(self.readScopes) || size(self.readScopes) <= 1 ||
-                        (has(self.tools) && (self.tools == ''read'' || self.tools ==
-                        ''all''))'
+                    - message: non-session maxReadScope requires memoryStore to be set
+                      rule: '!has(self.maxReadScope) || self.maxReadScope == ''session''
+                        || has(self.memoryStore)'
                   reasoningLoopMaxSteps:
                     default: 5
                     description: ReasoningLoopMaxSteps is the maximum number of reasoning

--- a/operator/chart/crds/memorystore-crd.yaml
+++ b/operator/chart/crds/memorystore-crd.yaml
@@ -306,16 +306,6 @@ spec:
                 - soft
                 - strict
                 type: string
-              defaultReadScope:
-                description: |-
-                  DefaultReadScope is the store-wide default read scope for bound agents that
-                  do not set their own. When unset, session is used.
-                enum:
-                - agent
-                - user
-                - group
-                - session
-                type: string
               engine:
                 default: mem0
                 description: Engine is the long-term memory engine. Mem0 is the only
@@ -391,6 +381,14 @@ spec:
                     minimum: 0
                     type: number
                 type: object
+              maxReadScope:
+                default: agent
+                description: MaxReadScope caps read scope for every bound agent.
+                enum:
+                - session
+                - agent
+                - user
+                type: string
               mediumTerm:
                 description: MediumTerm tunes the opt-in medium-term rolling digest.
                 properties:

--- a/operator/config/crd/bases/kaos.tools_agents.yaml
+++ b/operator/config/crd/bases/kaos.tools_agents.yaml
@@ -127,16 +127,6 @@ spec:
                             minimum: 0
                             type: integer
                         type: object
-                      defaultReadScope:
-                        description: |-
-                          DefaultReadScope selects the single scope used by automatic recall. When
-                          omitted it resolves to the MemoryStore defaultReadScope, then session.
-                        enum:
-                        - agent
-                        - user
-                        - group
-                        - session
-                        type: string
                       enabled:
                         default: true
                         description: |-
@@ -151,23 +141,19 @@ spec:
                         - soft
                         - strict
                         type: string
+                      maxReadScope:
+                        description: MaxReadScope caps automatic recall and the explicit
+                          search_memory tool.
+                        enum:
+                        - session
+                        - agent
+                        - user
+                        type: string
                       memoryStore:
                         description: |-
                           MemoryStore is the name of a MemoryStore in the same namespace providing the
                           long-term tier for this agent.
                         type: string
-                      readScopes:
-                        description: |-
-                          ReadScopes lists the scope levels available to the explicit search_memory
-                          tool. When omitted it resolves to only DefaultReadScope.
-                        items:
-                          enum:
-                          - agent
-                          - user
-                          - group
-                          - session
-                          type: string
-                        type: array
                       tools:
                         description: |-
                           Tools exposes explicit memory tools to the agent on top of the automatic
@@ -196,20 +182,10 @@ spec:
                       rule: '!has(self.type) || self.type != ''local'' || !has(self.memoryStore)'
                     - message: tools requires memoryStore to be set
                       rule: '!has(self.tools) || has(self.memoryStore)'
-                    - message: defaultReadScope must be included in readScopes
-                      rule: '!has(self.defaultReadScope) || !has(self.readScopes)
-                        || self.defaultReadScope in self.readScopes'
-                    - message: non-session defaultReadScope requires memoryStore to
-                        be set
-                      rule: '!has(self.defaultReadScope) || self.defaultReadScope
-                        == ''session'' || has(self.memoryStore)'
-                    - message: non-session readScopes require memoryStore to be set
-                      rule: '!has(self.readScopes) || self.readScopes.all(scope, scope
-                        == ''session'') || has(self.memoryStore)'
-                    - message: multiple readScopes require tools to be 'read' or 'all'
-                      rule: '!has(self.readScopes) || size(self.readScopes) <= 1 ||
-                        (has(self.tools) && (self.tools == ''read'' || self.tools
-                        == ''all''))'
+                    - message: non-session maxReadScope requires memoryStore to be
+                        set
+                      rule: '!has(self.maxReadScope) || self.maxReadScope == ''session''
+                        || has(self.memoryStore)'
                   reasoningLoopMaxSteps:
                     default: 5
                     description: ReasoningLoopMaxSteps is the maximum number of reasoning

--- a/operator/config/crd/bases/kaos.tools_memorystores.yaml
+++ b/operator/config/crd/bases/kaos.tools_memorystores.yaml
@@ -308,16 +308,6 @@ spec:
                 - soft
                 - strict
                 type: string
-              defaultReadScope:
-                description: |-
-                  DefaultReadScope is the store-wide default read scope for bound agents that
-                  do not set their own. When unset, session is used.
-                enum:
-                - agent
-                - user
-                - group
-                - session
-                type: string
               engine:
                 default: mem0
                 description: Engine is the long-term memory engine. Mem0 is the only
@@ -393,6 +383,14 @@ spec:
                     minimum: 0
                     type: number
                 type: object
+              maxReadScope:
+                default: agent
+                description: MaxReadScope caps read scope for every bound agent.
+                enum:
+                - session
+                - agent
+                - user
+                type: string
               mediumTerm:
                 description: MediumTerm tunes the opt-in medium-term rolling digest.
                 properties:

--- a/operator/config/samples/7-memory-agent.yaml
+++ b/operator/config/samples/7-memory-agent.yaml
@@ -40,6 +40,7 @@ spec:
       modelAPI: support-modelapi
       model: text-embedding-3-small
   defaultFailureMode: soft
+  maxReadScope: user
   shortTerm:
     tokenBudget: 64
   mediumTerm:
@@ -63,12 +64,7 @@ spec:
     memory:
       type: remote
       memoryStore: support-memory
-      defaultReadScope: user
-      readScopes:
-      - session
-      - agent
-      - user
-      - group
+      maxReadScope: user
       tools: read
       clientParams:
         tokenBudget: 64
@@ -92,6 +88,7 @@ spec:
     memory:
       type: remote
       memoryStore: support-memory
+      maxReadScope: session
       tools: read
       clientParams:
         tokenBudget: 64
@@ -111,7 +108,7 @@ spec:
     memory:
       type: remote
       memoryStore: support-memory
-      defaultReadScope: agent
+      maxReadScope: agent
       clientParams:
         tokenBudget: 64
         rollingSummary: true

--- a/operator/controllers/agent_controller.go
+++ b/operator/controllers/agent_controller.go
@@ -248,18 +248,8 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		mem := agent.Spec.Config.Memory
 		secCfg := security.GetConfig()
 		if !secCfg.SecurityEnabled() || strings.TrimSpace(secCfg.UserIssuer) == "" {
-			field := ""
-			if mem.DefaultReadScope == "user" {
-				field = "config.memory.defaultReadScope"
-			} else {
-				for _, scope := range mem.ReadScopes {
-					if scope == "user" {
-						field = "config.memory.readScopes"
-						break
-					}
-				}
-			}
-			if field != "" {
+			if mem.MaxReadScope == "user" {
+				field := "config.memory.maxReadScope"
 				msg := fmt.Sprintf("%s references user scope, but cluster security posture has no user identity", field)
 				agent.Status.Phase = "Failed"
 				agent.Status.Ready = false
@@ -304,6 +294,17 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				resolvedMemoryStore = store
 				memoryEndpoint = store.Status.Endpoint
 			}
+			if resolvedMemoryStore != nil && readScopeRank(resolveMaxReadScope(mem, store)) > readScopeRank(resolveStoreMaxReadScope(store)) {
+				msg := fmt.Sprintf("config.memory.maxReadScope %q exceeds MemoryStore %q maxReadScope %q", resolveMaxReadScope(mem, store), store.Name, resolveStoreMaxReadScope(store))
+				agent.Status.Phase = "Failed"
+				agent.Status.Ready = false
+				agent.Status.Message = msg
+				meta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{Type: "Ready", Status: metav1.ConditionFalse, Reason: "InvalidMemoryReadScope", Message: msg})
+				if err := r.Status().Update(ctx, agent); err != nil {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{}, nil
+			}
 		}
 	}
 
@@ -346,7 +347,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if agent.Spec.Config != nil {
 		memoryConfig = agent.Spec.Config.Memory
 	}
-	defaultReadScope := resolveDefaultReadScope(memoryConfig, resolvedMemoryStore)
+	maxReadScope := resolveMaxReadScope(memoryConfig, resolvedMemoryStore)
 
 	// Create or update Deployment
 	deployment := &appsv1.Deployment{}
@@ -355,7 +356,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if err != nil && apierrors.IsNotFound(err) {
 		// Create new Deployment
-		deployment, err = r.constructDeployment(agent, modelapi, mcpServers, peerAgents, memoryEndpoint, defaultReadScope, tokenExchangeConfig)
+		deployment, err = r.constructDeployment(agent, modelapi, mcpServers, peerAgents, memoryEndpoint, maxReadScope, tokenExchangeConfig)
 		if err != nil {
 			log.Error(err, "failed to construct Deployment")
 			agent.Status.Phase = "Failed"
@@ -385,7 +386,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	} else {
 		// Deployment exists - check if spec has changed using hash annotation
-		desiredDeployment, err := r.constructDeployment(agent, modelapi, mcpServers, peerAgents, memoryEndpoint, defaultReadScope, tokenExchangeConfig)
+		desiredDeployment, err := r.constructDeployment(agent, modelapi, mcpServers, peerAgents, memoryEndpoint, maxReadScope, tokenExchangeConfig)
 		if err != nil {
 			log.Error(err, "failed to construct Deployment for comparison")
 			return ctrl.Result{}, err
@@ -592,14 +593,25 @@ func (r *AgentReconciler) applyGatewayRouting(
 	}
 }
 
-func resolveDefaultReadScope(mem *kaosv1alpha1.MemoryConfig, store *kaosv1alpha1.MemoryStore) string {
-	if mem != nil && mem.DefaultReadScope != "" {
-		return mem.DefaultReadScope
+func resolveMaxReadScope(mem *kaosv1alpha1.MemoryConfig, store *kaosv1alpha1.MemoryStore) string {
+	if mem != nil && mem.MaxReadScope != "" {
+		return mem.MaxReadScope
 	}
-	if store != nil && store.Spec.DefaultReadScope != "" {
-		return store.Spec.DefaultReadScope
+	if store != nil {
+		return resolveStoreMaxReadScope(store)
 	}
 	return "session"
+}
+
+func resolveStoreMaxReadScope(store *kaosv1alpha1.MemoryStore) string {
+	if store.Spec.MaxReadScope != "" {
+		return store.Spec.MaxReadScope
+	}
+	return "agent"
+}
+
+func readScopeRank(scope string) int {
+	return map[string]int{"session": 0, "agent": 1, "user": 2}[scope]
 }
 
 // agentDeploymentExists reports whether the agent's Deployment already exists.
@@ -621,7 +633,7 @@ func (r *AgentReconciler) agentDeploymentExists(ctx context.Context, agent *kaos
 }
 
 // constructDeployment creates a Deployment for the Agent
-func (r *AgentReconciler) constructDeployment(agent *kaosv1alpha1.Agent, modelapi *kaosv1alpha1.ModelAPI, mcpServers map[string]string, peerAgents map[string]string, memoryEndpoint, defaultReadScope, tokenExchangeConfig string) (*appsv1.Deployment, error) {
+func (r *AgentReconciler) constructDeployment(agent *kaosv1alpha1.Agent, modelapi *kaosv1alpha1.ModelAPI, mcpServers map[string]string, peerAgents map[string]string, memoryEndpoint, maxReadScope, tokenExchangeConfig string) (*appsv1.Deployment, error) {
 	labels := map[string]string{
 		"app":   "agent",
 		"agent": agent.Name,
@@ -630,7 +642,7 @@ func (r *AgentReconciler) constructDeployment(agent *kaosv1alpha1.Agent, modelap
 	replicas := int32(1)
 
 	// Build environment variables
-	env := r.constructEnvVars(agent, modelapi, mcpServers, peerAgents, memoryEndpoint, defaultReadScope, tokenExchangeConfig)
+	env := r.constructEnvVars(agent, modelapi, mcpServers, peerAgents, memoryEndpoint, maxReadScope, tokenExchangeConfig)
 
 	// Get agent image from environment (required - set via ConfigMap)
 	agentImage := os.Getenv("DEFAULT_AGENT_IMAGE")
@@ -739,7 +751,7 @@ func (r *AgentReconciler) constructDeployment(agent *kaosv1alpha1.Agent, modelap
 }
 
 // constructEnvVars builds environment variables for the agent
-func (r *AgentReconciler) constructEnvVars(agent *kaosv1alpha1.Agent, modelapi *kaosv1alpha1.ModelAPI, mcpServers map[string]string, peerAgents map[string]string, memoryEndpoint, defaultReadScope, tokenExchangeConfig string) []corev1.EnvVar {
+func (r *AgentReconciler) constructEnvVars(agent *kaosv1alpha1.Agent, modelapi *kaosv1alpha1.ModelAPI, mcpServers map[string]string, peerAgents map[string]string, memoryEndpoint, maxReadScope, tokenExchangeConfig string) []corev1.EnvVar {
 	var env []corev1.EnvVar
 
 	// Agent identity and configuration
@@ -843,14 +855,7 @@ func (r *AgentReconciler) constructEnvVars(agent *kaosv1alpha1.Agent, modelapi *
 			})
 		}
 
-		readScopes := mem.ReadScopes
-		if len(readScopes) == 0 {
-			readScopes = []string{defaultReadScope}
-		}
-		env = append(env,
-			corev1.EnvVar{Name: "MEMORY_DEFAULT_READ_SCOPE", Value: defaultReadScope},
-			corev1.EnvVar{Name: "MEMORY_READ_SCOPES", Value: strings.Join(readScopes, ",")},
-		)
+		env = append(env, corev1.EnvVar{Name: "MEMORY_MAX_READ_SCOPE", Value: maxReadScope})
 		if mem.Tools != "" {
 			env = append(env, corev1.EnvVar{
 				Name:  "MEMORY_TOOLS",

--- a/operator/controllers/agent_memory_scope_test.go
+++ b/operator/controllers/agent_memory_scope_test.go
@@ -13,17 +13,23 @@ func TestResolveMemoryScope(t *testing.T) {
 		store *kaosv1alpha1.MemoryStore
 		want  string
 	}{
-		{name: "agent override", mem: &kaosv1alpha1.MemoryConfig{DefaultReadScope: "user"}, store: &kaosv1alpha1.MemoryStore{Spec: kaosv1alpha1.MemoryStoreSpec{DefaultReadScope: "group"}}, want: "user"},
-		{name: "store default", mem: &kaosv1alpha1.MemoryConfig{}, store: &kaosv1alpha1.MemoryStore{Spec: kaosv1alpha1.MemoryStoreSpec{DefaultReadScope: "group"}}, want: "group"},
-		{name: "agent fallback", mem: &kaosv1alpha1.MemoryConfig{}, store: &kaosv1alpha1.MemoryStore{}, want: "session"},
+		{name: "agent override", mem: &kaosv1alpha1.MemoryConfig{MaxReadScope: "user"}, store: &kaosv1alpha1.MemoryStore{Spec: kaosv1alpha1.MemoryStoreSpec{MaxReadScope: "user"}}, want: "user"},
+		{name: "store ceiling", mem: &kaosv1alpha1.MemoryConfig{}, store: &kaosv1alpha1.MemoryStore{Spec: kaosv1alpha1.MemoryStoreSpec{MaxReadScope: "user"}}, want: "user"},
+		{name: "store default", mem: &kaosv1alpha1.MemoryConfig{}, store: &kaosv1alpha1.MemoryStore{}, want: "agent"},
 		{name: "missing store", mem: &kaosv1alpha1.MemoryConfig{}, want: "session"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := resolveDefaultReadScope(tt.mem, tt.store); got != tt.want {
-				t.Fatalf("resolveDefaultReadScope() = %q, want %q", got, tt.want)
+			if got := resolveMaxReadScope(tt.mem, tt.store); got != tt.want {
+				t.Fatalf("resolveMaxReadScope() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReadScopeRank(t *testing.T) {
+	if !(readScopeRank("session") < readScopeRank("agent") && readScopeRank("agent") < readScopeRank("user")) {
+		t.Fatal("read scope ordering must be session < agent < user")
 	}
 }

--- a/operator/controllers/integration/agent_memory_test.go
+++ b/operator/controllers/integration/agent_memory_test.go
@@ -1,9 +1,9 @@
 package integration
 
 import (
-	"strings"
 	"context"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -99,12 +99,11 @@ var _ = Describe("Agent memory binding", func() {
 				Config: &kaosv1alpha1.AgentConfig{
 					Description: "mem agent",
 					Memory: &kaosv1alpha1.MemoryConfig{
-						Type:             "remote",
-						MemoryStore:      storeName,
-						DefaultReadScope: "group",
-						ReadScopes:       []string{"session", "group"},
-						Tools:            "all",
-						FailureMode:      "strict",
+						Type:         "remote",
+						MemoryStore:  storeName,
+						MaxReadScope: "agent",
+						Tools:        "all",
+						FailureMode:  "strict",
 						ClientParams: &kaosv1alpha1.MemoryClientParams{
 							TokenBudget:    int32Ptr(4096),
 							RollingSummary: boolPtr(false),
@@ -120,8 +119,7 @@ var _ = Describe("Agent memory binding", func() {
 		Expect(env["MEMORY_ENABLED"]).To(Equal("true"))
 		Expect(env["MEMORY_TYPE"]).To(Equal("remote"))
 		Expect(env["MEMORY_STORE_ENDPOINT"]).To(Equal(fmt.Sprintf("http://memorystore-%s.%s.svc.cluster.local:8080", storeName, namespace)))
-		Expect(env["MEMORY_DEFAULT_READ_SCOPE"]).To(Equal("group"))
-		Expect(env["MEMORY_READ_SCOPES"]).To(Equal("session,group"))
+		Expect(env["MEMORY_MAX_READ_SCOPE"]).To(Equal("agent"))
 		Expect(env["MEMORY_TOOLS"]).To(Equal("all"))
 		Expect(env["MEMORY_FAILURE_MODE"]).To(Equal("strict"))
 		Expect(env["MEMORY_SHORT_TERM_TOKEN_BUDGET"]).To(Equal("4096"))
@@ -170,12 +168,11 @@ var _ = Describe("Agent memory binding", func() {
 		env := agentMemoryEnv(ctx, namespace, agentName)
 		Expect(env["MEMORY_TYPE"]).To(Equal("local"))
 		Expect(env).NotTo(HaveKey("MEMORY_STORE_ENDPOINT"))
-		Expect(env["MEMORY_DEFAULT_READ_SCOPE"]).To(Equal("session"))
-		Expect(env["MEMORY_READ_SCOPES"]).To(Equal("session"))
+		Expect(env["MEMORY_MAX_READ_SCOPE"]).To(Equal("session"))
 		Expect(env["AGENT_IDENTITY"]).To(Equal(fmt.Sprintf("kaos://agent/%s/%s", namespace, agentName)))
 	})
 
-	It("inherits the store default read scope and allows an agent override", func() {
+	It("inherits the store ceiling and rejects an agent scope above it", func() {
 		modelAPIName := uniqueAgentName("agent-mem-model")
 		modelAPI := createReadyModelAPI(ctx, namespace, modelAPIName)
 		defer func() { k8sClient.Delete(ctx, modelAPI) }()
@@ -185,7 +182,7 @@ var _ = Describe("Agent memory binding", func() {
 		defer func() { k8sClient.Delete(ctx, store) }()
 		currentStore := &kaosv1alpha1.MemoryStore{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: storeName, Namespace: namespace}, currentStore)).To(Succeed())
-		currentStore.Spec.DefaultReadScope = "group"
+		currentStore.Spec.MaxReadScope = "session"
 		Expect(k8sClient.Update(ctx, currentStore)).To(Succeed())
 
 		agentName := uniqueAgentName("agent")
@@ -204,8 +201,7 @@ var _ = Describe("Agent memory binding", func() {
 		defer func() { k8sClient.Delete(ctx, agent) }()
 
 		env := agentMemoryEnv(ctx, namespace, agentName)
-		Expect(env["MEMORY_DEFAULT_READ_SCOPE"]).To(Equal("group"))
-		Expect(env["MEMORY_READ_SCOPES"]).To(Equal("group"))
+		Expect(env["MEMORY_MAX_READ_SCOPE"]).To(Equal("session"))
 
 		overrideName := uniqueAgentName("agent")
 		override := &kaosv1alpha1.Agent{
@@ -215,16 +211,20 @@ var _ = Describe("Agent memory binding", func() {
 				Model:               "mock-model",
 				WaitForDependencies: boolPtr(false),
 				Config: &kaosv1alpha1.AgentConfig{Memory: &kaosv1alpha1.MemoryConfig{
-					Type: "remote", MemoryStore: storeName, DefaultReadScope: "agent",
+					Type: "remote", MemoryStore: storeName, MaxReadScope: "agent",
 				}},
 			},
 		}
 		Expect(k8sClient.Create(ctx, override)).To(Succeed())
 		defer func() { k8sClient.Delete(ctx, override) }()
 
-		overrideEnv := agentMemoryEnv(ctx, namespace, overrideName)
-		Expect(overrideEnv["MEMORY_DEFAULT_READ_SCOPE"]).To(Equal("agent"))
-		Expect(overrideEnv["MEMORY_READ_SCOPES"]).To(Equal("agent"))
+		Eventually(func() bool {
+			updated := &kaosv1alpha1.Agent{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: overrideName, Namespace: namespace}, updated); err != nil {
+				return false
+			}
+			return updated.Status.Phase == "Failed" && strings.Contains(updated.Status.Message, "exceeds MemoryStore")
+		}, timeout, interval).Should(BeTrue())
 	})
 
 	It("rejects a user read scope when the cluster has no user identity", func() {
@@ -246,11 +246,10 @@ var _ = Describe("Agent memory binding", func() {
 				Config: &kaosv1alpha1.AgentConfig{
 					Description: "user-scope agent without user identity",
 					Memory: &kaosv1alpha1.MemoryConfig{
-						Type:             "remote",
-						MemoryStore:      storeName,
-						DefaultReadScope: "user",
-						ReadScopes:       []string{"session", "user"},
-						Tools:            "read",
+						Type:         "remote",
+						MemoryStore:  storeName,
+						MaxReadScope: "user",
+						Tools:        "read",
 					},
 				},
 			},
@@ -270,7 +269,7 @@ var _ = Describe("Agent memory binding", func() {
 			}
 			for _, c := range updated.Status.Conditions {
 				if c.Type == "Ready" && c.Status == metav1.ConditionFalse && c.Reason == "InvalidMemoryReadScope" {
-					return strings.Contains(c.Message, "config.memory.defaultReadScope")
+					return strings.Contains(c.Message, "config.memory.maxReadScope")
 				}
 			}
 			return false
@@ -502,30 +501,14 @@ var _ = Describe("Agent memory binding", func() {
 		By("rejecting tools without a memoryStore")
 		Expect(k8sClient.Create(ctx, makeAgent(&kaosv1alpha1.MemoryConfig{Tools: "all"}))).NotTo(Succeed())
 
-		By("rejecting a defaultReadScope outside readScopes")
-		Expect(k8sClient.Create(ctx, makeAgent(&kaosv1alpha1.MemoryConfig{
-			MemoryStore:      "store",
-			DefaultReadScope: "user",
-			ReadScopes:       []string{"agent"},
-		}))).NotTo(Succeed())
-
 		By("rejecting non-session read policy without a memoryStore")
-		Expect(k8sClient.Create(ctx, makeAgent(&kaosv1alpha1.MemoryConfig{DefaultReadScope: "agent"}))).NotTo(Succeed())
-		Expect(k8sClient.Create(ctx, makeAgent(&kaosv1alpha1.MemoryConfig{ReadScopes: []string{"session", "user"}, Tools: "read"}))).NotTo(Succeed())
+		Expect(k8sClient.Create(ctx, makeAgent(&kaosv1alpha1.MemoryConfig{MaxReadScope: "agent"}))).NotTo(Succeed())
 
-		By("rejecting multiple readScopes without a read tool")
-		Expect(k8sClient.Create(ctx, makeAgent(&kaosv1alpha1.MemoryConfig{
-			MemoryStore: "store",
-			ReadScopes:  []string{"session", "agent"},
-			Tools:       "write",
-		}))).NotTo(Succeed())
-
-		By("accepting an entitled multi-scope read policy")
+		By("accepting a max read scope with a store")
 		validReadPolicy := makeAgent(&kaosv1alpha1.MemoryConfig{
-			MemoryStore:      "store",
-			DefaultReadScope: "session",
-			ReadScopes:       []string{"session", "agent"},
-			Tools:            "read",
+			MemoryStore:  "store",
+			MaxReadScope: "session",
+			Tools:        "read",
 		})
 		Expect(k8sClient.Create(ctx, validReadPolicy)).To(Succeed())
 		defer func() { k8sClient.Delete(ctx, validReadPolicy) }()

--- a/operator/controllers/integration/memorystore_test.go
+++ b/operator/controllers/integration/memorystore_test.go
@@ -541,7 +541,7 @@ var _ = Describe("MemoryStore Controller", func() {
 		defer func() { k8sClient.Delete(ctx, valid) }()
 	})
 
-	It("fails closed when defaultReadScope is user without user identity", func() {
+	It("fails closed when maxReadScope is user without user identity", func() {
 		name := uniqueMemoryStoreName("user-scope-store")
 		store := &kaosv1alpha1.MemoryStore{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -551,7 +551,7 @@ var _ = Describe("MemoryStore Controller", func() {
 					Summarization: kaosv1alpha1.MemoryModelRef{ModelAPI: "m", Model: "mock-model"},
 					Embedding:     kaosv1alpha1.MemoryModelRef{ModelAPI: "m", Model: "mock-embed"},
 				},
-				DefaultReadScope: "user",
+				MaxReadScope: "user",
 			},
 		}
 		Expect(k8sClient.Create(ctx, store)).To(Succeed())
@@ -565,7 +565,7 @@ var _ = Describe("MemoryStore Controller", func() {
 				return false
 			}
 			return updated.Status.Phase == "Failed" && !updated.Status.Ready &&
-				strings.Contains(updated.Status.Message, "spec.defaultReadScope")
+				strings.Contains(updated.Status.Message, "spec.maxReadScope")
 		}, timeout, interval).Should(BeTrue())
 	})
 

--- a/operator/controllers/integration/memorystore_test.go
+++ b/operator/controllers/integration/memorystore_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"strings"
 	"context"
 	"fmt"
 	"sync/atomic"
@@ -541,7 +540,7 @@ var _ = Describe("MemoryStore Controller", func() {
 		defer func() { k8sClient.Delete(ctx, valid) }()
 	})
 
-	It("fails closed when maxReadScope is user without user identity", func() {
+	It("accepts maxReadScope user regardless of identity posture", func() {
 		name := uniqueMemoryStoreName("user-scope-store")
 		store := &kaosv1alpha1.MemoryStore{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -557,16 +556,19 @@ var _ = Describe("MemoryStore Controller", func() {
 		Expect(k8sClient.Create(ctx, store)).To(Succeed())
 		defer func() { k8sClient.Delete(ctx, store) }()
 
-		// The envtest posture has no user identity, so the store fails closed
-		// before bound agents can inherit a scope that can never resolve.
-		Eventually(func() bool {
+		// The ceiling grants permission and performs no reads, so it needs no
+		// posture; the store proceeds normally (held Pending here on the
+		// unresolved ModelAPI). Rejecting a user ceiling without user identity
+		// happens on the claiming Agent, never on the store.
+		getPhase := func() string {
 			updated := &kaosv1alpha1.MemoryStore{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, updated); err != nil {
-				return false
+				return ""
 			}
-			return updated.Status.Phase == "Failed" && !updated.Status.Ready &&
-				strings.Contains(updated.Status.Message, "spec.maxReadScope")
-		}, timeout, interval).Should(BeTrue())
+			return updated.Status.Phase
+		}
+		Eventually(getPhase, timeout, interval).Should(Equal("Pending"))
+		Consistently(getPhase, "2s", interval).ShouldNot(Equal("Failed"))
 	})
 
 	It("should hold Pending until the referenced ModelAPIs are ready", func() {

--- a/operator/controllers/memorystore_controller.go
+++ b/operator/controllers/memorystore_controller.go
@@ -73,10 +73,10 @@ func (r *MemoryStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// A user default read scope needs a verified principal on every read, which
 	// only a cluster with user identity can supply; fail the store closed at
 	// reconcile time so bound agents do not inherit a scope that can never work.
-	if store.Spec.DefaultReadScope == "user" {
+	if store.Spec.MaxReadScope == "user" {
 		secCfg := security.GetConfig()
 		if !secCfg.SecurityEnabled() || strings.TrimSpace(secCfg.UserIssuer) == "" {
-			msg := "spec.defaultReadScope references user scope, but cluster security posture has no user identity"
+			msg := "spec.maxReadScope references user scope, but cluster security posture has no user identity"
 			store.Status.Phase = "Failed"
 			store.Status.Ready = false
 			store.Status.Message = msg

--- a/operator/controllers/memorystore_controller.go
+++ b/operator/controllers/memorystore_controller.go
@@ -70,23 +70,6 @@ func (r *MemoryStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// A user default read scope needs a verified principal on every read, which
-	// only a cluster with user identity can supply; fail the store closed at
-	// reconcile time so bound agents do not inherit a scope that can never work.
-	if store.Spec.MaxReadScope == "user" {
-		secCfg := security.GetConfig()
-		if !secCfg.SecurityEnabled() || strings.TrimSpace(secCfg.UserIssuer) == "" {
-			msg := "spec.maxReadScope references user scope, but cluster security posture has no user identity"
-			store.Status.Phase = "Failed"
-			store.Status.Ready = false
-			store.Status.Message = msg
-			if err := r.Status().Update(ctx, store); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, nil
-		}
-	}
-
 	// Resolve and ready-gate the referenced ModelAPIs before deploying.
 	modelEnv, requeue, err := r.resolveModelEnv(ctx, store)
 	if err != nil {

--- a/operator/tests/e2e/test_memory_store_e2e.py
+++ b/operator/tests/e2e/test_memory_store_e2e.py
@@ -153,11 +153,11 @@ async def test_short_term_round_trips_verbatim_through_the_service(test_namespac
 
         recall = httpx.post(
             f"{base_url}/v1/recall",
-            json={"scope": scope, "query": "what port", "include_short_term": True},
+            json={"scope": scope, "query": "what port", "include": ["short_term", "medium_term", "long_term"]},
             timeout=30.0,
         )
         assert recall.status_code == 200, recall.text
-        recent = recall.json()["short_term"]["recent"]
+        recent = recall.json()["short_term"]["window"]
         flattened = [tuple(pair) for pair in recent]
         assert ("user", "my favourite port is 8080") in flattened
         assert ("assistant", "noted, port 8080") in flattened
@@ -203,14 +203,14 @@ async def test_short_term_is_isolated_between_scopes(test_namespace: str):
 
         a_recent = httpx.post(
             f"{base_url}/v1/recall",
-            json={"scope": alice, "query": "x", "include_short_term": True},
+            json={"scope": alice, "query": "x", "include": ["short_term", "medium_term", "long_term"]},
             timeout=30.0,
-        ).json()["short_term"]["recent"]
+        ).json()["short_term"]["window"]
         b_recent = httpx.post(
             f"{base_url}/v1/recall",
-            json={"scope": bob, "query": "x", "include_short_term": True},
+            json={"scope": bob, "query": "x", "include": ["short_term", "medium_term", "long_term"]},
             timeout=30.0,
-        ).json()["short_term"]["recent"]
+        ).json()["short_term"]["window"]
 
         a_text = " ".join(content for _, content in (tuple(p) for p in a_recent))
         b_text = " ".join(content for _, content in (tuple(p) for p in b_recent))
@@ -339,11 +339,11 @@ async def test_short_term_survives_a_pod_restart(test_namespace: str):
     try:
         recall = httpx.post(
             f"{base_url}/v1/recall",
-            json={"scope": scope, "query": "launch code", "include_short_term": True},
+            json={"scope": scope, "query": "launch code", "include": ["short_term", "medium_term", "long_term"]},
             timeout=30.0,
         )
         assert recall.status_code == 200, recall.text
-        recent = [tuple(pair) for pair in recall.json()["short_term"]["recent"]]
+        recent = [tuple(pair) for pair in recall.json()["short_term"]["window"]]
         assert ("user", "remember the launch code is orbit-42") in recent
         assert ("assistant", "stored launch code orbit-42") in recent
     finally:

--- a/pydantic-ai-server/pais/memory.py
+++ b/pydantic-ai-server/pais/memory.py
@@ -15,6 +15,7 @@ from kaos_memory.contract import Attribution, Scope, ScopeLevel
 from kaos_memory.client import (
     MemoryServiceClient,
     RecalledMemory,
+    LongTermRecall,
     ShortTermRecall,
     MediumTermRecall,
 )
@@ -101,7 +102,7 @@ class Memory(ABC):
         query: str,
         *,
         top_k: int = 10,
-        include_short_term: bool = True,
+        include: Optional[List[str]] = None,
         token_budget: Optional[int] = None,
     ) -> "RecalledMemory":
         """Assemble the context visible at ``scope`` for ``query``.
@@ -513,14 +514,14 @@ class RemoteMemory(Memory):
         query: str,
         *,
         top_k: int = 10,
-        include_short_term: bool = True,
+        include: Optional[List[str]] = None,
         token_budget: Optional[int] = None,
     ) -> "RecalledMemory":
         return await self._service.recall(
             scope,
             query,
             top_k=top_k,
-            include_short_term=include_short_term,
+            include=include,
             token_budget=token_budget,
         )
 

--- a/pydantic-ai-server/pais/server.py
+++ b/pydantic-ai-server/pais/server.py
@@ -465,7 +465,7 @@ class AgentServer:
         )
         read_scope = scope_from_deps(
             deps,
-            level=self.settings.memory_default_read_scope,
+            level=self.settings.memory_max_read_scope,
             agent_identity=self._agent_identity or None,
         )
 
@@ -479,9 +479,11 @@ class AgentServer:
         await self.memory.add_event(session_id, "user_message", user_prompt)
 
         # Prefer the service short-term tier for history; else the local event log.
-        if recalled.recent or recalled.summary:
+        if recalled.short_term.window or recalled.medium_term.summary:
             message_history = reconstruct_message_history(
-                recalled.recent, recalled.summary, self.settings.memory_context_limit
+                recalled.short_term.window,
+                recalled.medium_term.summary,
+                self.settings.memory_context_limit,
             )
         else:
             message_history = await self.memory.build_message_history(
@@ -490,8 +492,8 @@ class AgentServer:
 
         # Automatic recall: inject the recalled long-term block as leading system
         # context whenever memory is enabled (the baseline behavior of enabling memory).
-        if recalled.block:
-            block_msg = ModelRequest(parts=[SystemPromptPart(content=recalled.block)])
+        if recalled.long_term.block:
+            block_msg = ModelRequest(parts=[SystemPromptPart(content=recalled.long_term.block)])
             message_history = [block_msg] + (message_history or [])
 
         usage_limits = UsageLimits(request_limit=self.settings.agentic_loop_max_steps)
@@ -846,7 +848,12 @@ def create_agent_server(
 
     memory_toolset = build_memory_toolset(
         parse_memory_tools(settings.memory_tools),
-        [ScopeLevel(scope) for scope in settings.memory_read_scopes.split(",")],
+        list((ScopeLevel.SESSION, ScopeLevel.AGENT, ScopeLevel.USER))[
+            : (ScopeLevel.SESSION, ScopeLevel.AGENT, ScopeLevel.USER).index(
+                ScopeLevel(settings.memory_max_read_scope)
+            )
+            + 1
+        ],
         agent_identity=settings.agent_identity or settings.security_actor or None,
     )
     if memory_toolset is not None:

--- a/pydantic-ai-server/pais/serverutils.py
+++ b/pydantic-ai-server/pais/serverutils.py
@@ -412,9 +412,8 @@ class AgentServerSettings(BaseSettings):
     # backend; when empty the runtime falls back to the in-process short-term
     # LocalMemory backend (no long-term tier, pod-local).
     memory_store_endpoint: str = ""
-    # Automatic recall uses one default read scope; read entitlements default to it.
-    memory_default_read_scope: str = "session"
-    memory_read_scopes: str = ""
+    # Automatic recall and explicit search are capped at this scope.
+    memory_max_read_scope: str = "session"
     # Additive explicit memory tools exposed to the agent on top of the automatic
     # recall-inject/write-extract baseline: "all" (save + search), "read" (search
     # only), "write" (save only), or empty (none). Long-term tools require a bound
@@ -457,21 +456,7 @@ class AgentServerSettings(BaseSettings):
     model_config = {"env_file": ".env", "case_sensitive": False}
 
     @model_validator(mode="after")
-    def validate_memory_scopes(self):
-        valid = {"session", "agent", "user", "group"}
-        if self.memory_default_read_scope not in valid:
-            raise ValueError(f"unknown memory_default_read_scope: {self.memory_default_read_scope}")
-
-        if not self.memory_read_scopes:
-            scopes = [self.memory_default_read_scope]
-        else:
-            scopes = [scope.strip() for scope in self.memory_read_scopes.split(",")]
-            if any(not scope for scope in scopes):
-                raise ValueError("memory_read_scopes contains an empty scope")
-        unknown = [scope for scope in scopes if scope not in valid]
-        if unknown:
-            raise ValueError(f"unknown memory_read_scopes: {', '.join(unknown)}")
-        if self.memory_default_read_scope not in scopes:
-            raise ValueError("memory_default_read_scope must be included in memory_read_scopes")
-        self.memory_read_scopes = ",".join(scopes)
+    def validate_memory_scope(self):
+        if self.memory_max_read_scope not in {"session", "agent", "user"}:
+            raise ValueError(f"unknown memory_max_read_scope: {self.memory_max_read_scope}")
         return self

--- a/pydantic-ai-server/tests/test_agent.py
+++ b/pydantic-ai-server/tests/test_agent.py
@@ -83,7 +83,7 @@ class TestAgentCreationAndCard:
         )
         server._agent._user_toolsets.append(
             MemoryToolset(
-                [ScopeLevel.SESSION, ScopeLevel.GROUP],
+                [ScopeLevel.SESSION, ScopeLevel.STORE],
                 expose_save=False,
             )
         )
@@ -96,7 +96,7 @@ class TestAgentCreationAndCard:
         assert [tool["name"] for tool in tools] == ["search_memory"]
         assert tools[0]["parameters_json_schema"]["properties"]["level"]["enum"] == [
             "session",
-            "group",
+            "store",
         ]
 
     @pytest.mark.asyncio

--- a/pydantic-ai-server/tests/test_memory_contract.py
+++ b/pydantic-ai-server/tests/test_memory_contract.py
@@ -13,6 +13,7 @@ from pais.memory import (
     Memory,
     MemoryAttribution,
     MediumTermRecall,
+    LongTermRecall,
     MemoryScope,
     NullMemory,
     RecalledMemory,
@@ -35,46 +36,42 @@ class TestMemoryScope:
             "principal": "alice",
             "agent_client_id": "agent-1",
             "session_id": "sess-1",
-            "user_scoping_required": False,
         }
-
-        required = MemoryScope.model_validate({**payload, "user_scoping_required": True})
-        assert required.user_scoping_required is True
 
     def test_scope_level_values(self):
         assert ScopeLevel.AGENT.value == "agent"
         assert ScopeLevel.USER.value == "user"
-        assert ScopeLevel.GROUP.value == "group"
+        assert ScopeLevel.STORE.value == "store"
         assert ScopeLevel.SESSION.value == "session"
 
     def test_under_specified_scope_is_representable(self):
-        scope = MemoryScope(level=ScopeLevel.GROUP)
+        scope = MemoryScope(level=ScopeLevel.STORE)
         assert scope.principal is None
-        assert scope.model_dump(mode="json")["level"] == "group"
+        assert scope.model_dump(mode="json")["level"] == "store"
 
 
 class TestRecalledMemory:
     def test_empty_by_default(self):
         recalled = RecalledMemory()
         assert recalled.is_empty
-        assert recalled.facts == []
-        assert recalled.recent == []
-        assert recalled.block == ""
+        assert recalled.long_term.facts == []
+        assert recalled.short_term.window == []
+        assert recalled.long_term.block == ""
         assert recalled.degraded is False
 
     def test_non_empty_when_facts_present(self):
-        recalled = RecalledMemory(facts=[{"memory": "x"}])
+        recalled = RecalledMemory(long_term=LongTermRecall(facts=[{"memory": "x"}]))
         assert not recalled.is_empty
 
     def test_non_empty_when_short_term_present(self):
-        recalled = RecalledMemory(short_term=ShortTermRecall(recent=[("user", "hi")]))
+        recalled = RecalledMemory(short_term=ShortTermRecall(window=[("user", "hi")]))
         assert not recalled.is_empty
-        assert recalled.recent == [("user", "hi")]
+        assert recalled.short_term.window == [("user", "hi")]
 
     def test_medium_term_summary_is_exposed(self):
         recalled = RecalledMemory(medium_term=MediumTermRecall(summary="digest"))
         assert not recalled.is_empty
-        assert recalled.summary == "digest"
+        assert recalled.medium_term.summary == "digest"
 
 
 class TestLongTermDefaultsAreNoOp:

--- a/pydantic-ai-server/tests/test_memory_settings.py
+++ b/pydantic-ai-server/tests/test_memory_settings.py
@@ -6,40 +6,26 @@ from pydantic import ValidationError
 from pais.serverutils import AgentServerSettings
 
 
-def test_read_scope_defaults_to_session():
+def test_max_read_scope_defaults_to_session():
     settings = AgentServerSettings(agent_name="test")
 
-    assert settings.memory_default_read_scope == "session"
-    assert settings.memory_read_scopes == "session"
+    assert settings.memory_max_read_scope == "session"
 
 
-def test_read_scopes_parse_from_environment(monkeypatch):
-    monkeypatch.setenv("MEMORY_DEFAULT_READ_SCOPE", "user")
-    monkeypatch.setenv("MEMORY_READ_SCOPES", "agent, user,group")
+def test_max_read_scope_parses_from_environment(monkeypatch):
+    monkeypatch.setenv("MEMORY_MAX_READ_SCOPE", "user")
 
     settings = AgentServerSettings(agent_name="test")
 
-    assert settings.memory_default_read_scope == "user"
-    assert settings.memory_read_scopes == "agent,user,group"
+    assert settings.memory_max_read_scope == "user"
 
 
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        ("memory_default_read_scope", "tenant"),
-        ("memory_read_scopes", "session,tenant"),
-        ("memory_read_scopes", "session,,agent"),
+        ("memory_max_read_scope", "tenant"),
     ],
 )
 def test_unknown_or_empty_scope_values_fail_closed(field, value):
     with pytest.raises(ValidationError):
         AgentServerSettings(agent_name="test", **{field: value})
-
-
-def test_default_read_scope_must_be_entitled():
-    with pytest.raises(ValidationError, match="must be included"):
-        AgentServerSettings(
-            agent_name="test",
-            memory_default_read_scope="user",
-            memory_read_scopes="agent,group",
-        )

--- a/pydantic-ai-server/tests/test_memory_tools.py
+++ b/pydantic-ai-server/tests/test_memory_tools.py
@@ -9,7 +9,7 @@ import pytest
 from typing import Any, cast
 from pydantic_ai.messages import ModelRequest, UserPromptPart
 
-from pais.memory import MemoryAttribution, NullMemory, RecalledMemory, ScopeLevel
+from pais.memory import LongTermRecall, MemoryAttribution, NullMemory, RecalledMemory, ScopeLevel
 from pais.memory_tools import (
     MemoryTools,
     MemoryToolset,
@@ -119,7 +119,9 @@ class TestMemoryToolset:
 
     @pytest.mark.asyncio
     async def test_search_returns_block_when_present(self):
-        mem = _RecordingMemory(RecalledMemory(block="## Relevant memory\nalice likes tea"))
+        mem = _RecordingMemory(
+            RecalledMemory(long_term=LongTermRecall(block="## Relevant memory\nalice likes tea"))
+        )
         deps = AgentDeps(session_id="s1", memory=mem, security_context={"principal": "alice"})
         ts = MemoryToolset([ScopeLevel.USER])
         result = await ts.call_tool(
@@ -133,7 +135,9 @@ class TestMemoryToolset:
 
     @pytest.mark.asyncio
     async def test_search_falls_back_to_facts(self):
-        mem = _RecordingMemory(RecalledMemory(facts=[{"memory": "fact one"}]))
+        mem = _RecordingMemory(
+            RecalledMemory(long_term=LongTermRecall(facts=[{"memory": "fact one"}]))
+        )
         deps = AgentDeps(
             session_id="s1",
             memory=mem,
@@ -178,7 +182,7 @@ class TestMemoryToolset:
         ts = MemoryToolset([ScopeLevel.AGENT])
         await ts.call_tool(
             SAVE_MEMORY_TOOL,
-            {"content": "x", "scope": "group", "principal": "attacker"},
+            {"content": "x", "scope": "store", "principal": "attacker"},
             _ctx(deps),
             cast(Any, None),
         )
@@ -190,13 +194,13 @@ class TestMemoryToolset:
 async def test_baseline_recall_uses_read_scope_and_flush_uses_attribution():
     mem = _RecordingMemory()
     server = make_test_server(memory=mem)
-    server.settings.memory_default_read_scope = "group"
+    server.settings.memory_max_read_scope = "user"
 
     _prompt, _history, deps, _limits = await server._prepare_run("hello", "current-session")
 
     recalled_scope, query = mem.recalls[0]
     assert query == "hello"
-    assert recalled_scope.level is ScopeLevel.GROUP
+    assert recalled_scope.level is ScopeLevel.USER
     assert recalled_scope.session_id == "current-session"
     assert deps.memory_attribution is not None
     assert deps.memory_attribution.session_id == "current-session"

--- a/pydantic-ai-server/tests/test_remote_memory.py
+++ b/pydantic-ai-server/tests/test_remote_memory.py
@@ -45,14 +45,16 @@ class TestRecall:
             return httpx.Response(
                 200,
                 json={
-                    "facts": [{"memory": "alice likes tea", "score": 0.9}],
+                    "long_term": {
+                        "facts": [{"memory": "alice likes tea", "score": 0.9}],
+                        "block": "## Relevant memory\nalice likes tea",
+                    },
                     "short_term": {
-                        "recent": [["user", "hi"], ["assistant", "hello"]],
+                        "window": [["user", "hi"], ["assistant", "hello"]],
                     },
                     "medium_term": {
                         "summary": "prior chat",
                     },
-                    "block": "## Relevant memory\nalice likes tea",
                     "degraded": False,
                 },
             )
@@ -66,10 +68,10 @@ class TestRecall:
         assert seen["payload"]["short_term_token_budget"] == 512
         assert seen["payload"]["scope"]["level"] == "session"
         assert isinstance(recalled, RecalledMemory)
-        assert recalled.facts[0]["memory"] == "alice likes tea"
-        assert recalled.summary == "prior chat"
-        assert recalled.recent == [("user", "hi"), ("assistant", "hello")]
-        assert recalled.block.startswith("## Relevant memory")
+        assert recalled.long_term.facts[0]["memory"] == "alice likes tea"
+        assert recalled.medium_term.summary == "prior chat"
+        assert recalled.short_term.window == [("user", "hi"), ("assistant", "hello")]
+        assert recalled.long_term.block.startswith("## Relevant memory")
         assert recalled.degraded is False
         await mem.close()
 
@@ -100,10 +102,9 @@ class TestRecall:
             return httpx.Response(
                 200,
                 json={
-                    "facts": [],
-                    "short_term": {"recent": [["user", "hi"]]},
+                    "long_term": {"facts": [], "block": ""},
+                    "short_term": {"window": [["user", "hi"]]},
                     "medium_term": {"summary": ""},
-                    "block": "## Recent turns\nuser: hi",
                     "degraded": True,
                 },
             )
@@ -111,7 +112,7 @@ class TestRecall:
         mem = _client(handler)
         recalled = await mem.recall(_scope(), "tea")
         assert recalled.degraded is True
-        assert recalled.recent == [("user", "hi")]
+        assert recalled.short_term.window == [("user", "hi")]
         await mem.close()
 
 

--- a/pydantic-ai-server/tests/test_scope_injection.py
+++ b/pydantic-ai-server/tests/test_scope_injection.py
@@ -50,7 +50,7 @@ class TestScopeFromDeps:
 
     def test_missing_security_context_yields_unset_owner_fields(self):
         deps = AgentDeps(session_id="sess-9", security_context=None)
-        scope = scope_from_deps(deps, level=ScopeLevel.GROUP)
+        scope = scope_from_deps(deps, level=ScopeLevel.STORE)
         assert scope.principal is None
         assert scope.agent_client_id is None
         assert scope.session_id == "sess-9"
@@ -67,13 +67,13 @@ class TestScopeFromDeps:
         scope = scope_from_deps(deps, level=ScopeLevel.AGENT)
         assert scope.agent_client_id == "agent-actor"
 
-    def test_required_agent_scope_fails_closed_without_principal(self, monkeypatch):
+    def test_agent_scope_is_pool_without_principal(self, monkeypatch):
         monkeypatch.setenv("MEMORY_REQUIRE_PRINCIPAL", "true")
         deps = _deps(actor="agent-actor")
-        with pytest.raises(ValueError, match="authenticated principal"):
-            scope_from_deps(deps, level=ScopeLevel.AGENT)
+        scope = scope_from_deps(deps, level=ScopeLevel.AGENT)
+        assert scope.search_filters() == {"agent_id": "agent-actor"}
 
-    def test_required_agent_scope_marks_agent_and_user_partition(self, monkeypatch):
+    def test_agent_scope_with_principal_uses_agent_and_user_partition(self, monkeypatch):
         monkeypatch.setenv("MEMORY_REQUIRE_PRINCIPAL", "true")
         scope = scope_from_deps(
             _deps(principal="alice", actor="agent-actor"),
@@ -81,7 +81,7 @@ class TestScopeFromDeps:
         )
         assert scope.agent_client_id == "agent-actor"
         assert scope.principal == "alice"
-        assert scope.user_scoping_required is True
+        assert scope.search_filters() == {"user_id": "alice", "agent_id": "agent-actor"}
 
     def test_autonomous_principal_uses_uniform_required_partition(self, monkeypatch):
         monkeypatch.setenv("MEMORY_REQUIRE_PRINCIPAL", "true")
@@ -99,7 +99,6 @@ class TestScopeFromDeps:
 
         assert scope.agent_client_id == identity
         assert scope.principal == identity
-        assert scope.user_scoping_required is True
 
     def test_write_attribution_keeps_every_verified_contributor(self):
         attribution = attribution_from_deps(_deps(principal="alice", actor="agent-actor"))
@@ -129,7 +128,7 @@ class TestScopeFromDeps:
     def test_model_supplied_fields_on_deps_are_ignored(self):
         # Even if extra attributes are attached, only the known identity fields are read.
         deps = _deps(principal="alice", actor="agent-1")
-        setattr(deps, "scope", "group")  # would-be injected override
+        setattr(deps, "scope", "store")  # would-be injected override
         setattr(deps, "principal", "attacker")
         scope = scope_from_deps(deps, level=ScopeLevel.AGENT)
         assert scope.level is ScopeLevel.AGENT


### PR DESCRIPTION
Implements the decided spec ([recall ergonomics and read-scope model](https://github.com/axsaucedo/kaos-ai-docs), `memory/plan/recall-ergonomics-and-group-read-spec.md`).

## Part A: recall ergonomics

- **Nested response**, one object per tier: `long_term.{facts, block}`, `medium_term.summary`, `short_term.window`; `degraded` stays top-level; per-fact `score` preserved on semantic recall. A tier is present only when requested.
- **`--include` tier selector**: accepts `a|all|s|short-term|m|medium-term|l|long-term`, repeatable and comma-splitting, default all. Wire field `include: [...]` replaces `include_short_term`; the service fetches only requested tiers.
- **`--long-term-query` / `-q` optional**: present routes to semantic recall (`/v1/recall`), absent routes to list (`/v1/list`). `-q` without long-term in `--include` is an error. `--query`/`--all`/`--short-term` removed.

## Part B: three-level read-scope model

- **Hierarchy `session < agent < user`**, all principal-bound from gateway-verified identity: `agent` binds `{agent_id, user_id}` whenever a principal is present and is the agent pool otherwise; `user_scoping_required` removed.
- **Session reads bind the principal** (security fix): the principal is ANDed into both the long-term filter and the conversational `scope_key` path; mismatch returns empty.
- **`group` renamed `store`**, admin-plane only: the service refuses `store` level with 403 on requests carrying an agent actor context; actor-context-free (RBAC-gated port-forward) requests may use it.
- **`maxReadScope` ceiling** replaces the `readScopes` list on Agent and `defaultReadScope` on MemoryStore. Reconcile enforcement: agent ceiling above the store ceiling is rejected, `user` without cluster user identity is rejected. The `search_memory` tool enum and automatic recall derive from the ceiling (env `MEMORY_MAX_READ_SCOPE`).
- **Admin CLI**: `--scope store` for the whole-store view; `--session` plus `--user` compose for a narrowed session read.

## Validation

- kaos-memory: 133 passed
- pydantic-ai-server: 365 passed
- kaos-cli: 186 passed
- operator: `make test-unit` green, including the 51-spec envtest suite
- sample dry-run renders the new fields; jupytext notebook sync in sync; CRDs regenerated in `config/crd/bases` and `operator/chart/crds`
- Adversarial review against the spec: all dimensions PASS
