### PR TITLE
chore(deps): ignore TypeScript major bumps in kaos-ui

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,13 @@ updates:
       all-security:
         applies-to: security-updates
         patterns: ["*"]
+    ignore:
+      # typescript-eslint has no TypeScript 7 support yet: its peer range caps at
+      # <6.1.0 and it also hard-throws on major >= 7, so `npm ci` fails outright.
+      # Upstream typescript-eslint#10940 targets TS >= 7.1 — remove this once it
+      # ships. TS 6.x minor/patch updates are unaffected.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # npm - docs
   - package-ecosystem: "npm"


### PR DESCRIPTION
TypeScript 7 cannot currently be adopted in `kaos-ui` because `typescript-eslint` does not support it yet. The block is twofold: its peer range caps at `>=4.8.4 <6.1.0`, and `dist/index.js` carries an unconditional `if (versionMajor >= 7) throw` guard. So `npm ci` fails with `ERESOLVE` before any project code runs — which is why all six checks on #313 failed from a single root cause.

No repo-side change resolves this:

- `--legacy-peer-deps` gets past resolution, then trips the runtime guard at lint time.
- Nested npm `overrides` cannot help — npm will not nest a peer dependency, so it still resolves against hoisted `typescript@7.0.2`.
- The only remaining route would be dropping `typescript-eslint` from `eslint.config.js`, silently removing all type-aware linting from CI. Not an acceptable trade for a dev-only compiler bump.

This adds an `ignore` rule so Dependabot stops reopening a PR that cannot pass on every new 7.x release. **TS 6.x minor/patch updates are unaffected, as is every other package.**

Upstream tracking is [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940), which targets TS >= 7.1 — remove this rule once that ships.

Supersedes #313.