### PR TITLE
ci(ui): give E2E shards timeout headroom

### DIFF
--- a/.github/workflows/kaos-ui-tests.yaml
+++ b/.github/workflows/kaos-ui-tests.yaml
@@ -154,7 +154,11 @@ jobs:
   e2e-tests:
     name: E2E Tests (shard ${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Shards spend ~8 min on setup (image builds, KIND, loading images) before
+    # ~75s of actual tests, landing at 9-10 min against the old 10 min budget.
+    # A job that exceeds timeout-minutes is reported as "cancelled" rather than
+    # "failed", so tipping over looked like flake and cost a re-run each time.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The kaos-ui E2E shards run at 9–10 minutes against a `timeout-minutes` budget of **10**, leaving as little as 19 seconds of margin. Any variance tips a shard over — and because GitHub reports a timed-out job as **cancelled** rather than **failed**, these looked like flake rather than the budget problem they are. Each cost a re-run that then passed unchanged.

Measured on a recent run:

| Shard | Duration | Result |
|---|---|---|
| 3/3 | **10m37s** | cancelled — over budget |
| 1/3 | 9m41s | success (19s margin) |
| 2/3 | 9m06s | success |
| 3/3 (re-run) | 9m32s | success |

This also hit the **v0.7.1 release pipeline** — a cancelled shard skipped the entire publish stage, so a green tag produced zero artifacts until re-run — and three Dependabot PRs (#311, #312, #314).

Raising the budget to 20 minutes gives ~2x headroom. This does not mask a hang: a genuine hang still fails the shard, just 10 minutes later.

### Follow-up worth considering (not in this PR)

The cost is setup, not tests. Per shard:

| Step | Time |
|---|---|
| Load images into KIND | 122s |
| **Run Playwright E2E tests** | **75s** |
| Build LiteLLM image | 58s |
| Free runner disk | 55s |
| Install KAOS operator | 41s |
| Create KIND cluster | 39s |
| Install Playwright browsers | 37s |
| Pull Ollama image | 35s |

That is ~8 min of setup per shard, triplicated, to run 75s of tests each — roughly 29 runner-minutes for 225s of testing. Worth asking whether 3 shards earn their cost, and whether image build/load can be hoisted into one job.