### PR TITLE
ci(release): allow releases to be started without pushing a tag

### DIFF
--- a/.github/workflows/create-tag.yaml
+++ b/.github/workflows/create-tag.yaml
@@ -1,0 +1,77 @@
+name: Create Tag
+
+# Creates and pushes a release tag. Exists so a release can be started from
+# somewhere that cannot push a tag itself — notably a Claude Code cloud
+# session, whose git proxy accepts branch updates but rejects tag pushes, and
+# whose GitHub tooling can write refs/heads/* but not refs/tags/*.
+#
+# Pushing the tag from here does NOT start release.yaml: refs pushed with the
+# built-in GITHUB_TOKEN never trigger another workflow. That is deliberate.
+# Once this run finishes, dispatch release.yaml explicitly against the new tag:
+#
+#   gh workflow run release.yaml --ref v<version>
+#
+# release.yaml reads its version from the ref it runs on, so dispatching it at
+# the tag behaves exactly like a tag push.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag, without the leading v (e.g. 0.7.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    name: Create tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected X.Y.Z)"
+            exit 1
+          fi
+          echo "✓ Version format valid: $VERSION"
+
+      - name: Check tag does not already exist
+        run: |
+          TAG="v${{ inputs.version }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+          echo "✓ Tag $TAG is free"
+
+      - name: Create and push tag
+        run: |
+          TAG="v${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "✓ Pushed $TAG at $(git rev-parse --short HEAD)"
+
+      - name: Summary
+        run: |
+          TAG="v${{ inputs.version }}"
+          {
+            echo "### Tag created: \`$TAG\`"
+            echo ""
+            echo "This did **not** start a release. To release, dispatch \`release.yaml\` at this tag:"
+            echo ""
+            echo '```'
+            echo "gh workflow run release.yaml --ref $TAG"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,13 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'  # Standard releases (v1.0.0, v0.1.2, etc)
       - '!v0.0.*'  # Exclude test tags
+  # Dispatch must be run *against the tag* (`--ref v0.7.2`), not against main:
+  # every job reads the version from the ref it runs on, so a tag ref behaves
+  # exactly like a tag push. Dispatching at a branch would fail validation.
+  # This exists so a release can be started from a Claude Code cloud session,
+  # which can dispatch workflows but cannot push tags. Pair it with
+  # create-tag.yaml, which makes the tag first.
+  workflow_dispatch:
 
 # Grant permissions needed by all jobs including reusable workflows
 permissions:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -3,6 +3,10 @@ name: Test Release
 on:
   push:
     tags: ['v0.0.*']  # Only test tags
+  # Same contract as release.yaml: dispatch against the tag, not a branch.
+  # This is the safe rehearsal path for the create-tag + dispatch mechanism —
+  # it publishes docs only, no images and no PyPI.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Makes a release startable from somewhere that cannot push a git tag — specifically a Claude Code cloud session, so a scheduled routine can cut a release instead of handing it back to a laptop.

## Why

A cloud session's git proxy accepts updates to the session's working branch and rejects everything else with a `403` before GitHub's own ref rules are reached. Its GitHub tooling can write `refs/heads/*` but has **no** tool that writes `refs/tags/*` — no `create_tag`, no `create_release`. Since `release.yaml` triggers only on a tag push, a release could not be started from anywhere but a machine with direct push access. All of this was measured in a cloud session, not inferred.

The same probe found one usable lever: **workflow dispatch works**.

## What changed

**`create-tag.yaml`** (new) — takes a `version` input, validates `X.Y.Z`, refuses to clobber an existing tag, pushes the tag with the built-in `GITHUB_TOKEN`.

That push deliberately starts nothing: GitHub never triggers a workflow from a ref pushed with `GITHUB_TOKEN`. Normally that rule is an obstacle; here it's the design — the tag lands inert and the release is started explicitly afterwards.

**`release.yaml` / `test-release.yaml`** — each gains `workflow_dispatch`. Nothing else changes.

The dispatch must target **the tag**, not a branch. Every job already derives the version from the ref it runs on:

```bash
TAG=${GITHUB_REF#refs/tags/}
VERSION=${TAG#v}
```

so running at a tag ref is indistinguishable from a tag push — no job, input parsing, or version handling needed to change. Dispatching at a branch fails the existing `X.Y.Z` check, which is the correct outcome.

## Usage

```bash
gh workflow run create-tag.yaml -f version=0.7.2
gh workflow run release.yaml --ref v0.7.2
```

## Alternative considered

A separate tag-pushing workflow using a **PAT**, so the push cascades into `release.yaml` on its own and `release.yaml` stays untouched. Rejected: it trades a one-line trigger addition for a long-lived secret to store, rotate, and eventually be surprised by when it expires mid-release.

## Safety

The existing tag-push path is untouched — releasing locally by pushing a tag works exactly as before. `test-release.yaml` gets the same trigger so the whole mechanism can be rehearsed on a `v0.0.*` tag, which publishes docs only: no images, no PyPI.
